### PR TITLE
docs: harden scaffold tone and add minimal CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  claim-scan:
+    name: claim-scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: forbidden-claim grep
+        run: |
+          set -e
+          python3 - <<'PY'
+          import os, re, sys
+          PATTERN = re.compile(
+              r"(?:\bis\s+|\bnow\s+|\balready\s+|\bcurrently\s+)?"
+              r"(production[- ]ready|timing[- ]closed|fully verified|"
+              r"stable plugin abi|stable lsp|kv260 inference (?:works|works now|is working|is functional))",
+              re.IGNORECASE,
+          )
+          NEGATION = re.compile(
+              r"\b(?:no|not|never|avoid|without|forbidden|skip|do not"
+              r"|does not|is not|are not)\b",
+              re.IGNORECASE,
+          )
+          SCAN_EXTS = {".md", ".sh", ".yml", ".yaml"}
+          SKIP_DIRS = {".git"}
+          SKIP_FILES = {".github/workflows/ci.yml"}
+          violations = []
+          for root, dirs, files in os.walk("."):
+              dirs[:] = [
+                  d for d in dirs
+                  if os.path.relpath(os.path.join(root, d), ".") not in SKIP_DIRS
+              ]
+              for name in files:
+                  rel = os.path.relpath(os.path.join(root, name), ".")
+                  if rel in SKIP_FILES:
+                      continue
+                  if not any(rel.endswith(ext) for ext in SCAN_EXTS):
+                      continue
+                  with open(rel, encoding="utf-8", errors="replace") as fh:
+                      for i, line in enumerate(fh, 1):
+                          if PATTERN.search(line) and not NEGATION.search(line):
+                              violations.append(f"{rel}:{i}: {line.rstrip()}")
+          if violations:
+              print("Forbidden positive claims detected:")
+              for v in violations:
+                  print(v)
+              print(
+                  "::error::Rephrase as target / planned / pending verification.",
+              )
+              sys.exit(1)
+          print("claim-scan clean")
+          PY
+
+  link-sanity:
+    name: link-sanity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: required files
+        run: |
+          set -e
+          for f in README.md LICENSE; do
+            if [ ! -f "$f" ]; then
+              echo "::error::missing required file: $f"
+              exit 1
+            fi
+          done
+          echo "required files present"
+      - name: README cross-repo links
+        run: |
+          # Cheap sanity: ensure we still link to the four sibling pccxai repos.
+          set -e
+          for repo in pccx pccx-lab pccx-FPGA-NPU-LLM-kv260 pccx-llm-launcher; do
+            if ! grep -qE "pccxai/$repo" README.md; then
+              echo "::error::README missing reference to pccxai/$repo"
+              exit 1
+            fi
+          done
+          echo "all expected sibling-repo references present"

--- a/README.md
+++ b/README.md
@@ -2,56 +2,72 @@
 
 SystemVerilog IDE layer for the PCCX tooling stack.
 
+## What this repo is
+
+The IDE-adjacent surface that is being **spun out of [pccx-lab][pccx-lab]**.
+This is not a greenfield project — the initial code base traces back to
+IDE-shaped work that already lives in `pccx-lab`. As that work matures
+its CLI / core boundary, the IDE-side pieces will land here while
+verification, trace analysis, and diagnostics remain in `pccx-lab`.
+
 ## Status
 
-This repository is the **planned IDE spin-out from [pccx-lab][pccx-lab]**.
-Work has begun inside pccx-lab; this repo will hold the IDE code once the
-boundary is stabilized. Until then, expect the public surface to evolve.
-
-The IDE is expected to stay tightly connected to pccx-lab for trace
-analysis, diagnostics, verification workflows, and future AI-assisted
-development flows.
+Public surface is intentionally minimal while the `pccx-lab` CLI / core
+boundary is being stabilized. The IDE will follow that boundary; it does
+not duplicate analysis logic locally.
 
 ## Integration model
 
-The IDE integrates with pccx-lab through the **CLI / core boundary
-first**, not by duplicating analysis logic. The same boundary should
-support future VS Code extensions and MCP-controlled workflows.
+`pccx-lab` is **CLI-first**. The IDE consumes the same CLI / core
+contract that the lab CLI itself uses. VS Code extensions and any
+MCP-controlled flows ride on top of the same contract; they do not get a
+private back channel into the lab internals.
 
 Development order is fixed:
 
-1. CLI / core boundary first (in pccx-lab)
-2. IDE GUI surface second
-3. VS Code extension and MCP integrations on top
+1. CLI / core boundary first (in `pccx-lab`).
+2. IDE GUI surface second (in this repo).
+3. VS Code extension and MCP-controlled flows on top.
 
-## Planned features
+If a feature would need a side channel that bypasses the CLI / core
+contract, that is a signal the contract needs to grow first — not a
+signal to add a back door from the GUI.
 
-- SystemVerilog navigation
-- diagnostics and project-aware analysis
-- xsim / log integration
-- pccx trace and verification workflow integration
-- pccx-lab plugin integration
-- controlled MCP-backed analysis actions
-- future VS Code extension path
-- AI-assisted SystemVerilog development workflow
-- evolutionary generate / simulate / evaluate / refine loop
-- CLI-backed IDE actions
-- shared command boundary with pccx-lab
-- VS Code extension compatibility path
+## Initial track (near-term)
+
+- SystemVerilog navigation backed by `pccx-lab` analysis.
+- Diagnostics surfaced from the same place the lab CLI surfaces them.
+- xsim run launching and log handoff via the CLI / core boundary.
+- Project-aware view of `pccx-lab` artifacts (traces, run reports,
+  verification status).
+
+## Later track (deferred)
+
+- AI workers can interact with `pccx-lab` through a controlled MCP
+  interface; the IDE surfaces those flows but does not own the
+  contract.
+- Evolutionary generate / simulate / evaluate / refine loop, again
+  driven through the lab boundary.
+- VS Code extension distribution.
+
+These items are explicitly *deferred* — not part of the near-term
+surface — and depend on the CLI / core boundary in `pccx-lab` being
+formal enough to bind to.
 
 ## Non-goals
 
-- not a Vivado replacement
-- not claiming complete LSP support yet
-- not production-ready
-- no autonomous hardware design claim
-- no automatic merge / release actions
+- Not a Vivado replacement.
+- No claim of complete LSP coverage today.
+- This repo is not labelled as stable, and there is no commitment to a
+  frozen plugin ABI yet.
+- No autonomous hardware design claim.
+- No automatic merge or release actions driven by the IDE.
 
 ## Related
 
 - [pccxai/pccx][pccx] — spec / docs / roadmap / release coordination
-- [pccxai/pccx-lab][pccx-lab] — verification lab + plugin host + analysis backend
-- [pccxai/pccx-FPGA-NPU-LLM-kv260][pccx-fpga] — RTL / Sail / KV260 / hardware evidence
+- [pccxai/pccx-lab][pccx-lab] — verification lab + CLI / core boundary
+- [pccxai/pccx-FPGA-NPU-LLM-kv260][pccx-fpga] — RTL / KV260 / hardware evidence
 - [pccxai/pccx-llm-launcher][pccx-launcher] — user-facing local LLM launcher
 
 ## License


### PR DESCRIPTION
## Goal

Tighten the public README so the spin-out narrative is explicit, and
add a minimal CI surface (claim-scan + link-sanity) before any IDE code
lands here.

## What changes

**README.md**
- Frames the repo as a spin-out from \`pccx-lab\`, not a greenfield project.
- Splits planned features into **Initial track** (near-term: SV
  navigation, diagnostics, xsim handoff, project view) and **Later
  track** (deferred: MCP-controlled flows for AI workers, evolutionary
  generate/simulate/evaluate/refine loop, VS Code distribution).
- Adopts the \"AI workers can interact with \`pccx-lab\` through a
  controlled MCP interface\" framing.
- Removes the literal \"production-ready\" token and the \"stable LSP\"
  shape from prose; intent preserved as a non-goal.

**.github/workflows/ci.yml** (new)
- \`claim-scan\` — negation-aware Python grep that blocks accidental
  overclaims: \`production-ready\`, \`timing-closed\`, \`fully verified\`,
  \`stable plugin ABI\`, \`stable LSP\`, \`KV260 inference works\`.
- \`link-sanity\` — checks that README + LICENSE exist and that README
  still references the four sibling pccxai repos.

## What this PR does NOT do

- No IDE code is added.
- No release / tag is generated.
- No staging repo activity.
- No claim of LSP coverage, plugin ABI stability, or AI autonomy.

## Validation

- Local claim-scan (negation-aware) clean.
- Local file/link sanity clean.
- CI in this PR exercises the same checks.