### PR TITLE
feat: add SystemVerilog IDE diagnostics scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,33 @@ jobs:
             fi
           done
           echo "all expected sibling-repo references present"
+
+  scaffold-smoke:
+    name: scaffold-smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: install pytest
+        run: python -m pip install --upgrade pip pytest
+      - name: pytest
+        run: python -m pytest -q
+      - name: cli smoke (ok fixture)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli check fixtures/ok_module.sv
+      - name: cli smoke (broken fixture exits non-zero)
+        run: |
+          set -e
+          if PYTHONPATH=src python -m pccx_ide_cli check \
+              fixtures/missing_endmodule.sv; then
+            echo "::error::expected non-zero exit on broken fixture"
+            exit 1
+          fi
+          echo "broken fixture correctly produced diagnostics"
+      - name: schema dump
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli schema | python -c "import json,sys; json.load(sys.stdin)"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+build/
+dist/
+*.egg-info/
+.venv/
+venv/
+.env

--- a/README.md
+++ b/README.md
@@ -41,6 +41,31 @@ signal to add a back door from the GUI.
 - Project-aware view of `pccx-lab` artifacts (traces, run reports,
   verification status).
 
+## Current scaffold
+
+The repository currently contains a placeholder Python CLI that emits
+the **diagnostics envelope** the IDE expects to consume from
+`pccx-lab`. The CLI does not perform real semantic analysis — its
+checks are file-shape level only (file exists, file non-empty,
+`module` / `endmodule` present). The envelope schema is the artifact
+that matters; analysis arrives later, through `pccx-lab`.
+
+```bash
+python -m pccx_ide_cli check fixtures/ok_module.sv
+python -m pccx_ide_cli check fixtures/missing_endmodule.sv
+python -m pccx_ide_cli schema
+```
+
+Tests are run with:
+
+```bash
+python -m pytest -q
+```
+
+The envelope shape is fixed in [`schema/diagnostics-v0.json`](./schema/diagnostics-v0.json).
+Handoff notes for the eventual `pccx-lab` and xsim integration paths
+live in [`docs/HANDOFF.md`](./docs/HANDOFF.md).
+
 ## Later track (deferred)
 
 - AI workers can interact with `pccx-lab` through a controlled MCP

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,0 +1,47 @@
+# Handoff notes
+
+This document is a placeholder for two boundaries the scaffold CLI does
+**not** yet talk to:
+
+1. The `pccx-lab` CLI / core boundary (analysis backend).
+2. The xsim runner / log surfacing path inside `pccx-lab`.
+
+Both will be wired up only after `pccx-lab` formalises its CLI / core
+contract. Until then, this repo intentionally stops at the diagnostics
+envelope schema — see [`schema/diagnostics-v0.json`](../schema/diagnostics-v0.json).
+
+## pccx-lab handoff (planned)
+
+When the `pccx-lab` CLI exposes a stable `analyze` subcommand that
+emits diagnostics in (or convertible to) the v0 envelope, this CLI is
+expected to:
+
+1. Resolve the `pccx-lab` binary on `$PATH` or via `PCCX_LAB_BIN`.
+2. Forward the file under inspection through that binary.
+3. Validate the response against `schema/diagnostics-v0.json`.
+4. Re-emit the response from this CLI without re-analysing.
+
+The IDE side (later: VS Code extension, GUI shell, MCP-controlled
+flows) consumes that same envelope. There is no private back channel
+between the GUI and `pccx-lab` internals.
+
+## xsim handoff (planned)
+
+xsim runs and log surfacing remain on the `pccx-lab` side. This CLI is
+expected only to:
+
+1. Pass through a `run` request to `pccx-lab`.
+2. Translate the resulting log / report into the same diagnostics
+   envelope where it makes sense, or surface a structured run-summary
+   document (envelope version to be defined alongside the lab CLI).
+
+## Open questions
+
+- Whether the envelope grows a `metadata` object at v1, and what
+  fields belong inside (e.g. `commit`, `pccx-lab-version`).
+- Whether multi-file batches are represented as one envelope per file
+  or one envelope with a list of `source` entries.
+- How verification status (xsim pass/fail counts) is layered on top of
+  the diagnostics envelope.
+
+These are intentionally unresolved while the scaffold matures.

--- a/fixtures/missing_endmodule.sv
+++ b/fixtures/missing_endmodule.sv
@@ -1,0 +1,10 @@
+module bad_module (
+    input  logic clk,
+    output logic o_x
+);
+
+    always_ff @(posedge clk) begin
+        o_x <= 1'b0;
+    end
+
+// endmodule intentionally omitted to exercise PCCX-SCAFFOLD-003

--- a/fixtures/ok_module.sv
+++ b/fixtures/ok_module.sv
@@ -1,0 +1,16 @@
+// Minimal fixture; not a real design.
+module ok_module (
+    input  logic clk,
+    input  logic rst_n,
+    output logic o_done
+);
+
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            o_done <= 1'b0;
+        end else begin
+            o_done <= 1'b1;
+        end
+    end
+
+endmodule

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pccx-systemverilog-ide"
+version = "0.0.1"
+description = "Scaffold CLI for the SystemVerilog IDE spin-out from pccx-lab."
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.9"
+authors = [{ name = "pccxai" }]
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+]
+
+[project.scripts]
+pccx-ide = "pccx_ide_cli.__main__:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/pccx_ide_cli"]
+
+[tool.hatch.build.targets.sdist]
+include = ["src", "schema", "tests", "fixtures", "README.md", "LICENSE"]

--- a/schema/diagnostics-v0.json
+++ b/schema/diagnostics-v0.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/pccxai/pccx-systemverilog-ide/schema/diagnostics-v0.json",
+  "title": "pccx IDE diagnostics envelope (v0, scaffold)",
+  "description": "Wire format the IDE will use to receive diagnostics from pccx-lab once the CLI / core boundary lands. The envelope is intentionally narrow and explicitly versioned via the `envelope` field. v0 is a scaffold contract and may break.",
+  "type": "object",
+  "required": ["envelope", "tool", "source", "diagnostics"],
+  "additionalProperties": false,
+  "properties": {
+    "envelope": {
+      "type": "string",
+      "const": "0",
+      "description": "Envelope version. v0 is scaffold-only and not stable."
+    },
+    "tool": {
+      "type": "string",
+      "description": "Name of the producing tool."
+    },
+    "source": {
+      "type": "string",
+      "description": "Identifier of the source artifact (path, URI, ...)."
+    },
+    "diagnostics": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/diagnostic" }
+    }
+  },
+  "$defs": {
+    "diagnostic": {
+      "type": "object",
+      "required": ["line", "column", "severity", "code", "message", "source"],
+      "additionalProperties": false,
+      "properties": {
+        "line": { "type": "integer", "minimum": 1 },
+        "column": { "type": "integer", "minimum": 1 },
+        "severity": {
+          "type": "string",
+          "enum": ["error", "warning", "info", "hint"]
+        },
+        "code": { "type": "string" },
+        "message": { "type": "string" },
+        "source": { "type": "string" }
+      }
+    }
+  }
+}

--- a/src/pccx_ide_cli/__init__.py
+++ b/src/pccx_ide_cli/__init__.py
@@ -1,0 +1,7 @@
+"""Scaffold CLI for the pccx SystemVerilog IDE spin-out.
+
+Real analysis is expected to land in pccx-lab and be consumed through its
+CLI / core boundary; this package only emits a stable diagnostics envelope.
+"""
+
+__version__ = "0.0.1"

--- a/src/pccx_ide_cli/__main__.py
+++ b/src/pccx_ide_cli/__main__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+
+from .cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from . import __version__
+from .diagnostics import scan_file
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="pccx-ide",
+        description=(
+            "Scaffold CLI for the pccx SystemVerilog IDE spin-out. "
+            "Emits a placeholder diagnostics envelope; real analysis "
+            "will be consumed from pccx-lab once its CLI / core "
+            "boundary stabilizes."
+        ),
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"pccx-ide {__version__}",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    check = sub.add_parser(
+        "check",
+        help="Run the placeholder envelope check on a SystemVerilog file.",
+    )
+    check.add_argument("path", type=Path, help="Path to a .sv / .svh file.")
+    check.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
+    sub.add_parser(
+        "schema",
+        help="Print the diagnostics envelope JSON schema.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "schema":
+        schema_path = (
+            Path(__file__).resolve().parent.parent.parent
+            / "schema"
+            / "diagnostics-v0.json"
+        )
+        if not schema_path.exists():
+            schema_path = Path(__file__).resolve().parent / "_schema_fallback.json"
+        sys.stdout.write(schema_path.read_text(encoding="utf-8"))
+        return 0
+
+    if args.command == "check":
+        envelope = scan_file(args.path)
+        if args.format == "json":
+            json.dump(envelope, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            for d in envelope["diagnostics"]:
+                sys.stdout.write(
+                    f"{envelope['source']}:{d['line']}: "
+                    f"{d['severity']}: {d['code']}: {d['message']}\n"
+                )
+        return 0 if not envelope["diagnostics"] else 1
+
+    parser.error(f"unknown command: {args.command}")
+    return 2

--- a/src/pccx_ide_cli/diagnostics.py
+++ b/src/pccx_ide_cli/diagnostics.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+ENVELOPE_VERSION = "0"
+
+_MODULE_RE = re.compile(r"^\s*module\s+\w+", re.MULTILINE)
+_ENDMODULE_RE = re.compile(r"^\s*endmodule\b", re.MULTILINE)
+
+
+def _diag(
+    line: int,
+    col: int,
+    severity: str,
+    code: str,
+    message: str,
+) -> dict[str, Any]:
+    return {
+        "line": line,
+        "column": col,
+        "severity": severity,
+        "code": code,
+        "message": message,
+        "source": "pccx-ide-scaffold",
+    }
+
+
+def scan_text(text: str, source: str) -> dict[str, Any]:
+    """Return a diagnostics envelope for a piece of SystemVerilog text.
+
+    The checks here are intentionally trivial scaffold-level placeholders:
+    they exercise the envelope shape, not real analysis. Real semantic
+    analysis is expected to come from pccx-lab via its CLI / core
+    boundary.
+    """
+
+    diagnostics: list[dict[str, Any]] = []
+
+    if not text.strip():
+        diagnostics.append(
+            _diag(1, 1, "error", "PCCX-SCAFFOLD-001", "file is empty"),
+        )
+
+    has_module = bool(_MODULE_RE.search(text))
+    has_endmodule = bool(_ENDMODULE_RE.search(text))
+
+    if not has_module:
+        diagnostics.append(
+            _diag(
+                1,
+                1,
+                "warning",
+                "PCCX-SCAFFOLD-002",
+                "no top-level `module` declaration found",
+            ),
+        )
+
+    if has_module and not has_endmodule:
+        diagnostics.append(
+            _diag(
+                1,
+                1,
+                "error",
+                "PCCX-SCAFFOLD-003",
+                "`module` declared but no matching `endmodule` found",
+            ),
+        )
+
+    return {
+        "envelope": ENVELOPE_VERSION,
+        "tool": "pccx-ide-scaffold",
+        "source": source,
+        "diagnostics": diagnostics,
+    }
+
+
+def scan_file(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {
+            "envelope": ENVELOPE_VERSION,
+            "tool": "pccx-ide-scaffold",
+            "source": str(path),
+            "diagnostics": [
+                _diag(
+                    1,
+                    1,
+                    "error",
+                    "PCCX-SCAFFOLD-000",
+                    f"file does not exist: {path}",
+                ),
+            ],
+        }
+    text = path.read_text(encoding="utf-8", errors="replace")
+    return scan_text(text, str(path))

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+
+sys.path.insert(0, str(SRC))
+
+from pccx_ide_cli.diagnostics import scan_file, scan_text  # noqa: E402
+
+
+def test_ok_fixture_has_no_diagnostics():
+    env = scan_file(REPO_ROOT / "fixtures" / "ok_module.sv")
+    assert env["envelope"] == "0"
+    assert env["diagnostics"] == []
+
+
+def test_missing_endmodule_flagged():
+    env = scan_file(REPO_ROOT / "fixtures" / "missing_endmodule.sv")
+    codes = {d["code"] for d in env["diagnostics"]}
+    assert "PCCX-SCAFFOLD-003" in codes
+
+
+def test_empty_file_flagged():
+    env = scan_text("", "<empty>")
+    codes = {d["code"] for d in env["diagnostics"]}
+    assert "PCCX-SCAFFOLD-001" in codes
+
+
+def test_no_module_flagged():
+    env = scan_text("// just a comment\n", "<comment-only>")
+    codes = {d["code"] for d in env["diagnostics"]}
+    assert "PCCX-SCAFFOLD-002" in codes
+
+
+def test_missing_path_flagged():
+    env = scan_file(REPO_ROOT / "fixtures" / "does_not_exist.sv")
+    codes = {d["code"] for d in env["diagnostics"]}
+    assert "PCCX-SCAFFOLD-000" in codes
+
+
+def test_cli_check_smoke():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pccx_ide_cli",
+            "check",
+            str(REPO_ROOT / "fixtures" / "ok_module.sv"),
+        ],
+        cwd=REPO_ROOT,
+        env={
+            "PYTHONPATH": str(SRC),
+            "PATH": __import__("os").environ.get("PATH", ""),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["envelope"] == "0"
+    assert payload["diagnostics"] == []
+
+
+def test_cli_schema_smoke():
+    result = subprocess.run(
+        [sys.executable, "-m", "pccx_ide_cli", "schema"],
+        cwd=REPO_ROOT,
+        env={
+            "PYTHONPATH": str(SRC),
+            "PATH": __import__("os").environ.get("PATH", ""),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["title"].startswith("pccx IDE diagnostics envelope")
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

- Add a placeholder Python CLI (`pccx-ide`) that emits the diagnostics envelope shape the IDE expects to consume from `pccx-lab` once its CLI / core boundary stabilizes.
- Pin the envelope contract in `schema/diagnostics-v0.json` (versioned via the `envelope` field; v0 is scaffold-only and may break).
- Add SystemVerilog fixtures, pytest coverage, and a CI `scaffold-smoke` job.
- Document the planned `pccx-lab` and xsim handoff paths in `docs/HANDOFF.md`.

This PR keeps the architectural invariant from the README: the IDE consumes the same CLI / core contract that `pccx-lab` exposes — it does not duplicate analysis. The CLI here only checks file shape (file exists, non-empty, `module` / `endmodule` present); real semantic analysis comes later, through `pccx-lab`.

## What this is not

- Not a working LSP, parser, or analyzer.
- No claim of stable plugin ABI, stable LSP, or production readiness.
- VS Code extension and MCP-driven flows remain a deferred later track.

## Test plan

- [x] `python -m pytest -q` — 7 tests pass locally.
- [x] `python -m pccx_ide_cli check fixtures/ok_module.sv` — exits 0 with empty diagnostics.
- [x] `python -m pccx_ide_cli check fixtures/missing_endmodule.sv` — exits 1 with `PCCX-SCAFFOLD-003`.
- [x] `python -m pccx_ide_cli schema` — emits valid JSON.
- [x] Local pre-flight of `claim-scan` regex — 0 violations.
- [ ] CI: `claim-scan`, `link-sanity`, `scaffold-smoke` green on this PR.