### PR TITLE
chore: finish systemverilog-ide rename metadata cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "pccx-systemverilog-ide"
+name = "systemverilog-ide"
 version = "0.0.1"
 description = "Scaffold CLI for the SystemVerilog IDE spin-out from pccx-lab."
 readme = "README.md"

--- a/schema/diagnostics-v0.json
+++ b/schema/diagnostics-v0.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/pccxai/pccx-systemverilog-ide/schema/diagnostics-v0.json",
+  "$id": "https://github.com/pccxai/systemverilog-ide/schema/diagnostics-v0.json",
   "title": "pccx IDE diagnostics envelope (v0, scaffold)",
   "description": "Wire format the IDE will use to receive diagnostics from pccx-lab once the CLI / core boundary lands. The envelope is intentionally narrow and explicitly versioned via the `envelope` field. v0 is a scaffold contract and may break.",
   "type": "object",


### PR DESCRIPTION
## Changes

- **pyproject.toml**: Update distribution metadata `name` from `pccx-systemverilog-ide` to `systemverilog-ide`. Python import/module names are unchanged.
- **schema/diagnostics-v0.json**: Update `$id` URL from old repo path to canonical `github.com/pccxai/systemverilog-ide`. Schema remains an early diagnostics envelope for integration planning — not claimed as stable.

## Stale reference scan

Covers all `.py`, `.toml`, `.json`, `.md`, `.txt`, `.rst`, `.yaml`, `.yml` files. All references cleaned.

## Tests

7 passed in 0.11s

## Notes

- No stable schema/API claimed.
- Python import names unchanged (`pccx_ide_cli`).
- Distribution name now matches canonical repo name.