### PR TITLE
feat: strengthen diagnostics envelope scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: install pytest
-        run: python -m pip install --upgrade pip pytest
+        run: python -m pip install --upgrade pip pytest "jsonschema>=4"
       - name: pytest
         run: python -m pytest -q
       - name: cli smoke (ok fixture)
@@ -110,6 +110,14 @@ jobs:
             exit 1
           fi
           echo "broken fixture correctly produced diagnostics"
+      - name: cli smoke (empty fixture exits non-zero)
+        run: |
+          set -e
+          if PYTHONPATH=src python -m pccx_ide_cli check fixtures/empty.sv; then
+            echo "::error::expected non-zero exit on empty fixture"
+            exit 1
+          fi
+          echo "empty fixture correctly produced diagnostics"
       - name: schema dump
         run: |
           set -e

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -25,6 +25,21 @@ The IDE side (later: VS Code extension, GUI shell, MCP-controlled
 flows) consumes that same envelope. There is no private back channel
 between the GUI and `pccx-lab` internals.
 
+### PCCX_LAB_BIN resolution order (planned)
+
+When the handoff is wired up, binary resolution will follow this
+precedence:
+
+1. `PCCX_LAB_BIN` environment variable (absolute path).
+2. `pccx-lab` on `$PATH`.
+3. Hard error with a clear message — no silent fallback to scaffold
+   analysis when the lab binary is expected but missing.
+
+The scaffold will never silently substitute its own placeholder checks
+for a missing `pccx-lab` binary once the handoff contract is active.
+A missing binary is a configuration error, not a graceful degradation
+case.
+
 ## xsim handoff (planned)
 
 xsim runs and log surfacing remain on the `pccx-lab` side. This CLI is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 
+[project.optional-dependencies]
+test = ["pytest", "jsonschema>=4"]
+
 [project.scripts]
 pccx-ide = "pccx_ide_cli.__main__:main"
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -5,15 +5,27 @@ import subprocess
 import sys
 from pathlib import Path
 
+import jsonschema
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SRC = REPO_ROOT / "src"
+SCHEMA_PATH = REPO_ROOT / "schema" / "diagnostics-v0.json"
 
 sys.path.insert(0, str(SRC))
 
 from pccx_ide_cli.diagnostics import scan_file, scan_text  # noqa: E402
 
+_SCHEMA = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+_VALIDATOR = jsonschema.Draft202012Validator(_SCHEMA)
+
+
+def _assert_conforms(envelope: dict) -> None:
+    errors = list(_VALIDATOR.iter_errors(envelope))
+    assert not errors, "\n".join(str(e) for e in errors)
+
+
+# ── existing behavioural tests ────────────────────────────────────────────────
 
 def test_ok_fixture_has_no_diagnostics():
     env = scan_file(REPO_ROOT / "fixtures" / "ok_module.sv")
@@ -45,15 +57,44 @@ def test_missing_path_flagged():
     assert "PCCX-SCAFFOLD-000" in codes
 
 
-def test_cli_check_smoke():
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "pccx_ide_cli",
-            "check",
-            str(REPO_ROOT / "fixtures" / "ok_module.sv"),
-        ],
+# ── schema-conformance tests ──────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "source,text",
+    [
+        ("ok", (REPO_ROOT / "fixtures" / "ok_module.sv").read_text()),
+        ("missing_endmodule", (REPO_ROOT / "fixtures" / "missing_endmodule.sv").read_text()),
+        ("empty_sv", (REPO_ROOT / "fixtures" / "empty.sv").read_text()),
+        ("empty_str", ""),
+        ("comment_only", "// just a comment\n"),
+        ("nonexistent", None),  # triggers scan_file path
+    ],
+)
+def test_envelope_conforms_to_schema(source: str, text):
+    if text is None:
+        envelope = scan_file(REPO_ROOT / "fixtures" / "does_not_exist.sv")
+    else:
+        envelope = scan_text(text, source)
+    _assert_conforms(envelope)
+
+
+def test_scan_file_ok_conforms():
+    _assert_conforms(scan_file(REPO_ROOT / "fixtures" / "ok_module.sv"))
+
+
+def test_scan_file_missing_endmodule_conforms():
+    _assert_conforms(scan_file(REPO_ROOT / "fixtures" / "missing_endmodule.sv"))
+
+
+def test_scan_file_empty_fixture_conforms():
+    _assert_conforms(scan_file(REPO_ROOT / "fixtures" / "empty.sv"))
+
+
+# ── CLI tests ─────────────────────────────────────────────────────────────────
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "pccx_ide_cli", *args],
         cwd=REPO_ROOT,
         env={
             "PYTHONPATH": str(SRC),
@@ -63,27 +104,55 @@ def test_cli_check_smoke():
         text=True,
         check=False,
     )
+
+
+def test_cli_check_smoke():
+    result = _run_cli("check", str(REPO_ROOT / "fixtures" / "ok_module.sv"))
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
     assert payload["envelope"] == "0"
     assert payload["diagnostics"] == []
 
 
-def test_cli_schema_smoke():
-    result = subprocess.run(
-        [sys.executable, "-m", "pccx_ide_cli", "schema"],
-        cwd=REPO_ROOT,
-        env={
-            "PYTHONPATH": str(SRC),
-            "PATH": __import__("os").environ.get("PATH", ""),
-        },
-        capture_output=True,
-        text=True,
-        check=False,
+def test_cli_check_json_conforms():
+    for fixture in ("ok_module.sv", "missing_endmodule.sv", "empty.sv"):
+        result = _run_cli("check", str(REPO_ROOT / "fixtures" / fixture))
+        payload = json.loads(result.stdout)
+        _assert_conforms(payload)
+
+
+def test_cli_check_text_format():
+    result = _run_cli(
+        "check",
+        "--format", "text",
+        str(REPO_ROOT / "fixtures" / "missing_endmodule.sv"),
     )
+    assert result.returncode != 0
+    assert "PCCX-SCAFFOLD-003" in result.stdout
+    assert "error" in result.stdout
+
+
+def test_cli_check_text_ok_exits_zero():
+    result = _run_cli(
+        "check",
+        "--format", "text",
+        str(REPO_ROOT / "fixtures" / "ok_module.sv"),
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_cli_schema_smoke():
+    result = _run_cli("schema")
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
     assert payload["title"].startswith("pccx IDE diagnostics envelope")
+
+
+def test_cli_schema_is_valid_json_schema():
+    result = _run_cli("schema")
+    payload = json.loads(result.stdout)
+    jsonschema.Draft202012Validator.check_schema(payload)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Changes

### schema-conformance tests (new)
Parametrized 6-case suite validates every envelope produced by
`scan_file` / `scan_text` against `schema/diagnostics-v0.json` using
`jsonschema.Draft202012Validator`. Covers: ok fixture, missing-endmodule
fixture, empty.sv fixture, empty string, comment-only text, nonexistent
path. Also adds `test_cli_schema_is_valid_json_schema` (schema dump is
itself a valid JSON Schema) and `test_cli_check_json_conforms` (CLI JSON
output for all three fixtures validates against the envelope schema).

### `--format text` coverage (new)
`test_cli_check_text_format` and `test_cli_check_text_ok_exits_zero`
exercise the text output path (previously zero coverage in tests).

### `fixtures/empty.sv` (new)
Empty fixture file enabling CLI-level smoke of the PCCX-SCAFFOLD-001
path without going through the Python API directly.

### CI: jsonschema install + empty-fixture smoke (updated)
`scaffold-smoke` job installs `jsonschema>=4` alongside pytest.
Added smoke step: empty fixture must exit non-zero.

### `docs/HANDOFF.md`: PCCX_LAB_BIN resolution (updated)
Documents the planned binary resolution order once the pccx-lab
handoff is active. No silent fallback when the lab binary is missing.

### `pyproject.toml`: optional test extras (updated)
Added `[project.optional-dependencies] test = ["pytest", "jsonschema>=4"]`.

---

## What is intentionally not implemented

- Real semantic SystemVerilog parser
- LSP server
- GUI
- VS Code extension
- MCP integration
- New diagnostic codes (SCAFFOLD-004+)
- pccx-lab CLI/core handoff wiring

All real analysis remains a future pccx-lab responsibility.

## pccx-lab integration boundary

This CLI is a diagnostics envelope scaffold only. It will forward to
`pccx-lab` via `PCCX_LAB_BIN` / `$PATH` once the lab CLI/core contract
stabilises. No private back channel between IDE surface and pccx-lab
internals.

## Validation

```
PYTHONPATH=src python3 -m pytest -v   → 20 passed in 0.46s
PYTHONPATH=src python3 -m pccx_ide_cli check fixtures/ok_module.sv  → exit 0
PYTHONPATH=src python3 -m pccx_ide_cli check fixtures/empty.sv      → exit 1
PYTHONPATH=src python3 -m pccx_ide_cli schema | python3 -c "import json,sys; json.load(sys.stdin)"  → ok
git diff --check  → clean
```

---

No full IDE/LSP support claimed. No stable ABI. No autonomous hardware design.