### PR TITLE
feat: add pccx-lab diagnostics handoff backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: install pytest
+      - name: install deps
         run: python -m pip install --upgrade pip pytest "jsonschema>=4"
       - name: pytest
         run: python -m pytest -q
@@ -122,3 +122,13 @@ jobs:
         run: |
           set -e
           PYTHONPATH=src python -m pccx_ide_cli schema | python -c "import json,sys; json.load(sys.stdin)"
+      - name: cli smoke (pccx-lab backend missing binary fails clearly)
+        run: |
+          set -e
+          # pccx-lab is not installed in CI; the backend must fail without scaffold fallback.
+          if PYTHONPATH=src PCCX_LAB_BIN="" python -m pccx_ide_cli check \
+              fixtures/ok_module.sv --backend pccx-lab; then
+            echo "::error::expected non-zero exit when pccx-lab binary is missing"
+            exit 1
+          fi
+          echo "missing pccx-lab binary correctly fails"

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,54 +1,102 @@
 # Handoff notes
 
-This document is a placeholder for two boundaries the scaffold CLI does
-**not** yet talk to:
+This document describes the controlled integration boundary between
+`pccx-ide` (this CLI) and `pccx-lab`.
 
-1. The `pccx-lab` CLI / core boundary (analysis backend).
-2. The xsim runner / log surfacing path inside `pccx-lab`.
+Two handoff paths are tracked:
 
-Both will be wired up only after `pccx-lab` formalises its CLI / core
-contract. Until then, this repo intentionally stops at the diagnostics
-envelope schema — see [`schema/diagnostics-v0.json`](../schema/diagnostics-v0.json).
+1. The `pccx-lab` CLI / core boundary (analysis backend) — **wired**.
+2. The xsim runner / log surfacing path inside `pccx-lab` — **planned**.
 
-## pccx-lab handoff (planned)
+---
 
-When the `pccx-lab` CLI exposes a stable `analyze` subcommand that
-emits diagnostics in (or convertible to) the v0 envelope, this CLI is
-expected to:
+## pccx-lab diagnostics handoff (active)
 
-1. Resolve the `pccx-lab` binary on `$PATH` or via `PCCX_LAB_BIN`.
-2. Forward the file under inspection through that binary.
-3. Validate the response against `schema/diagnostics-v0.json`.
-4. Re-emit the response from this CLI without re-analysing.
+`pccx-lab` now exposes `analyze <path> [--format json]` which emits an
+early diagnostics envelope.  The `pccx-ide check --backend pccx-lab`
+flag wires this path.
 
-The IDE side (later: VS Code extension, GUI shell, MCP-controlled
-flows) consumes that same envelope. There is no private back channel
-between the GUI and `pccx-lab` internals.
+### Usage
 
-### PCCX_LAB_BIN resolution order (planned)
+```bash
+# Default: built-in scaffold checks (no external binary needed)
+python -m pccx_ide_cli check fixtures/ok_module.sv
 
-When the handoff is wired up, binary resolution will follow this
-precedence:
+# Opt-in: forward through pccx-lab CLI / core boundary
+PCCX_LAB_BIN=/path/to/pccx-lab \
+    python -m pccx_ide_cli check fixtures/ok_module.sv --backend pccx-lab
 
-1. `PCCX_LAB_BIN` environment variable (absolute path).
-2. `pccx-lab` on `$PATH`.
+# pccx-lab on PATH (PCCX_LAB_BIN takes priority if both are set)
+python -m pccx_ide_cli check fixtures/ok_module.sv --backend pccx-lab
+```
+
+### PCCX_LAB_BIN resolution order
+
+1. `PCCX_LAB_BIN` environment variable (non-empty, absolute path).
+2. `pccx-lab` on `$PATH` via `shutil.which`.
 3. Hard error with a clear message — no silent fallback to scaffold
-   analysis when the lab binary is expected but missing.
+   analysis when the pccx-lab backend is explicitly requested.
 
-The scaffold will never silently substitute its own placeholder checks
-for a missing `pccx-lab` binary once the handoff contract is active.
 A missing binary is a configuration error, not a graceful degradation
-case.
+case.  The scaffold analysis will never substitute silently.
+
+### Adapter rules
+
+Two narrow transformations are applied to the raw pccx-lab output before
+schema validation and forwarding:
+
+1. **`_note` stripped** — pccx-lab includes a `_note` comment field that
+   is explicitly described as "not a stable API contract".  It is a
+   comment, not data.  It is removed before validation.
+
+2. **line/column 0 → 1** — pccx-lab uses `line: 0, column: 0` to
+   indicate an unknown source location.  The `diagnostics-v0.json`
+   schema requires `minimum: 1`.  Values below 1 are clamped to 1 per
+   diagnostic.
+
+No other transformations are applied.  Any unknown top-level field
+beyond `_note` causes a schema validation error rather than silent
+discard — drift between pccx-lab and the v0 schema should surface
+loudly while both sides are pre-stable.
+
+### Exit codes
+
+Exit codes pass through from pccx-lab to the CLI caller:
+
+| pccx-lab exit | meaning | CLI exit |
+|---|---|---|
+| 0 | no diagnostics | 0 |
+| 1 | diagnostics found | 1 |
+| 2 | I/O error | 2 |
+
+Internal CLI errors (JSON parse failure, schema validation failure) also
+exit 2 with a message on stderr.
+
+### Claims
+
+- The default scaffold remains available for local development and
+  testing without any external binary.
+- The pccx-lab backend is opt-in; it requires explicit `--backend pccx-lab`.
+- pccx-lab output is an early diagnostics envelope — pre-stable, not a
+  committed API contract.
+- This CLI does not implement a full SystemVerilog semantic parser.
+- This CLI does not implement an LSP server.
+- There is no stable plugin ABI claim.
+- There is no full IDE replacement claim.
+
+---
 
 ## xsim handoff (planned)
 
-xsim runs and log surfacing remain on the `pccx-lab` side. This CLI is
-expected only to:
+xsim runs and log surfacing remain on the `pccx-lab` side.  This CLI is
+expected to:
 
 1. Pass through a `run` request to `pccx-lab`.
 2. Translate the resulting log / report into the same diagnostics
    envelope where it makes sense, or surface a structured run-summary
    document (envelope version to be defined alongside the lab CLI).
+
+---
 
 ## Open questions
 
@@ -58,5 +106,7 @@ expected only to:
   or one envelope with a list of `source` entries.
 - How verification status (xsim pass/fail counts) is layered on top of
   the diagnostics envelope.
+- Whether the `additionalProperties: false` constraint on diagnostics
+  should relax at v1 to allow forward-compatible extension fields.
 
-These are intentionally unresolved while the scaffold matures.
+These are intentionally unresolved while both sides mature.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,10 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
 ]
+dependencies = ["jsonschema>=4"]
 
 [project.optional-dependencies]
-test = ["pytest", "jsonschema>=4"]
+test = ["pytest"]
 
 [project.scripts]
 pccx-ide = "pccx_ide_cli.__main__:main"

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -15,9 +15,9 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="pccx-ide",
         description=(
             "Scaffold CLI for the pccx SystemVerilog IDE spin-out. "
-            "Emits a placeholder diagnostics envelope; real analysis "
-            "will be consumed from pccx-lab once its CLI / core "
-            "boundary stabilizes."
+            "Default backend emits a placeholder diagnostics envelope. "
+            "Use --backend pccx-lab to forward through the pccx-lab "
+            "CLI / core boundary."
         ),
     )
     parser.add_argument(
@@ -29,7 +29,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     check = sub.add_parser(
         "check",
-        help="Run the placeholder envelope check on a SystemVerilog file.",
+        help="Run a diagnostics check on a SystemVerilog file.",
     )
     check.add_argument("path", type=Path, help="Path to a .sv / .svh file.")
     check.add_argument(
@@ -37,6 +37,17 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=("json", "text"),
         default="json",
         help="Output format (default: json).",
+    )
+    check.add_argument(
+        "--backend",
+        choices=("scaffold", "pccx-lab"),
+        default="scaffold",
+        help=(
+            "Analysis backend. 'scaffold' runs the built-in placeholder checks. "
+            "'pccx-lab' invokes the pccx-lab binary (requires PCCX_LAB_BIN env var "
+            "or pccx-lab on PATH); fails clearly if binary is missing — "
+            "no silent fallback to scaffold. Default: scaffold."
+        ),
     )
 
     sub.add_parser(
@@ -62,7 +73,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
 
     if args.command == "check":
-        envelope = scan_file(args.path)
+        if args.backend == "pccx-lab":
+            from .pccx_lab_backend import run as _run_pccx_lab
+            envelope, lab_exit = _run_pccx_lab(args.path)
+        else:
+            envelope = scan_file(args.path)
+            lab_exit = None
+
         if args.format == "json":
             json.dump(envelope, sys.stdout, indent=2, sort_keys=True)
             sys.stdout.write("\n")
@@ -72,6 +89,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                     f"{envelope['source']}:{d['line']}: "
                     f"{d['severity']}: {d['code']}: {d['message']}\n"
                 )
+
+        if lab_exit is not None:
+            return lab_exit
         return 0 if not envelope["diagnostics"] else 1
 
     parser.error(f"unknown command: {args.command}")

--- a/src/pccx_ide_cli/pccx_lab_backend.py
+++ b/src/pccx_ide_cli/pccx_lab_backend.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+_SCHEMA_PATH = (
+    Path(__file__).resolve().parent.parent.parent / "schema" / "diagnostics-v0.json"
+)
+_SCHEMA = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+_VALIDATOR = jsonschema.Draft202012Validator(_SCHEMA)
+
+
+def resolve_binary() -> str | None:
+    """Return the pccx-lab binary path, or None if not resolvable.
+
+    Resolution order:
+      1. PCCX_LAB_BIN environment variable (non-empty).
+      2. 'pccx-lab' on PATH via shutil.which.
+    """
+    env_bin = os.environ.get("PCCX_LAB_BIN")
+    if env_bin:
+        return env_bin
+    return shutil.which("pccx-lab")
+
+
+def _normalize_envelope(raw: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    """Apply the two narrow adapter rules and return (adapted_envelope, notes).
+
+    Rules applied:
+      1. Strip _note (it is a self-described comment field, not data).
+      2. Clamp line/column from 0 to 1 per-diagnostic (pccx-lab uses 0 for
+         "unknown location"; diagnostics-v0.json requires minimum: 1).
+
+    Any other unknown top-level field is left in place so that the schema
+    validator can reject it explicitly rather than silently discarding it.
+    """
+    adapted = dict(raw)
+    notes: list[str] = []
+
+    if "_note" in adapted:
+        del adapted["_note"]
+        notes.append("_note stripped (comment field, not data)")
+
+    if "diagnostics" in adapted and isinstance(adapted["diagnostics"], list):
+        clamped = 0
+        new_diags: list[dict[str, Any]] = []
+        for d in adapted["diagnostics"]:
+            d = dict(d)
+            if isinstance(d.get("line"), int) and d["line"] < 1:
+                d["line"] = 1
+                clamped += 1
+            if isinstance(d.get("column"), int) and d["column"] < 1:
+                d["column"] = 1
+                clamped += 1
+            new_diags.append(d)
+        adapted["diagnostics"] = new_diags
+        if clamped:
+            notes.append(
+                f"{clamped} line/column 0→1 "
+                f"(pccx-lab uses 0 for unknown location; schema minimum is 1)"
+            )
+
+    return adapted, notes
+
+
+def run(file: Path) -> tuple[dict[str, Any], int]:
+    """Invoke 'pccx-lab analyze <file> --format json' and return (envelope, exit_code).
+
+    Raises SystemExit(2) with a clear error message on:
+      - binary not found (no PCCX_LAB_BIN and no pccx-lab on PATH)
+      - binary execution failure
+      - empty stdout
+      - JSON parse error
+      - schema validation failure after normalization
+
+    Never falls back to scaffold analysis.  A missing or broken pccx-lab
+    binary is a configuration error, not a graceful-degradation case.
+    """
+    bin_path = resolve_binary()
+    if bin_path is None:
+        sys.stderr.write(
+            "error: --backend pccx-lab requested but no binary found\n"
+            "  Set PCCX_LAB_BIN to the pccx-lab binary path, "
+            "or add pccx-lab to PATH\n"
+            "  No fallback to scaffold analysis\n"
+        )
+        raise SystemExit(2)
+
+    try:
+        proc = subprocess.run(
+            [bin_path, "analyze", str(file), "--format", "json"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        sys.stderr.write(
+            f"error: failed to execute pccx-lab ({bin_path!r}): {exc}\n"
+            "  No fallback to scaffold analysis\n"
+        )
+        raise SystemExit(2)
+
+    if proc.stderr:
+        sys.stderr.write(proc.stderr)
+
+    stdout = proc.stdout.strip()
+    if not stdout:
+        sys.stderr.write(
+            f"error: pccx-lab exited {proc.returncode} with empty stdout\n"
+        )
+        raise SystemExit(2)
+
+    try:
+        raw: dict[str, Any] = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(
+            f"error: pccx-lab stdout is not valid JSON: {exc}\n"
+            f"  (first 200 chars) {stdout[:200]!r}\n"
+        )
+        raise SystemExit(2)
+
+    adapted, notes = _normalize_envelope(raw)
+
+    if notes:
+        sys.stderr.write(
+            "# pccx-ide: forwarded from pccx-lab v0 envelope ("
+            + "; ".join(notes)
+            + ")\n"
+        )
+
+    errors = list(_VALIDATOR.iter_errors(adapted))
+    if errors:
+        sys.stderr.write(
+            "error: pccx-lab envelope failed diagnostics-v0.json validation "
+            "after normalization\n"
+        )
+        for e in errors:
+            sys.stderr.write(f"  {e.message}\n")
+        raise SystemExit(2)
+
+    return adapted, proc.returncode

--- a/tests/test_pccx_lab_backend.py
+++ b/tests/test_pccx_lab_backend.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+SCHEMA_PATH = REPO_ROOT / "schema" / "diagnostics-v0.json"
+
+_SCHEMA = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+_VALIDATOR = jsonschema.Draft202012Validator(_SCHEMA)
+
+
+def _assert_conforms(envelope: dict) -> None:
+    errors = list(_VALIDATOR.iter_errors(envelope))
+    assert not errors, "\n".join(str(e) for e in errors)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _make_fake_binary(tmp_path: Path, stdout: str, exit_code: int, name: str = "fake_pccx_lab") -> Path:
+    """Create an executable Python script that prints stdout and exits exit_code.
+
+    Uses sys.executable (absolute path) as shebang so the script works even
+    when the subprocess is given a restricted PATH.
+    """
+    script = tmp_path / name
+    script.write_text(
+        f"#!{sys.executable}\n"
+        "import sys\n"
+        f"sys.stdout.write({stdout!r})\n"
+        f"sys.exit({exit_code})\n",
+        encoding="utf-8",
+    )
+    script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return script
+
+
+def _run_cli(*args: str, extra_env: dict | None = None) -> subprocess.CompletedProcess:
+    env: dict[str, str] = {
+        "PYTHONPATH": str(SRC),
+        "PATH": os.environ.get("PATH", ""),
+    }
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, "-m", "pccx_ide_cli", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+# ── pre-built envelopes used across tests ─────────────────────────────────────
+
+_CLEAN_ENVELOPE = json.dumps({
+    "envelope": "0",
+    "tool": "pccx-lab",
+    "source": "ok_module.sv",
+    "diagnostics": [],
+}) + "\n"
+
+_DIAG_ENVELOPE = json.dumps({
+    "envelope": "0",
+    "tool": "pccx-lab",
+    "source": "missing_endmodule.sv",
+    "diagnostics": [
+        {
+            "line": 1,
+            "column": 1,
+            "severity": "error",
+            "code": "PCCX-SCAFFOLD-003",
+            "message": "module declaration found but `endmodule` is missing",
+            "source": "pccx-lab",
+        }
+    ],
+}) + "\n"
+
+_NOTE_ENVELOPE = json.dumps({
+    "_note": "Early example — not a stable API contract.",
+    "envelope": "0",
+    "tool": "pccx-lab",
+    "source": "ok_module.sv",
+    "diagnostics": [],
+}) + "\n"
+
+_ZERO_LINE_ENVELOPE = json.dumps({
+    "envelope": "0",
+    "tool": "pccx-lab",
+    "source": "some.sv",
+    "diagnostics": [
+        {
+            "line": 0,
+            "column": 0,
+            "severity": "error",
+            "code": "PCCX-IO-001",
+            "message": "cannot read file: no such file or directory",
+            "source": "pccx-lab",
+        }
+    ],
+}) + "\n"
+
+_IO_ERROR_ENVELOPE = json.dumps({
+    "envelope": "0",
+    "tool": "pccx-lab",
+    "source": "/nonexistent.sv",
+    "diagnostics": [
+        {
+            "line": 1,
+            "column": 1,
+            "severity": "error",
+            "code": "PCCX-IO-001",
+            "message": "cannot read file: no such file or directory",
+            "source": "pccx-lab",
+        }
+    ],
+}) + "\n"
+
+_UNKNOWN_FIELD_ENVELOPE = json.dumps({
+    "envelope": "0",
+    "tool": "pccx-lab",
+    "source": "ok.sv",
+    "diagnostics": [],
+    "unexpected_field": "schema_must_reject_this",
+}) + "\n"
+
+
+# ── default scaffold still works ──────────────────────────────────────────────
+
+def test_scaffold_default_unchanged():
+    """Existing default backend is unaffected by adding --backend."""
+    result = _run_cli("check", str(REPO_ROOT / "fixtures" / "ok_module.sv"))
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["envelope"] == "0"
+    assert payload["diagnostics"] == []
+
+
+def test_scaffold_explicit_flag_unchanged():
+    """--backend scaffold is identical to the default."""
+    result = _run_cli(
+        "check",
+        "--backend", "scaffold",
+        str(REPO_ROOT / "fixtures" / "ok_module.sv"),
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["diagnostics"] == []
+
+
+def test_scaffold_missing_endmodule_still_flagged():
+    result = _run_cli(
+        "check",
+        "--backend", "scaffold",
+        str(REPO_ROOT / "fixtures" / "missing_endmodule.sv"),
+    )
+    assert result.returncode != 0
+    codes = {d["code"] for d in json.loads(result.stdout)["diagnostics"]}
+    assert "PCCX-SCAFFOLD-003" in codes
+
+
+# ── missing binary: fail clearly, no silent fallback ─────────────────────────
+
+def test_missing_binary_no_env_no_path(tmp_path):
+    """No PCCX_LAB_BIN, pccx-lab absent from PATH → non-zero, no scaffold output."""
+    result = _run_cli(
+        "check",
+        "--backend", "pccx-lab",
+        str(REPO_ROOT / "fixtures" / "ok_module.sv"),
+        extra_env={
+            "PCCX_LAB_BIN": "",          # empty treated as unset
+            "PATH": str(tmp_path),        # tmp dir has no pccx-lab binary
+        },
+    )
+    assert result.returncode != 0
+    assert "PCCX-SCAFFOLD" not in result.stdout
+    assert result.stderr.strip() != ""
+
+
+def test_missing_binary_env_nonexistent(tmp_path):
+    """PCCX_LAB_BIN points to nonexistent path → non-zero, no scaffold output."""
+    result = _run_cli(
+        "check",
+        "--backend", "pccx-lab",
+        str(REPO_ROOT / "fixtures" / "ok_module.sv"),
+        extra_env={
+            "PCCX_LAB_BIN": str(tmp_path / "no_such_binary"),
+        },
+    )
+    assert result.returncode != 0
+    assert "PCCX-SCAFFOLD" not in result.stdout
+
+
+# ── fake binary: PCCX_LAB_BIN takes priority over PATH ───────────────────────
+
+def test_pccx_lab_bin_takes_priority(tmp_path):
+    """PCCX_LAB_BIN is honoured before PATH when both are set."""
+    fake = _make_fake_binary(tmp_path, _CLEAN_ENVELOPE, 0)
+    # PATH points to a directory with a pccx-lab that would exit 99 if run
+    path_dir = tmp_path / "pathdir"
+    path_dir.mkdir()
+    decoy = path_dir / "pccx-lab"
+    decoy.write_text(f"#!{sys.executable}\nimport sys\nsys.exit(99)\n")
+    decoy.chmod(decoy.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    result = _run_cli(
+        "check",
+        "--backend", "pccx-lab",
+        "fixtures/ok_module.sv",
+        extra_env={
+            "PCCX_LAB_BIN": str(fake),
+            "PATH": str(path_dir),
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["diagnostics"] == []
+
+
+# ── fake binary: clean envelope → exit 0 ─────────────────────────────────────
+
+def test_clean_envelope_exits_zero(tmp_path):
+    fake = _make_fake_binary(tmp_path, _CLEAN_ENVELOPE, 0)
+    result = _run_cli(
+        "check",
+        "--backend", "pccx-lab",
+        "fixtures/ok_module.sv",
+        extra_env={"PCCX_LAB_BIN": str(fake)},
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["envelope"] == "0"
+    assert payload["tool"] == "pccx-lab"
+    assert payload["diagnostics"] == []
+    _assert_conforms(payload)
+
+
+# ── fake binary: diagnostics envelope → exit 1 ───────────────────────────────
+
+def test_diagnostics_envelope_exits_one(tmp_path):
+    fake = _make_fake_binary(tmp_path, _DIAG_ENVELOPE, 1)
+    result = _run_cli(
+        "check",
+        "--backend", "pccx-lab",
+        "fixtures/missing_endmodule.sv",
+        extra_env={"PCCX_LAB_BIN": str(fake)},
+    )
+    assert result.returncode == 1, result.stderr
+    payload = json.loads(result.stdout)
+    codes = {d["code"] for d in payload["diagnostics"]}
+    assert "PCCX-SCAFFOLD-003" in codes
+    _assert_conforms(payload)
+
+
+# ── fake binary: invalid JSON → fail clearly ─────────────────────────────────
+
+def test_invalid_json_fails_clearly(tmp_path):
+    fake = _make_fake_binary(tmp_path, "this is not json at all\n", 0)
+    result = _run_cli(
+        "check",
+        "--backend", "pccx-lab",
+        "fixtures/ok_module.sv",
+        extra_env={"PCCX_LAB_BIN": str(fake)},
+    )
+    assert result.returncode != 0
+    assert "json" in result.stderr.lower()
+    assert "PCCX-SCAFFOLD" not in result.stdout
+
+
+# ── adapter: _note field stripped ────────────────────────────────────────────
+
+def test_note_field_stripped(tmp_path):
+    """_note is stripped; output conforms to schema."""
+    fake = _make_fake_binary(tmp_path, _NOTE_ENVELOPE, 0)
+    result = _run_cli(
+        "check",
+        "--backend", "pccx-lab",
+        "fixtures/ok_module.sv",
+        extra_env={"PCCX_LAB_BIN": str(fake)},
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert "_note" not in payload
+    _assert_conforms(payload)
+
+
+# ── adapter: line/column 0 clamped to 1 ──────────────────────────────────────
+
+def test_zero_line_column_clamped(tmp_path):
+    """line=0 / column=0 are clamped to 1; output conforms to schema."""
+    fake = _make_fake_binary(tmp_path, _ZERO_LINE_ENVELOPE, 1)
+    result = _run_cli(
+        "check",
+        "--backend", "pccx-lab",
+        "fixtures/ok_module.sv",
+        extra_env={"PCCX_LAB_BIN": str(fake)},
+    )
+    assert result.returncode == 1, result.stderr
+    payload = json.loads(result.stdout)
+    for d in payload["diagnostics"]:
+        assert d["line"] >= 1, f"line should be >=1, got {d['line']}"
+        assert d["column"] >= 1, f"column should be >=1, got {d['column']}"
+    _assert_conforms(payload)
+
+
+# ── adapter: unknown top-level field (not _note) → schema rejects ────────────
+
+def test_unknown_field_rejected(tmp_path):
+    """Unknown top-level fields beyond _note cause schema validation failure."""
+    fake = _make_fake_binary(tmp_path, _UNKNOWN_FIELD_ENVELOPE, 0)
+    result = _run_cli(
+        "check",
+        "--backend", "pccx-lab",
+        "fixtures/ok_module.sv",
+        extra_env={"PCCX_LAB_BIN": str(fake)},
+    )
+    assert result.returncode != 0
+    assert "PCCX-SCAFFOLD" not in result.stdout
+
+
+# ── exit code passthrough ─────────────────────────────────────────────────────
+
+def test_exit_code_2_passthrough(tmp_path):
+    """pccx-lab exit code 2 (I/O error) passes through to CLI exit code."""
+    fake = _make_fake_binary(tmp_path, _IO_ERROR_ENVELOPE, 2)
+    result = _run_cli(
+        "check",
+        "--backend", "pccx-lab",
+        "fixtures/ok_module.sv",
+        extra_env={"PCCX_LAB_BIN": str(fake)},
+    )
+    assert result.returncode == 2, f"expected 2, got {result.returncode}"
+    payload = json.loads(result.stdout)
+    _assert_conforms(payload)
+
+
+# ── text format works with pccx-lab backend ───────────────────────────────────
+
+def test_text_format_with_pccx_lab_backend(tmp_path):
+    """--format text emits human-readable lines when using pccx-lab backend."""
+    fake = _make_fake_binary(tmp_path, _DIAG_ENVELOPE, 1)
+    result = _run_cli(
+        "check",
+        "--backend", "pccx-lab",
+        "--format", "text",
+        "fixtures/missing_endmodule.sv",
+        extra_env={"PCCX_LAB_BIN": str(fake)},
+    )
+    assert result.returncode == 1
+    assert "PCCX-SCAFFOLD-003" in result.stdout
+    assert "error" in result.stdout
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

- Adds `--backend pccx-lab` option to `pccx-ide check` to forward file analysis through the pccx-lab CLI / core boundary
- Default scaffold behavior is unchanged; pccx-lab backend is explicitly opt-in
- No silent fallback: missing binary fails with a clear error message

## Command added

```bash
# Opt-in: forward through pccx-lab
PCCX_LAB_BIN=/path/to/pccx-lab python -m pccx_ide_cli check <file> --backend pccx-lab

# Default scaffold (unchanged)
python -m pccx_ide_cli check <file>
```

## PCCX_LAB_BIN resolution order

1. `PCCX_LAB_BIN` environment variable (non-empty, absolute path)
2. `pccx-lab` on `$PATH` via `shutil.which`
3. Hard error — no silent fallback to scaffold analysis

## No-silent-fallback behavior

When `--backend pccx-lab` is specified and no binary is available, the CLI exits non-zero with a clear error on stderr. Scaffold output is never emitted in this case.

## Adapter rules (two only)

- `_note` stripped from pccx-lab envelope (self-described comment field, not data)
- `line`/`column` values of `0` clamped to `1` (pccx-lab uses `0` for unknown location; `diagnostics-v0.json` requires minimum `1`)
- Any other unknown top-level field causes schema validation failure — no silent discard

## Exit code passthrough

| pccx-lab exit | meaning | CLI exit |
|---|---|---|
| 0 | clean | 0 |
| 1 | diagnostics found | 1 |
| 2 | I/O error | 2 |

## Validation commands run

```bash
# All tests (34 total, 14 new)
python3 -m pytest -q  # 34 passed

# Default scaffold
python3 -m pccx_ide_cli check fixtures/ok_module.sv

# Missing binary fails clearly
PCCX_LAB_BIN="" python3 -m pccx_ide_cli check fixtures/ok_module.sv --backend pccx-lab
# exit 2, clear error on stderr, no scaffold output
```

## Fake-binary test coverage

14 new tests in `tests/test_pccx_lab_backend.py`:
- Scaffold default and explicit `--backend scaffold` unchanged
- Missing binary (no env, no PATH) → non-zero, no scaffold output
- Missing binary (PCCX_LAB_BIN to nonexistent path) → non-zero
- PCCX_LAB_BIN takes priority over PATH
- Clean envelope → exit 0, schema-conformant output
- Diagnostics envelope → exit 1, codes forwarded
- Invalid JSON → non-zero, clear error
- `_note` field stripped → schema-conformant
- `line`/`column` 0 clamped to 1 → schema-conformant
- Unknown extra field → schema validation failure
- Exit code 2 passthrough
- `--format text` works with pccx-lab backend

## Real pccx-lab smoke (local, not in CI)

```bash
# ok_module.sv → exit 0, _note stripped
PCCX_LAB_BIN=.../pccx-lab python3 -m pccx_ide_cli check fixtures/ok_module.sv --backend pccx-lab
# missing_endmodule.sv → exit 1, _note stripped, line/col 0→1
PCCX_LAB_BIN=.../pccx-lab python3 -m pccx_ide_cli check fixtures/missing_endmodule.sv --backend pccx-lab
```

Both pass end-to-end with the real binary.

## Claims

- pccx-lab output is an early diagnostics envelope — pre-stable, not a committed API contract
- No full SystemVerilog semantic parser
- No LSP server
- No stable plugin ABI
- No full IDE replacement