### PR TITLE
docs: link handoff notes to org-level engineering discipline

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -110,3 +110,10 @@ expected to:
   should relax at v1 to allow forward-compatible extension fields.
 
 These are intentionally unresolved while both sides mature.
+
+---
+
+*See also*:
+[AI-assisted engineering discipline](https://github.com/pccxai/pccxai/blob/main/docs/AI_ASSISTED_ENGINEERING.md) —
+org-level rules covering interface-first work and gray-box delegation that govern
+how AI workers interact with the pccx-lab boundary from this IDE layer.


### PR DESCRIPTION
## Summary

- Adds a "See also" cross-reference at the end of `docs/HANDOFF.md` pointing to the org-level AI-assisted engineering discipline, specifically the interface-first and gray-box delegation rules that govern AI worker interaction with the pccx-lab boundary.

## Type of change

- [x] Documentation

## Verification

`git diff --check` clean. One-line addition only.

## Linked issues

(none)