### PR TITLE
feat: improve diagnostics text output with backend, source, and column

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,28 @@ checks are file-shape level only (file exists, file non-empty,
 that matters; analysis arrives later, through `pccx-lab`.
 
 ```bash
+# JSON output (default)
 python -m pccx_ide_cli check fixtures/ok_module.sv
 python -m pccx_ide_cli check fixtures/missing_endmodule.sv
+
+# Human-readable text output
+python -m pccx_ide_cli check fixtures/ok_module.sv --format text
+python -m pccx_ide_cli check fixtures/missing_endmodule.sv --format text
+
+# pccx-lab backend (requires binary)
+PCCX_LAB_BIN=/path/to/pccx-lab \
+    python -m pccx_ide_cli check fixtures/ok_module.sv --backend pccx-lab --format text
+
+# Print the diagnostics schema
 python -m pccx_ide_cli schema
+```
+
+Text output format:
+```
+backend: scaffold
+source: fixtures/missing_endmodule.sv
+1 diagnostic
+fixtures/missing_endmodule.sv:1:1: error: PCCX-SCAFFOLD-003: `module` declared but no matching `endmodule` found
 ```
 
 Tests are run with:

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -84,9 +84,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             json.dump(envelope, sys.stdout, indent=2, sort_keys=True)
             sys.stdout.write("\n")
         else:
-            for d in envelope["diagnostics"]:
+            diags = envelope["diagnostics"]
+            count = len(diags)
+            plural = "s" if count != 1 else ""
+            sys.stdout.write(f"backend: {args.backend}\n")
+            sys.stdout.write(f"source: {envelope['source']}\n")
+            sys.stdout.write(f"{count} diagnostic{plural}\n")
+            for d in diags:
                 sys.stdout.write(
-                    f"{envelope['source']}:{d['line']}: "
+                    f"{envelope['source']}:{d['line']}:{d['column']}: "
                     f"{d['severity']}: {d['code']}: {d['message']}\n"
                 )
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -128,6 +128,8 @@ def test_cli_check_text_format():
         str(REPO_ROOT / "fixtures" / "missing_endmodule.sv"),
     )
     assert result.returncode != 0
+    assert "backend: scaffold" in result.stdout
+    assert "1 diagnostic" in result.stdout
     assert "PCCX-SCAFFOLD-003" in result.stdout
     assert "error" in result.stdout
 
@@ -139,7 +141,24 @@ def test_cli_check_text_ok_exits_zero():
         str(REPO_ROOT / "fixtures" / "ok_module.sv"),
     )
     assert result.returncode == 0
-    assert result.stdout.strip() == ""
+    assert "backend: scaffold" in result.stdout
+    assert "0 diagnostics" in result.stdout
+
+
+def test_cli_check_text_includes_column():
+    result = _run_cli(
+        "check",
+        "--format", "text",
+        str(REPO_ROOT / "fixtures" / "missing_endmodule.sv"),
+    )
+    # diagnostic lines must be path:line:col: severity: code: message
+    diag_lines = [
+        ln for ln in result.stdout.splitlines()
+        if "PCCX-SCAFFOLD" in ln
+    ]
+    assert diag_lines, "expected at least one diagnostic line"
+    # column field present: path:L:C: ...
+    assert diag_lines[0].count(":") >= 4
 
 
 def test_cli_schema_smoke():

--- a/tests/test_pccx_lab_backend.py
+++ b/tests/test_pccx_lab_backend.py
@@ -356,8 +356,25 @@ def test_text_format_with_pccx_lab_backend(tmp_path):
         extra_env={"PCCX_LAB_BIN": str(fake)},
     )
     assert result.returncode == 1
+    assert "backend: pccx-lab" in result.stdout
+    assert "1 diagnostic" in result.stdout
     assert "PCCX-SCAFFOLD-003" in result.stdout
     assert "error" in result.stdout
+
+
+def test_text_format_clean_pccx_lab_backend(tmp_path):
+    """--format text with zero diagnostics shows backend and source headers."""
+    fake = _make_fake_binary(tmp_path, _CLEAN_ENVELOPE, 0)
+    result = _run_cli(
+        "check",
+        "--backend", "pccx-lab",
+        "--format", "text",
+        "fixtures/ok_module.sv",
+        extra_env={"PCCX_LAB_BIN": str(fake)},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "backend: pccx-lab" in result.stdout
+    assert "0 diagnostics" in result.stdout
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Text mode now prints a three-line header (`backend:`, `source:`, `N diagnostic(s)`) before any per-diagnostic lines
- Diagnostic lines now include column: `path:line:col: severity: code: message`
- JSON output and schema are unchanged
- scaffold backend and pccx-lab backend behaviour are unchanged
- no-silent-fallback policy remains enforced

## Test plan

- [ ] `python3 -m pytest -q` → 36 passed
- [ ] `pccx_ide_cli check fixtures/ok_module.sv --format text` → header + `0 diagnostics`, exit 0
- [ ] `pccx_ide_cli check fixtures/missing_endmodule.sv --format text` → header + `1 diagnostic` + diagnostic line with column, exit 1
- [ ] JSON mode unchanged: same envelope shape and schema conformance
- [ ] `test_text_format_with_pccx_lab_backend` checks `backend: pccx-lab` and `1 diagnostic`
- [ ] `test_text_format_clean_pccx_lab_backend` (new) checks `backend: pccx-lab` + `0 diagnostics`
- [ ] `test_cli_check_text_includes_column` (new) checks `path:L:C:` format