### PR TITLE
feat: add module index scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,3 +132,25 @@ jobs:
             exit 1
           fi
           echo "missing pccx-lab binary correctly fails"
+      - name: cli smoke (index single file exits zero, JSON parses)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli index \
+              fixtures/modules/simple_module.sv \
+              | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-index'"
+          echo "index single-file smoke ok"
+      - name: cli smoke (index directory exits zero)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli index fixtures/modules \
+              | python -c "import json,sys; d=json.load(sys.stdin); assert len(d['modules'])>0"
+          echo "index directory smoke ok"
+      - name: cli smoke (index missing path exits non-zero)
+        run: |
+          set -e
+          if PYTHONPATH=src python -m pccx_ide_cli index \
+              fixtures/modules/does_not_exist.sv; then
+            echo "::error::expected non-zero exit for missing index path"
+            exit 1
+          fi
+          echo "index missing path correctly fails"

--- a/README.md
+++ b/README.md
@@ -51,28 +51,41 @@ checks are file-shape level only (file exists, file non-empty,
 that matters; analysis arrives later, through `pccx-lab`.
 
 ```bash
-# JSON output (default)
+# Diagnostics check — JSON output (default)
 python -m pccx_ide_cli check fixtures/ok_module.sv
 python -m pccx_ide_cli check fixtures/missing_endmodule.sv
 
-# Human-readable text output
+# Diagnostics check — human-readable text output
 python -m pccx_ide_cli check fixtures/ok_module.sv --format text
 python -m pccx_ide_cli check fixtures/missing_endmodule.sv --format text
 
-# pccx-lab backend (requires binary)
+# Diagnostics check — pccx-lab backend (requires binary)
 PCCX_LAB_BIN=/path/to/pccx-lab \
     python -m pccx_ide_cli check fixtures/ok_module.sv --backend pccx-lab --format text
+
+# Module index (early scaffold — not a full parser)
+python -m pccx_ide_cli index fixtures/modules/simple_module.sv
+python -m pccx_ide_cli index fixtures/modules/ --format text
 
 # Print the diagnostics schema
 python -m pccx_ide_cli schema
 ```
 
-Text output format:
+Diagnostics text output format:
 ```
 backend: scaffold
 source: fixtures/missing_endmodule.sv
 1 diagnostic
 fixtures/missing_endmodule.sv:1:1: error: PCCX-SCAFFOLD-003: `module` declared but no matching `endmodule` found
+```
+
+Module index text output format:
+```
+source: fixtures/modules/
+3 modules
+fixtures/modules/simple_module.sv:1:1: module simple_mod
+fixtures/modules/two_modules.sv:1:1: module mod_a
+fixtures/modules/two_modules.sv:3:1: module mod_b
 ```
 
 Tests are run with:

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -86,6 +86,53 @@ exit 2 with a message on stderr.
 
 ---
 
+## module index scaffold (active, pre-stable)
+
+`pccx-ide index` scans `.sv` and `.v` files for `module` declarations and
+emits a lightweight index.  This is an early scaffold intended to support
+future navigation and editor-bridge work — it is not a full SystemVerilog
+parser.
+
+### Usage
+
+```bash
+# JSON output (default)
+python -m pccx_ide_cli index fixtures/modules/simple_module.sv
+
+# Human-readable text output
+python -m pccx_ide_cli index fixtures/modules/ --format text
+```
+
+### Output shape (JSON)
+
+```json
+{
+  "kind": "module-index",
+  "tool": "pccx-ide-scaffold",
+  "source": "<path passed on CLI>",
+  "modules": [
+    { "name": "simple_mod", "file": "<abs-path>", "line": 1, "column": 1 }
+  ]
+}
+```
+
+### Parser limitations
+
+- Single-line `//` comments are skipped.
+- Block comments (`/* ... */`) are **not** parsed — a `module` keyword
+  inside a block comment will be reported as a false positive.
+- `package`, `interface`, and `class` declarations are ignored.
+- No semantic analysis.  Column is the 1-indexed position of the `module`
+  keyword.
+
+### Scope
+
+- pccx-lab backend is diagnostics-only for now.  `index` always uses the
+  built-in scaffold scanner.
+- No stable ABI or API contract — the output shape may change before v1.
+
+---
+
 ## xsim handoff (planned)
 
 xsim runs and log surfacing remain on the `pccx-lab` side.  This CLI is

--- a/fixtures/modules/commented_module.sv
+++ b/fixtures/modules/commented_module.sv
@@ -1,0 +1,3 @@
+// module fake_mod; // this line is commented out — should be ignored
+module real_mod;
+endmodule

--- a/fixtures/modules/nested_dir/child_module.sv
+++ b/fixtures/modules/nested_dir/child_module.sv
@@ -1,0 +1,4 @@
+module child_mod (
+    input logic clk
+);
+endmodule

--- a/fixtures/modules/nested_dir/extra_v_mod.v
+++ b/fixtures/modules/nested_dir/extra_v_mod.v
@@ -1,0 +1,5 @@
+// Verilog (.v) fixture — verifies that .v files are included in directory scans.
+module extra_v_mod (
+    input clk
+);
+endmodule

--- a/fixtures/modules/no_module.sv
+++ b/fixtures/modules/no_module.sv
@@ -1,0 +1,3 @@
+// No module declaration here — just comments and a timescale directive.
+// Used to verify that empty module lists are valid and exit 0.
+`timescale 1ns/1ps

--- a/fixtures/modules/simple_module.sv
+++ b/fixtures/modules/simple_module.sv
@@ -1,0 +1,5 @@
+module simple_mod (
+    input logic clk,
+    input logic rst_n
+);
+endmodule

--- a/fixtures/modules/two_modules.sv
+++ b/fixtures/modules/two_modules.sv
@@ -1,0 +1,9 @@
+module mod_a;
+endmodule
+
+module mod_b #(
+    parameter int W = 8
+) (
+    input logic clk
+);
+endmodule

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -50,6 +50,22 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    index_cmd = sub.add_parser(
+        "index",
+        help="Scan a .sv/.v file or directory for module declarations.",
+    )
+    index_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    index_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     sub.add_parser(
         "schema",
         help="Print the diagnostics envelope JSON schema.",
@@ -99,6 +115,30 @@ def main(argv: Sequence[str] | None = None) -> int:
         if lab_exit is not None:
             return lab_exit
         return 0 if not envelope["diagnostics"] else 1
+
+    if args.command == "index":
+        from .module_index import build_index, scan_path
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        modules = scan_path(args.path)
+        index = build_index(str(args.path), modules)
+
+        if args.format == "json":
+            json.dump(index, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            count = len(modules)
+            plural = "s" if count != 1 else ""
+            sys.stdout.write(f"source: {index['source']}\n")
+            sys.stdout.write(f"{count} module{plural}\n")
+            for m in modules:
+                sys.stdout.write(
+                    f"{m['file']}:{m['line']}:{m['column']}: module {m['name']}\n"
+                )
+        return 0
 
     parser.error(f"unknown command: {args.command}")
     return 2

--- a/src/pccx_ide_cli/module_index.py
+++ b/src/pccx_ide_cli/module_index.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+# Matches `module <name>` at the start of a line (optional leading whitespace).
+# Conservative: handles  module foo;  /  module foo #(  /  module foo (
+# Does NOT parse block comments — see HANDOFF.md.
+_MODULE_LINE_RE = re.compile(r"^(\s*)module\s+(\w+)")
+
+_IGNORE_DIRS: frozenset[str] = frozenset({".git", "__pycache__", "build", "dist", "target"})
+_SV_SUFFIXES: frozenset[str] = frozenset({".sv", ".v"})
+
+
+def _scan_text(text: str, source: str) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for line_num, line in enumerate(text.splitlines(), 1):
+        if line.lstrip().startswith("//"):
+            continue
+        m = _MODULE_LINE_RE.match(line)
+        if m:
+            results.append({
+                "name": m.group(2),
+                "file": source,
+                "line": line_num,
+                "column": len(m.group(1)) + 1,
+            })
+    return results
+
+
+def scan_file(path: Path) -> list[dict[str, Any]]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    return _scan_text(text, str(path))
+
+
+def scan_path(path: Path) -> list[dict[str, Any]]:
+    """Return module records for a single file or a directory tree.
+
+    Directory scan skips _IGNORE_DIRS and collects .sv and .v files only.
+    Output is sorted by (file, line, name) for determinism.
+    """
+    if path.is_file():
+        return scan_file(path)
+
+    sv_files = sorted(
+        f
+        for suffix in _SV_SUFFIXES
+        for f in path.rglob(f"*{suffix}")
+        if not any(part in _IGNORE_DIRS for part in f.parts)
+    )
+    modules: list[dict[str, Any]] = []
+    for f in sv_files:
+        modules.extend(scan_file(f))
+
+    modules.sort(key=lambda m: (m["file"], m["line"], m["name"]))
+    return modules
+
+
+def build_index(source: str, modules: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "kind": "module-index",
+        "modules": modules,
+        "source": source,
+        "tool": "pccx-ide-scaffold",
+    }

--- a/tests/test_module_index.py
+++ b/tests/test_module_index.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+FIXTURES = REPO_ROOT / "fixtures" / "modules"
+
+sys.path.insert(0, str(SRC))
+
+from pccx_ide_cli.module_index import build_index, scan_file, scan_path  # noqa: E402
+
+
+# ── unit: single-file scanning ────────────────────────────────────────────────
+
+def test_single_file_one_module():
+    mods = scan_file(FIXTURES / "simple_module.sv")
+    assert len(mods) == 1
+    assert mods[0]["name"] == "simple_mod"
+    assert mods[0]["line"] == 1
+    assert mods[0]["column"] == 1
+
+
+def test_two_modules_both_found():
+    mods = scan_file(FIXTURES / "two_modules.sv")
+    names = [m["name"] for m in mods]
+    assert "mod_a" in names
+    assert "mod_b" in names
+
+
+def test_two_modules_ordered_by_line():
+    mods = scan_file(FIXTURES / "two_modules.sv")
+    assert mods[0]["name"] == "mod_a"
+    assert mods[1]["name"] == "mod_b"
+    assert mods[0]["line"] < mods[1]["line"]
+
+
+def test_no_module_file_returns_empty():
+    mods = scan_file(FIXTURES / "no_module.sv")
+    assert mods == []
+
+
+def test_commented_module_ignored():
+    mods = scan_file(FIXTURES / "commented_module.sv")
+    names = [m["name"] for m in mods]
+    assert "real_mod" in names
+    assert "fake_mod" not in names
+
+
+def test_v_extension_scanned():
+    mods = scan_file(FIXTURES / "nested_dir" / "extra_v_mod.v")
+    assert len(mods) == 1
+    assert mods[0]["name"] == "extra_v_mod"
+
+
+# ── unit: directory scanning ──────────────────────────────────────────────────
+
+def test_scan_directory_finds_all_modules():
+    mods = scan_path(FIXTURES)
+    names = {m["name"] for m in mods}
+    assert "simple_mod" in names
+    assert "mod_a" in names
+    assert "mod_b" in names
+    assert "child_mod" in names
+    assert "real_mod" in names
+    assert "extra_v_mod" in names
+    assert "fake_mod" not in names
+
+
+def test_scan_directory_deterministic():
+    assert scan_path(FIXTURES) == scan_path(FIXTURES)
+
+
+def test_scan_directory_sorted():
+    mods = scan_path(FIXTURES)
+    keys = [(m["file"], m["line"], m["name"]) for m in mods]
+    assert keys == sorted(keys)
+
+
+# ── unit: build_index shape ───────────────────────────────────────────────────
+
+def test_build_index_shape():
+    mods = scan_file(FIXTURES / "simple_module.sv")
+    idx = build_index("fixtures/modules/simple_module.sv", mods)
+    assert idx["tool"] == "pccx-ide-scaffold"
+    assert idx["kind"] == "module-index"
+    assert idx["source"] == "fixtures/modules/simple_module.sv"
+    assert len(idx["modules"]) == 1
+
+
+def test_build_index_module_record_fields():
+    mods = scan_file(FIXTURES / "simple_module.sv")
+    assert all(
+        {"name", "file", "line", "column"} <= set(m.keys()) for m in mods
+    )
+
+
+# ── CLI helpers ───────────────────────────────────────────────────────────────
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "pccx_ide_cli", *args],
+        cwd=REPO_ROOT,
+        env={
+            "PYTHONPATH": str(SRC),
+            "PATH": os.environ.get("PATH", ""),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+# ── CLI: JSON output ──────────────────────────────────────────────────────────
+
+def test_cli_index_json_single_file():
+    result = _run_cli("index", str(FIXTURES / "simple_module.sv"))
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-index"
+    assert payload["tool"] == "pccx-ide-scaffold"
+    assert len(payload["modules"]) == 1
+    assert payload["modules"][0]["name"] == "simple_mod"
+
+
+def test_cli_index_json_no_module_exits_zero():
+    result = _run_cli("index", str(FIXTURES / "no_module.sv"))
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["modules"] == []
+
+
+def test_cli_index_json_directory():
+    result = _run_cli("index", str(FIXTURES))
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    names = {m["name"] for m in payload["modules"]}
+    assert "simple_mod" in names
+    assert "child_mod" in names
+    assert "extra_v_mod" in names
+    assert "fake_mod" not in names
+
+
+def test_cli_index_json_has_required_keys():
+    result = _run_cli("index", str(FIXTURES / "simple_module.sv"))
+    payload = json.loads(result.stdout)
+    assert {"kind", "tool", "source", "modules"} <= payload.keys()
+
+
+# ── CLI: text output ──────────────────────────────────────────────────────────
+
+def test_cli_index_text_single_file():
+    result = _run_cli("index", "--format", "text", str(FIXTURES / "simple_module.sv"))
+    assert result.returncode == 0, result.stderr
+    assert "source:" in result.stdout
+    assert "1 module" in result.stdout
+    assert "simple_mod" in result.stdout
+
+
+def test_cli_index_text_no_module():
+    result = _run_cli("index", "--format", "text", str(FIXTURES / "no_module.sv"))
+    assert result.returncode == 0
+    assert "0 modules" in result.stdout
+
+
+def test_cli_index_text_two_modules():
+    result = _run_cli("index", "--format", "text", str(FIXTURES / "two_modules.sv"))
+    assert result.returncode == 0
+    assert "2 modules" in result.stdout
+    assert "mod_a" in result.stdout
+    assert "mod_b" in result.stdout
+
+
+def test_cli_index_text_format_has_path_line_col():
+    result = _run_cli("index", "--format", "text", str(FIXTURES / "simple_module.sv"))
+    # Diagnostic lines have the form: path:line:col: module <name>
+    diag_lines = [ln for ln in result.stdout.splitlines() if "module simple_mod" in ln]
+    assert diag_lines, "expected a diagnostic line containing 'module simple_mod'"
+    # path:line:col: module name  →  at least 3 colons
+    assert diag_lines[0].count(":") >= 3
+
+
+# ── CLI: error cases ──────────────────────────────────────────────────────────
+
+def test_cli_index_missing_path_exits_nonzero():
+    result = _run_cli("index", str(FIXTURES / "does_not_exist.sv"))
+    assert result.returncode != 0
+    assert result.stderr.strip() != ""
+
+
+def test_cli_existing_check_still_works():
+    result = _run_cli("check", str(REPO_ROOT / "fixtures" / "ok_module.sv"))
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["envelope"] == "0"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Command added

```
python -m pccx_ide_cli index <path> [--format json|text]
```

- `<path>` may be a single `.sv`/`.v` file or a directory (scanned recursively).
- Directory scan skips `.git`, `__pycache__`, `build`, `dist`, `target`.
- `.v` and `.sv` files included.
- Output sorted by `(file, line, name)` for determinism.

## Output shape

JSON:
```json
{
  "kind": "module-index",
  "tool": "pccx-ide-scaffold",
  "source": "<path>",
  "modules": [
    {"name": "simple_mod", "file": "<abs-path>", "line": 1, "column": 1}
  ]
}
```

Text:
```
source: fixtures/modules/
6 modules
fixtures/modules/simple_module.sv:1:1: module simple_mod
...
```

## Parser limitations

- Single-line `//` comments are skipped.
- Block comments (`/* ... */`) are not parsed — `module` inside a block comment is a known false positive.
- `package`, `interface`, `class` not tracked in this batch.
- No semantic analysis; no stable ABI/API contract.

## Tests added

- 21 new tests in `tests/test_module_index.py`: unit (single file, two modules, commented, no-module, .v extension, directory recursive, determinism, sort) + CLI (JSON, text, missing path).
- 3 new CI smoke steps for `index` entry point.

## Validation commands run

```
python3 -m pytest -q                       # 57 passed
PYTHONPATH=src python3 -m pccx_ide_cli index fixtures/modules/simple_module.sv
PYTHONPATH=src python3 -m pccx_ide_cli index fixtures/modules/simple_module.sv --format text
PYTHONPATH=src python3 -m pccx_ide_cli index fixtures/modules --format json
PYTHONPATH=src python3 -m pccx_ide_cli check fixtures/ok_module.sv --format text
git diff --check  # clean
```

## No full parser/LSP/stable ABI claim

This is a scaffold-level module name finder. Not a full SystemVerilog parser. Not an LSP server. Not a stable ABI.

## FPGA repo untouched

`/home/hwkim/Desktop/github/pccxai/pccx-FPGA-NPU-LLM-kv260` — not accessed, not modified.