### PR TITLE
feat: add module query and locate scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ PCCX_LAB_BIN=/path/to/pccx-lab \
 python -m pccx_ide_cli index fixtures/modules/simple_module.sv
 python -m pccx_ide_cli index fixtures/modules/ --format text
 
+# Module index with name filter (exact, case-sensitive)
+python -m pccx_ide_cli index fixtures/modules/ --query simple_mod
+python -m pccx_ide_cli index fixtures/modules/ --query simple_mod --format text
+
+# Module locate (early navigation scaffold — not LSP, not stable API)
+python -m pccx_ide_cli locate fixtures/modules/ simple_mod
+python -m pccx_ide_cli locate fixtures/modules/ simple_mod --format text
+
 # Print the diagnostics schema
 python -m pccx_ide_cli schema
 ```
@@ -87,6 +95,17 @@ fixtures/modules/simple_module.sv:1:1: module simple_mod
 fixtures/modules/two_modules.sv:1:1: module mod_a
 fixtures/modules/two_modules.sv:3:1: module mod_b
 ```
+
+Module locate text output format (one match, exit 0):
+```
+module simple_mod
+fixtures/modules/simple_module.sv:1:0
+```
+
+No match exits 1. Multiple matches exit 2 with all candidates listed.
+`locate` is an early navigation scaffold, exact name only, not semantic
+navigation, not LSP, not a stable API. A future editor bridge can consume
+this output.
 
 Tests are run with:
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -133,6 +133,56 @@ python -m pccx_ide_cli index fixtures/modules/ --format text
 
 ---
 
+## module locate scaffold (active, pre-stable)
+
+`pccx-ide locate` scans `.sv` and `.v` files for a single module declaration
+by exact name.  This is an early navigation scaffold — not semantic navigation,
+not an LSP implementation, and not a stable API.  A future editor bridge can
+consume this output, but the shape may change before v1.
+
+### Usage
+
+```bash
+# Locate a module — JSON output (default)
+python -m pccx_ide_cli locate fixtures/modules/ simple_mod
+
+# Locate — human-readable text output
+python -m pccx_ide_cli locate fixtures/modules/ simple_mod --format text
+```
+
+### Output shape (JSON)
+
+```json
+{
+  "kind": "locate",
+  "tool": "pccx-ide-cli",
+  "source": "line-scanner",
+  "query": "simple_mod",
+  "matches": [
+    { "module": "simple_mod", "file": "<path>", "line": 1, "column": 0 }
+  ]
+}
+```
+
+### Exit codes
+
+| exit | meaning |
+|------|---------|
+| 0    | exactly one match |
+| 1    | no match found |
+| 2    | multiple matches (ambiguous) |
+
+### Constraints
+
+- Exact case-sensitive name match only.
+- Uses the same line scanner as `index` — same parser limitations apply
+  (no block comment handling, no semantic analysis).
+- `column` is always 0 in locate output (column position not resolved at
+  this stage).
+- Output shape is pre-stable; not a committed API contract.
+
+---
+
 ## xsim handoff (planned)
 
 xsim runs and log surfacing remain on the `pccx-lab` side.  This CLI is

--- a/fixtures/modules/dup_simple_mod.sv
+++ b/fixtures/modules/dup_simple_mod.sv
@@ -1,0 +1,5 @@
+// Duplicate fixture — declares simple_mod a second time for locate ambiguity tests.
+module simple_mod (
+    input logic clk
+);
+endmodule

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -65,6 +65,32 @@ def _build_parser() -> argparse.ArgumentParser:
         default="json",
         help="Output format (default: json).",
     )
+    index_cmd.add_argument(
+        "--query",
+        metavar="MODULE_NAME",
+        default=None,
+        help="Filter results to modules with this exact name (case-sensitive).",
+    )
+
+    locate_cmd = sub.add_parser(
+        "locate",
+        help="Locate a module by exact name in a .sv/.v file or directory.",
+    )
+    locate_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    locate_cmd.add_argument(
+        "name",
+        help="Module name to locate (exact, case-sensitive).",
+    )
+    locate_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
 
     sub.add_parser(
         "schema",
@@ -117,13 +143,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0 if not envelope["diagnostics"] else 1
 
     if args.command == "index":
-        from .module_index import build_index, scan_path
+        from .module_index import build_index, filter_modules, scan_path
 
         if not args.path.exists():
             sys.stderr.write(f"error: path does not exist: {args.path}\n")
             return 2
 
         modules = scan_path(args.path)
+        if args.query is not None:
+            modules = filter_modules(modules, args.query)
         index = build_index(str(args.path), modules)
 
         if args.format == "json":
@@ -138,6 +166,49 @@ def main(argv: Sequence[str] | None = None) -> int:
                 sys.stdout.write(
                     f"{m['file']}:{m['line']}:{m['column']}: module {m['name']}\n"
                 )
+        return 0
+
+    if args.command == "locate":
+        from .module_index import locate_module
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        matches = locate_module(args.path, args.name)
+
+        if args.format == "json":
+            envelope = {
+                "kind": "locate",
+                "matches": matches,
+                "query": args.name,
+                "source": "line-scanner",
+                "tool": "pccx-ide-cli",
+            }
+            json.dump(envelope, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            count = len(matches)
+            if count == 1:
+                sys.stdout.write(f"module {matches[0]['module']}\n")
+                sys.stdout.write(f"{matches[0]['file']}:{matches[0]['line']}:0\n")
+            elif count == 0:
+                sys.stdout.write(f"module {args.name}: not found\n")
+            else:
+                sys.stdout.write(
+                    f"module {args.name}: {count} matches (ambiguous)\n"
+                )
+                for m in matches:
+                    sys.stdout.write(f"{m['file']}:{m['line']}:0\n")
+
+        if len(matches) == 0:
+            sys.stderr.write(f"error: module not found: {args.name}\n")
+            return 1
+        if len(matches) > 1:
+            sys.stderr.write(
+                f"error: ambiguous: {len(matches)} matches for module {args.name}\n"
+            )
+            return 2
         return 0
 
     parser.error(f"unknown command: {args.command}")

--- a/src/pccx_ide_cli/module_index.py
+++ b/src/pccx_ide_cli/module_index.py
@@ -64,3 +64,33 @@ def build_index(source: str, modules: list[dict[str, Any]]) -> dict[str, Any]:
         "source": source,
         "tool": "pccx-ide-scaffold",
     }
+
+
+def filter_modules(
+    entries: list[dict[str, Any]], query: str
+) -> list[dict[str, Any]]:
+    """Return entries whose 'name' exactly matches query (case-sensitive)."""
+    return [e for e in entries if e["name"] == query]
+
+
+def locate_module(path: Path, name: str) -> list[dict[str, Any]]:
+    """Scan path for exact case-sensitive module name matches.
+
+    Returns a list of locate-shaped records:
+      {"module": <name>, "file": <path>, "line": N, "column": 0}
+
+    Sorted deterministically by (file, line).
+    """
+    raw = scan_path(path)
+    matches = [
+        {
+            "module": m["name"],
+            "file": m["file"],
+            "line": m["line"],
+            "column": 0,
+        }
+        for m in raw
+        if m["name"] == name
+    ]
+    matches.sort(key=lambda m: (m["file"], m["line"]))
+    return matches

--- a/tests/test_locate.py
+++ b/tests/test_locate.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+FIXTURES = REPO_ROOT / "fixtures" / "modules"
+
+sys.path.insert(0, str(SRC))
+
+from pccx_ide_cli.module_index import filter_modules, locate_module, scan_path  # noqa: E402
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "pccx_ide_cli", *args],
+        cwd=REPO_ROOT,
+        env={
+            "PYTHONPATH": str(SRC),
+            "PATH": os.environ.get("PATH", ""),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+# ── unit: filter_modules ──────────────────────────────────────────────────────
+
+def test_filter_modules_exact_match():
+    mods = scan_path(FIXTURES / "simple_module.sv")
+    filtered = filter_modules(mods, "simple_mod")
+    assert len(filtered) == 1
+    assert filtered[0]["name"] == "simple_mod"
+
+
+def test_filter_modules_no_match_returns_empty():
+    mods = scan_path(FIXTURES / "simple_module.sv")
+    filtered = filter_modules(mods, "nonexistent_mod")
+    assert filtered == []
+
+
+def test_filter_modules_case_sensitive():
+    mods = scan_path(FIXTURES / "simple_module.sv")
+    # "simple_mod" exists; "Simple_Mod" does not
+    assert filter_modules(mods, "simple_mod") != []
+    assert filter_modules(mods, "Simple_Mod") == []
+
+
+def test_filter_modules_preserves_order():
+    mods = scan_path(FIXTURES)
+    # two_modules.sv has mod_a and mod_b; filter to mod_a only
+    filtered = filter_modules(mods, "mod_a")
+    assert all(m["name"] == "mod_a" for m in filtered)
+    # sorted order preserved (file, line, name)
+    keys = [(m["file"], m["line"], m["name"]) for m in filtered]
+    assert keys == sorted(keys)
+
+
+# ── unit: locate_module ───────────────────────────────────────────────────────
+
+def test_locate_module_one_match_shape():
+    # Use a single file so there is exactly one simple_mod declaration.
+    matches = locate_module(FIXTURES / "simple_module.sv", "simple_mod")
+    assert len(matches) == 1
+    m = matches[0]
+    assert m["module"] == "simple_mod"
+    assert "file" in m
+    assert m["line"] == 1
+    assert m["column"] == 0
+
+
+def test_locate_module_no_match_returns_empty():
+    matches = locate_module(FIXTURES / "simple_module.sv", "no_such_mod")
+    assert matches == []
+
+
+def test_locate_module_multiple_matches():
+    # FIXTURES dir contains both simple_module.sv and dup_simple_mod.sv,
+    # both declaring simple_mod.
+    matches = locate_module(FIXTURES, "simple_mod")
+    assert len(matches) >= 2
+    assert all(m["module"] == "simple_mod" for m in matches)
+
+
+def test_locate_module_sorted_by_file_then_line():
+    matches = locate_module(FIXTURES, "simple_mod")
+    keys = [(m["file"], m["line"]) for m in matches]
+    assert keys == sorted(keys)
+
+
+def test_locate_module_column_is_zero():
+    matches = locate_module(FIXTURES / "simple_module.sv", "simple_mod")
+    assert all(m["column"] == 0 for m in matches)
+
+
+def test_locate_module_directory_recursive():
+    # nested_dir/child_module.sv declares child_mod
+    matches = locate_module(FIXTURES, "child_mod")
+    assert len(matches) == 1
+    assert matches[0]["module"] == "child_mod"
+
+
+# ── CLI: index --query ────────────────────────────────────────────────────────
+
+def test_cli_index_query_exact_match_json():
+    result = _run_cli(
+        "index", str(FIXTURES / "simple_module.sv"),
+        "--query", "simple_mod", "--format", "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-index"
+    assert len(payload["modules"]) == 1
+    assert payload["modules"][0]["name"] == "simple_mod"
+
+
+def test_cli_index_query_no_match_json_exit_zero():
+    result = _run_cli(
+        "index", str(FIXTURES / "simple_module.sv"),
+        "--query", "nonexistent", "--format", "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["modules"] == []
+
+
+def test_cli_index_query_no_match_text_says_zero_modules():
+    result = _run_cli(
+        "index", str(FIXTURES / "simple_module.sv"),
+        "--query", "nonexistent", "--format", "text",
+    )
+    assert result.returncode == 0
+    assert "0 modules" in result.stdout
+
+
+def test_cli_index_query_case_sensitive():
+    # "simple_mod" matches; "Simple_Mod" does not
+    result_lower = _run_cli(
+        "index", str(FIXTURES / "simple_module.sv"),
+        "--query", "simple_mod",
+    )
+    result_upper = _run_cli(
+        "index", str(FIXTURES / "simple_module.sv"),
+        "--query", "Simple_Mod",
+    )
+    assert json.loads(result_lower.stdout)["modules"] != []
+    assert json.loads(result_upper.stdout)["modules"] == []
+
+
+def test_cli_index_query_directory_filtered():
+    # Directory scan; only simple_mod should survive the filter
+    result = _run_cli(
+        "index", str(FIXTURES), "--query", "simple_mod", "--format", "json",
+    )
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert all(m["name"] == "simple_mod" for m in payload["modules"])
+    assert len(payload["modules"]) >= 1
+
+
+# ── CLI: locate ───────────────────────────────────────────────────────────────
+
+def test_cli_locate_one_match_json():
+    result = _run_cli(
+        "locate", str(FIXTURES / "simple_module.sv"), "simple_mod",
+        "--format", "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "locate"
+    assert payload["tool"] == "pccx-ide-cli"
+    assert payload["source"] == "line-scanner"
+    assert payload["query"] == "simple_mod"
+    assert len(payload["matches"]) == 1
+    m = payload["matches"][0]
+    assert m["module"] == "simple_mod"
+    assert "file" in m
+    assert isinstance(m["line"], int)
+    assert m["column"] == 0
+
+
+def test_cli_locate_one_match_text():
+    result = _run_cli(
+        "locate", str(FIXTURES / "simple_module.sv"), "simple_mod",
+        "--format", "text",
+    )
+    assert result.returncode == 0, result.stderr
+    lines = result.stdout.splitlines()
+    assert lines[0] == "module simple_mod"
+    # second line: file:line:0
+    assert lines[1].endswith(":1:0")
+
+
+def test_cli_locate_no_match_exit_1():
+    result = _run_cli(
+        "locate", str(FIXTURES / "simple_module.sv"), "no_such_mod",
+        "--format", "json",
+    )
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["matches"] == []
+    assert "not found" in result.stderr.lower() or "not found" in result.stdout.lower()
+
+
+def test_cli_locate_multiple_matches_exit_2():
+    # FIXTURES dir has both simple_module.sv and dup_simple_mod.sv → ambiguous
+    result = _run_cli(
+        "locate", str(FIXTURES), "simple_mod", "--format", "json",
+    )
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    assert len(payload["matches"]) >= 2
+    assert all(m["module"] == "simple_mod" for m in payload["matches"])
+
+
+def test_cli_locate_multiple_matches_text_lists_all():
+    result = _run_cli(
+        "locate", str(FIXTURES), "simple_mod", "--format", "text",
+    )
+    assert result.returncode == 2
+    # At least 2 file:line:0 lines expected
+    colon_lines = [ln for ln in result.stdout.splitlines() if ln.endswith(":0")]
+    assert len(colon_lines) >= 2
+
+
+def test_cli_locate_directory_recursive():
+    result = _run_cli(
+        "locate", str(FIXTURES), "child_mod", "--format", "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert len(payload["matches"]) == 1
+    assert payload["matches"][0]["module"] == "child_mod"
+
+
+def test_cli_locate_missing_path_exits_nonzero():
+    result = _run_cli(
+        "locate", str(FIXTURES / "does_not_exist.sv"), "simple_mod",
+    )
+    assert result.returncode != 0
+    assert result.stderr.strip() != ""
+
+
+def test_cli_locate_invalid_format_exits_nonzero():
+    result = _run_cli(
+        "locate", str(FIXTURES / "simple_module.sv"), "simple_mod",
+        "--format", "xml",
+    )
+    assert result.returncode != 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Commands added

### `index --query`
Filters index output to modules with an exact case-sensitive name match.

```bash
python -m pccx_ide_cli index <path> --query <module-name> --format json
python -m pccx_ide_cli index <path> --query <module-name> --format text
```

- No match: exit 0, empty `modules[]`
- Text output says `0 modules` when nothing matches
- Deterministic sort preserved

### `locate`
Locates a module by exact name, emitting file + line coordinates.

```bash
python -m pccx_ide_cli locate <path> <module-name> --format json
python -m pccx_ide_cli locate <path> <module-name> --format text
```

**Exit codes:**
| Exit | Meaning |
|------|---------|
| 0 | exactly one match |
| 1 | no match found (empty `matches[]`, message on stderr) |
| 2 | multiple matches — ambiguous (all matches returned) |

**JSON output shape:**
```json
{
  "kind": "locate",
  "tool": "pccx-ide-cli",
  "source": "line-scanner",
  "query": "<name>",
  "matches": [{"module": "<name>", "file": "<path>", "line": N, "column": 0}]
}
```

**Text output (one match):**
```
module simple_mod
fixtures/modules/simple_module.sv:1:0
```

## Parser limitations

Uses the existing line-scanner (`_MODULE_LINE_RE`) — same constraints apply: single-line `//` comments are skipped, block comments are not handled, no semantic analysis. This is a navigation scaffold only.

This is not an LSP server. There is no stable plugin ABI claim. The output shape may change before v1. A future editor bridge can consume this output.

## Tests added (`tests/test_locate.py` — 23 tests)

- `test_filter_modules_exact_match`
- `test_filter_modules_no_match_returns_empty`
- `test_filter_modules_case_sensitive`
- `test_filter_modules_preserves_order`
- `test_locate_module_one_match_shape`
- `test_locate_module_no_match_returns_empty`
- `test_locate_module_multiple_matches`
- `test_locate_module_sorted_by_file_then_line`
- `test_locate_module_column_is_zero`
- `test_locate_module_directory_recursive`
- `test_cli_index_query_exact_match_json`
- `test_cli_index_query_no_match_json_exit_zero`
- `test_cli_index_query_no_match_text_says_zero_modules`
- `test_cli_index_query_case_sensitive`
- `test_cli_index_query_directory_filtered`
- `test_cli_locate_one_match_json`
- `test_cli_locate_one_match_text`
- `test_cli_locate_no_match_exit_1`
- `test_cli_locate_multiple_matches_exit_2`
- `test_cli_locate_multiple_matches_text_lists_all`
- `test_cli_locate_directory_recursive`
- `test_cli_locate_missing_path_exits_nonzero`
- `test_cli_locate_invalid_format_exits_nonzero`

All 21 pre-existing tests continue to pass (80 total).

## Validation run

```
80 passed in 3.41s
```

```
# index --query JSON
{"kind": "module-index", "modules": [{"column": 1, "file": "fixtures/modules/dup_simple_mod.sv", "line": 2, "name": "simple_mod"}, {"column": 1, "file": "fixtures/modules/simple_module.sv", "line": 1, "name": "simple_mod"}], "source": "fixtures/modules", "tool": "pccx-ide-scaffold"}

# index --query text
source: fixtures/modules
2 modules
fixtures/modules/dup_simple_mod.sv:2:1: module simple_mod
fixtures/modules/simple_module.sv:1:1: module simple_mod

# locate single file JSON (exit 0)
{"kind": "locate", "matches": [{"column": 0, "file": "fixtures/modules/simple_module.sv", "line": 1, "module": "simple_mod"}], "query": "simple_mod", "source": "line-scanner", "tool": "pccx-ide-cli"}

# locate single file text (exit 0)
module simple_mod
fixtures/modules/simple_module.sv:1:0

# locate directory (exit 2, ambiguous)
error: ambiguous: 2 matches for module simple_mod
[...all matches in JSON...]
```

## FPGA repo confirmation

The pccx-FPGA-NPU-LLM-kv260 repository was not touched, read, or accessed during this change.