### PR TITLE
fix: use real module columns and skip block comment declarations

### DIFF
--- a/fixtures/modules/block_comment_module.sv
+++ b/fixtures/modules/block_comment_module.sv
@@ -1,0 +1,3 @@
+/* module block_fake_mod; */
+module block_real_mod;
+endmodule

--- a/fixtures/modules/indented_module.sv
+++ b/fixtures/modules/indented_module.sv
@@ -1,0 +1,2 @@
+    module indented_mod;
+endmodule

--- a/fixtures/modules/multiline_block_comment.sv
+++ b/fixtures/modules/multiline_block_comment.sv
@@ -1,0 +1,5 @@
+/*
+ * module multi_fake_mod;
+ */
+module after_block_mod;
+endmodule

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -191,7 +191,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             count = len(matches)
             if count == 1:
                 sys.stdout.write(f"module {matches[0]['module']}\n")
-                sys.stdout.write(f"{matches[0]['file']}:{matches[0]['line']}:0\n")
+                sys.stdout.write(
+                    f"{matches[0]['file']}:{matches[0]['line']}:{matches[0]['column']}\n"
+                )
             elif count == 0:
                 sys.stdout.write(f"module {args.name}: not found\n")
             else:
@@ -199,7 +201,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     f"module {args.name}: {count} matches (ambiguous)\n"
                 )
                 for m in matches:
-                    sys.stdout.write(f"{m['file']}:{m['line']}:0\n")
+                    sys.stdout.write(f"{m['file']}:{m['line']}:{m['column']}\n")
 
         if len(matches) == 0:
             sys.stderr.write(f"error: module not found: {args.name}\n")

--- a/src/pccx_ide_cli/module_index.py
+++ b/src/pccx_ide_cli/module_index.py
@@ -6,19 +6,51 @@ from typing import Any
 
 # Matches `module <name>` at the start of a line (optional leading whitespace).
 # Conservative: handles  module foo;  /  module foo #(  /  module foo (
-# Does NOT parse block comments — see HANDOFF.md.
+# Column convention: 1-based character offset of the `module` keyword.
+# Limitation: column reflects the visible text after block-comment removal;
+# if /* */ spans precede `module` on the same line the column is scanner-based,
+# not byte-offset in the original source.
 _MODULE_LINE_RE = re.compile(r"^(\s*)module\s+(\w+)")
 
 _IGNORE_DIRS: frozenset[str] = frozenset({".git", "__pycache__", "build", "dist", "target"})
 _SV_SUFFIXES: frozenset[str] = frozenset({".sv", ".v"})
 
 
+def _strip_block_comments(line: str, in_comment: bool) -> tuple[str, bool]:
+    """Remove /* ... */ spans from one line, tracking multi-line comment state.
+
+    Returns (visible_text, new_in_comment).  Non-nested only; nested /* are
+    treated as the same comment level (documented limitation).
+    """
+    out: list[str] = []
+    i = 0
+    n = len(line)
+    while i < n:
+        if in_comment:
+            end = line.find("*/", i)
+            if end == -1:
+                return "".join(out), True
+            i = end + 2
+            in_comment = False
+        else:
+            start = line.find("/*", i)
+            if start == -1:
+                out.append(line[i:])
+                break
+            out.append(line[i:start])
+            in_comment = True
+            i = start + 2
+    return "".join(out), in_comment
+
+
 def _scan_text(text: str, source: str) -> list[dict[str, Any]]:
     results: list[dict[str, Any]] = []
+    in_block_comment = False
     for line_num, line in enumerate(text.splitlines(), 1):
-        if line.lstrip().startswith("//"):
+        visible, in_block_comment = _strip_block_comments(line, in_block_comment)
+        if visible.lstrip().startswith("//"):
             continue
-        m = _MODULE_LINE_RE.match(line)
+        m = _MODULE_LINE_RE.match(visible)
         if m:
             results.append({
                 "name": m.group(2),
@@ -77,8 +109,9 @@ def locate_module(path: Path, name: str) -> list[dict[str, Any]]:
     """Scan path for exact case-sensitive module name matches.
 
     Returns a list of locate-shaped records:
-      {"module": <name>, "file": <path>, "line": N, "column": 0}
+      {"module": <name>, "file": <path>, "line": N, "column": C}
 
+    Column is the same 1-based character offset as the index command.
     Sorted deterministically by (file, line).
     """
     raw = scan_path(path)
@@ -87,7 +120,7 @@ def locate_module(path: Path, name: str) -> list[dict[str, Any]]:
             "module": m["name"],
             "file": m["file"],
             "line": m["line"],
-            "column": 0,
+            "column": m["column"],
         }
         for m in raw
         if m["name"] == name

--- a/tests/test_locate.py
+++ b/tests/test_locate.py
@@ -75,7 +75,7 @@ def test_locate_module_one_match_shape():
     assert m["module"] == "simple_mod"
     assert "file" in m
     assert m["line"] == 1
-    assert m["column"] == 0
+    assert m["column"] == 1  # `module` starts at column 1 (no leading whitespace)
 
 
 def test_locate_module_no_match_returns_empty():
@@ -97,9 +97,12 @@ def test_locate_module_sorted_by_file_then_line():
     assert keys == sorted(keys)
 
 
-def test_locate_module_column_is_zero():
-    matches = locate_module(FIXTURES / "simple_module.sv", "simple_mod")
-    assert all(m["column"] == 0 for m in matches)
+def test_locate_module_column_matches_index():
+    """locate column must match the index column for the same declaration."""
+    from pccx_ide_cli.module_index import scan_path
+    index_mods = scan_path(FIXTURES / "simple_module.sv")
+    locate_matches = locate_module(FIXTURES / "simple_module.sv", "simple_mod")
+    assert locate_matches[0]["column"] == index_mods[0]["column"]
 
 
 def test_locate_module_directory_recursive():
@@ -185,7 +188,7 @@ def test_cli_locate_one_match_json():
     assert m["module"] == "simple_mod"
     assert "file" in m
     assert isinstance(m["line"], int)
-    assert m["column"] == 0
+    assert m["column"] == 1  # `module` at column 1 (no leading whitespace in simple_module.sv)
 
 
 def test_cli_locate_one_match_text():
@@ -196,8 +199,8 @@ def test_cli_locate_one_match_text():
     assert result.returncode == 0, result.stderr
     lines = result.stdout.splitlines()
     assert lines[0] == "module simple_mod"
-    # second line: file:line:0
-    assert lines[1].endswith(":1:0")
+    # second line: file:line:col  (col=1 for simple_module.sv which has no leading whitespace)
+    assert lines[1].endswith(":1:1")
 
 
 def test_cli_locate_no_match_exit_1():
@@ -227,8 +230,11 @@ def test_cli_locate_multiple_matches_text_lists_all():
         "locate", str(FIXTURES), "simple_mod", "--format", "text",
     )
     assert result.returncode == 2
-    # At least 2 file:line:0 lines expected
-    colon_lines = [ln for ln in result.stdout.splitlines() if ln.endswith(":0")]
+    # At least 2 file:line:col lines; col is a real 1-based integer, not a placeholder
+    colon_lines = [
+        ln for ln in result.stdout.splitlines()
+        if ":" in ln and ln.split(":")[-1].isdigit()
+    ]
     assert len(colon_lines) >= 2
 
 

--- a/tests/test_module_index.py
+++ b/tests/test_module_index.py
@@ -15,6 +15,41 @@ FIXTURES = REPO_ROOT / "fixtures" / "modules"
 sys.path.insert(0, str(SRC))
 
 from pccx_ide_cli.module_index import build_index, scan_file, scan_path  # noqa: E402
+from pccx_ide_cli.module_index import _strip_block_comments  # noqa: E402
+
+
+# ── unit: _strip_block_comments helper ───────────────────────────────────────
+
+def test_strip_single_line_block_comment():
+    visible, in_cmt = _strip_block_comments("/* module fake; */", False)
+    assert "module" not in visible
+    assert in_cmt is False
+
+
+def test_strip_block_comment_opens_does_not_close():
+    visible, in_cmt = _strip_block_comments("/* module fake;", False)
+    assert "module" not in visible
+    assert in_cmt is True
+
+
+def test_strip_block_comment_closes():
+    visible, in_cmt = _strip_block_comments(" * module fake; */", True)
+    assert "module" not in visible
+    assert in_cmt is False
+
+
+def test_strip_no_comment_passthrough():
+    line = "module real_mod;"
+    visible, in_cmt = _strip_block_comments(line, False)
+    assert visible == line
+    assert in_cmt is False
+
+
+def test_strip_inline_comment_then_module():
+    # Block comment before module on same line — visible retains rest of line
+    visible, in_cmt = _strip_block_comments("/* hdr */ module real_mod;", False)
+    assert "real_mod" in visible
+    assert in_cmt is False
 
 
 # ── unit: single-file scanning ────────────────────────────────────────────────
@@ -53,6 +88,32 @@ def test_commented_module_ignored():
     assert "fake_mod" not in names
 
 
+def test_indented_module_real_column():
+    mods = scan_file(FIXTURES / "indented_module.sv")
+    assert len(mods) == 1
+    assert mods[0]["name"] == "indented_mod"
+    assert mods[0]["column"] == 5  # 4 leading spaces → `module` at col 5
+
+
+def test_single_line_block_comment_fake_ignored():
+    mods = scan_file(FIXTURES / "block_comment_module.sv")
+    names = [m["name"] for m in mods]
+    assert "block_fake_mod" not in names
+    assert "block_real_mod" in names
+
+
+def test_multiline_block_comment_fake_ignored():
+    mods = scan_file(FIXTURES / "multiline_block_comment.sv")
+    names = [m["name"] for m in mods]
+    assert "multi_fake_mod" not in names
+    assert "after_block_mod" in names
+
+
+def test_real_module_after_block_comment_found():
+    mods = scan_file(FIXTURES / "multiline_block_comment.sv")
+    assert any(m["name"] == "after_block_mod" for m in mods)
+
+
 def test_v_extension_scanned():
     mods = scan_file(FIXTURES / "nested_dir" / "extra_v_mod.v")
     assert len(mods) == 1
@@ -70,7 +131,13 @@ def test_scan_directory_finds_all_modules():
     assert "child_mod" in names
     assert "real_mod" in names
     assert "extra_v_mod" in names
+    assert "indented_mod" in names
+    assert "block_real_mod" in names
+    assert "after_block_mod" in names
+    # block-commented fakes must not appear
     assert "fake_mod" not in names
+    assert "block_fake_mod" not in names
+    assert "multi_fake_mod" not in names
 
 
 def test_scan_directory_deterministic():


### PR DESCRIPTION
## Summary

- `locate` no longer emits column `0`; returns the same 1-based column as `index`
- Block comment guard: `/* ... */` spans stripped before scanning, suppressing false positives
- CLI `locate` text output uses `file:line:col` with real column

## Column convention

- **1-based character offset** of the `module` keyword in post-block-comment-removal text
- Raw character count (no tab-width expansion)
- Scanner-based, not semantic-parser based

## Block comment guard scope

- Single-line: `/* module fake; */` ignored
- Multi-line: `/*\n module fake;\n */` ignored
- State persists across lines via `_strip_block_comments` returning `in_block_comment`
- Limitation: nested `/*` treated as same level (documented in `_strip_block_comments` docstring)

## Parser limitations (unchanged)

- No full SystemVerilog parser, preprocessor, or macro expansion
- No package/interface/class indexing; no semantic cross-file resolution
- No LSP server; no stable ABI/API

## Tests added / updated

- `_strip_block_comments` unit tests (5 cases)
- `test_indented_module_real_column` — col 5 for 4-space indent
- `test_single_line_block_comment_fake_ignored`
- `test_multiline_block_comment_fake_ignored`
- `test_real_module_after_block_comment_found`
- Updated `test_scan_directory_finds_all_modules`: new real modules asserted, fake names absent
- `test_locate_module_column_matches_index` replaces `test_locate_module_column_is_zero`
- Locate column and text-output assertions updated to real column values

**89 tests pass (was 80)**

## Validation run

```
python3 -m pytest -q                          → 89 passed
index --query simple_mod --format json        → column: 1
locate simple_mod --format json               → column: 1
locate simple_mod --format text               → "…:1:1"
index fixtures/modules --format text          → indented_module.sv:1:5 ✓
check ok_module.sv --format text              → 0 diagnostics ✓
git diff --check                              → clean
```

## Scope confirmation

- No full parser / LSP / stable ABI claim
- No release / tag created
- FPGA repo (`pccx-FPGA-NPU-LLM-kv260`) untouched