### PR TITLE
feat: add xsim log handoff scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,3 +154,17 @@ jobs:
             exit 1
           fi
           echo "index missing path correctly fails"
+      - name: cli smoke (xsim-log clean JSON)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli xsim-log \
+              fixtures/xsim/clean.log --format json \
+              | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='xsim-log'; assert d['diagnostics']==[]"
+          echo "xsim-log clean JSON smoke ok"
+      - name: cli smoke (xsim-log mixed text)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli xsim-log \
+              fixtures/xsim/mixed.log --format text \
+              | grep -q "5 diagnostics"
+          echo "xsim-log mixed text smoke ok"

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ python -m pccx_ide_cli index fixtures/modules/ --query simple_mod --format text
 python -m pccx_ide_cli locate fixtures/modules/ simple_mod
 python -m pccx_ide_cli locate fixtures/modules/ simple_mod --format text
 
+# xsim log handoff scaffold (parses existing log files only)
+python -m pccx_ide_cli xsim-log fixtures/xsim/mixed.log --format json
+python -m pccx_ide_cli xsim-log fixtures/xsim/mixed.log --format text
+
 # Print the diagnostics schema
 python -m pccx_ide_cli schema
 ```
@@ -106,6 +110,12 @@ No match exits 1. Multiple matches exit 2 with all candidates listed.
 `locate` is an early navigation scaffold, exact name only, not semantic
 navigation, not LSP, not a stable API. A future editor bridge can consume
 this output.
+
+`xsim-log` is an early handoff scaffold. It parses existing synthetic
+xsim-style log files into diagnostics-like JSON or text output. It does
+not run xsim or Vivado, does not prove hardware correctness, and does
+not claim full Vivado/xsim coverage. The output shape is pre-stable; a
+future `pccx-lab` integration may provide richer log and report handoff.
 
 Tests are run with:
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -183,15 +183,48 @@ python -m pccx_ide_cli locate fixtures/modules/ simple_mod --format text
 
 ---
 
-## xsim handoff (planned)
+## xsim log handoff scaffold (active, pre-stable)
 
-xsim runs and log surfacing remain on the `pccx-lab` side.  This CLI is
-expected to:
+`pccx-ide xsim-log` parses an existing xsim-style log file and emits a
+small diagnostics-like document for future editor integration.
 
-1. Pass through a `run` request to `pccx-lab`.
-2. Translate the resulting log / report into the same diagnostics
-   envelope where it makes sense, or surface a structured run-summary
-   document (envelope version to be defined alongside the lab CLI).
+### Usage
+
+```bash
+python -m pccx_ide_cli xsim-log fixtures/xsim/mixed.log --format json
+python -m pccx_ide_cli xsim-log fixtures/xsim/mixed.log --format text
+```
+
+### Output shape (JSON)
+
+```json
+{
+  "tool": "pccx-ide-cli",
+  "kind": "xsim-log",
+  "source": "<path passed on CLI>",
+  "diagnostics": [
+    {
+      "severity": "error",
+      "code": "VRFC 10-1234",
+      "message": "syntax error near token ';'",
+      "raw_line": "ERROR: [VRFC 10-1234] syntax error near token ';'"
+    }
+  ]
+}
+```
+
+### Scope
+
+- Parses existing log files only; it does not run xsim or Vivado.
+- Uses synthetic fixtures in this repository; no hardware logs are
+  required.
+- Supports only simple severity-prefixed lines, file:line diagnostics,
+  file:line:column diagnostics, and simple bracket codes.
+- Unknown lines are ignored.
+- This does not prove hardware correctness and is not a full
+  Vivado/xsim parser.
+- Output is pre-stable.  Future `pccx-lab` integration may provide
+  richer log and report handoff.
 
 ---
 

--- a/fixtures/xsim/clean.log
+++ b/fixtures/xsim/clean.log
@@ -1,0 +1,3 @@
+xsim: simulation started
+run all
+Simulation completed successfully

--- a/fixtures/xsim/errors.log
+++ b/fixtures/xsim/errors.log
@@ -1,0 +1,2 @@
+ERROR: [VRFC 10-1234] syntax error near token ';'
+src/top.sv:12: error: module declaration failed

--- a/fixtures/xsim/mixed.log
+++ b/fixtures/xsim/mixed.log
@@ -1,0 +1,5 @@
+INFO: elaboration started
+WARNING: [XSIM 43-9999] signal has no driver
+src/top.sv:12: error: module declaration failed
+src/warn.sv:7:5: warning: implicit net created
+ERROR: [VRFC 10-1234] syntax error near token ';'

--- a/fixtures/xsim/unknown_lines.log
+++ b/fixtures/xsim/unknown_lines.log
@@ -1,0 +1,4 @@
+Vivado Simulator v2024.x synthetic fixture
+random progress line without a recognized prefix
+src/top.sv line 12 maybe has text, but not a supported pattern
+INFO: parseable informational line

--- a/fixtures/xsim/warnings.log
+++ b/fixtures/xsim/warnings.log
@@ -1,0 +1,2 @@
+WARNING: [XSIM 43-9999] signal has no driver
+src/warn.sv:7:5: warning: implicit net created

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -92,6 +92,22 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    xsim_log = sub.add_parser(
+        "xsim-log",
+        help="Parse an existing xsim-style log file into diagnostics-like output.",
+    )
+    xsim_log.add_argument(
+        "log_file",
+        type=Path,
+        help="Path to an existing xsim-style log file.",
+    )
+    xsim_log.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     sub.add_parser(
         "schema",
         help="Print the diagnostics envelope JSON schema.",
@@ -211,6 +227,24 @@ def main(argv: Sequence[str] | None = None) -> int:
                 f"error: ambiguous: {len(matches)} matches for module {args.name}\n"
             )
             return 2
+        return 0
+
+    if args.command == "xsim-log":
+        from .xsim_log import format_text, parse_log_file
+
+        if not args.log_file.exists():
+            sys.stderr.write(f"error: log file does not exist: {args.log_file}\n")
+            return 2
+        if not args.log_file.is_file():
+            sys.stderr.write(f"error: log path is not a file: {args.log_file}\n")
+            return 2
+
+        envelope = parse_log_file(args.log_file)
+        if args.format == "json":
+            json.dump(envelope, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_text(envelope))
         return 0
 
     parser.error(f"unknown command: {args.command}")

--- a/src/pccx_ide_cli/xsim_log.py
+++ b/src/pccx_ide_cli/xsim_log.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+_COMPILE_STYLE_RE = re.compile(
+    r"^(?P<file>.+?):(?P<line>\d+)(?::(?P<column>\d+))?:\s*"
+    r"(?P<severity>error|warning|info):\s*(?P<message>.*)$",
+    re.IGNORECASE,
+)
+_SIMPLE_SEVERITY_RE = re.compile(
+    r"^(?P<severity>ERROR|WARNING|INFO):\s*(?P<message>.*)$",
+    re.IGNORECASE,
+)
+_BRACKET_CODE_RE = re.compile(
+    r"^\[(?P<code>[^\]]*\d+-\d+[^\]]*)\]\s*(?P<message>.*)$"
+)
+
+
+def _split_code(message: str) -> tuple[str | None, str]:
+    match = _BRACKET_CODE_RE.match(message)
+    if not match:
+        return None, message
+    return match.group("code").strip(), match.group("message")
+
+
+def _record(
+    *,
+    severity: str,
+    message: str,
+    raw_line: str,
+    code: str | None = None,
+    file: str | None = None,
+    line: int | None = None,
+    column: int | None = None,
+) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "severity": severity.lower(),
+        "message": message,
+        "raw_line": raw_line,
+    }
+    if code:
+        record["code"] = code
+    if file:
+        record["file"] = file
+    if line is not None:
+        record["line"] = line
+    if column is not None:
+        record["column"] = column
+    return record
+
+
+def parse_line(line: str) -> dict[str, Any] | None:
+    """Parse one conservative xsim/compile-style log line.
+
+    Unknown lines return None. This is intentionally a small handoff scaffold,
+    not a full Vivado/xsim parser.
+    """
+    raw_line = line.rstrip("\n")
+
+    match = _COMPILE_STYLE_RE.match(raw_line)
+    if match:
+        code, message = _split_code(match.group("message"))
+        column = match.group("column")
+        return _record(
+            severity=match.group("severity"),
+            code=code,
+            message=message,
+            file=match.group("file"),
+            line=int(match.group("line")),
+            column=int(column) if column is not None else None,
+            raw_line=raw_line,
+        )
+
+    match = _SIMPLE_SEVERITY_RE.match(raw_line)
+    if match:
+        code, message = _split_code(match.group("message"))
+        return _record(
+            severity=match.group("severity"),
+            code=code,
+            message=message,
+            raw_line=raw_line,
+        )
+
+    return None
+
+
+def parse_text(text: str) -> list[dict[str, Any]]:
+    diagnostics: list[dict[str, Any]] = []
+    for line in text.splitlines():
+        record = parse_line(line)
+        if record is not None:
+            diagnostics.append(record)
+    return diagnostics
+
+
+def parse_file(path: Path) -> list[dict[str, Any]]:
+    return parse_text(path.read_text(encoding="utf-8", errors="replace"))
+
+
+def build_envelope(source: str, diagnostics: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "diagnostics": diagnostics,
+        "kind": "xsim-log",
+        "source": source,
+        "tool": "pccx-ide-cli",
+    }
+
+
+def parse_log_file(path: Path) -> dict[str, Any]:
+    return build_envelope(str(path), parse_file(path))
+
+
+def format_text(envelope: dict[str, Any]) -> str:
+    diagnostics = envelope["diagnostics"]
+    count = len(diagnostics)
+    plural = "s" if count != 1 else ""
+    lines = [
+        f"source: {envelope['source']}",
+        f"{count} diagnostic{plural}",
+    ]
+
+    for diagnostic in diagnostics:
+        severity = diagnostic["severity"]
+        message = diagnostic["message"]
+        code = diagnostic.get("code")
+        message_part = f"{code}: {message}" if code else message
+
+        file = diagnostic.get("file")
+        line = diagnostic.get("line")
+        column = diagnostic.get("column")
+        if file is not None and line is not None:
+            location = f"{file}:{line}"
+            if column is not None:
+                location = f"{location}:{column}"
+            lines.append(f"{location}: {severity}: {message_part}")
+        else:
+            lines.append(f"{severity}: {message_part}")
+
+    return "\n".join(lines) + "\n"

--- a/tests/test_xsim_log.py
+++ b/tests/test_xsim_log.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+FIXTURES = REPO_ROOT / "fixtures" / "xsim"
+
+sys.path.insert(0, str(SRC))
+
+from pccx_ide_cli.xsim_log import build_envelope, parse_line, parse_text  # noqa: E402
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "pccx_ide_cli", *args],
+        cwd=REPO_ROOT,
+        env={
+            "PYTHONPATH": str(SRC),
+            "PATH": os.environ.get("PATH", ""),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_empty_log_exits_zero_with_zero_diagnostics():
+    result = _run_cli("xsim-log", str(FIXTURES / "empty.log"), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["diagnostics"] == []
+
+
+def test_clean_log_exits_zero_with_zero_diagnostics():
+    result = _run_cli("xsim-log", str(FIXTURES / "clean.log"), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "xsim-log"
+    assert payload["diagnostics"] == []
+
+
+def test_one_error_line():
+    record = parse_line("ERROR: syntax error")
+    assert record is not None
+    assert record["severity"] == "error"
+    assert record["message"] == "syntax error"
+    assert record["raw_line"] == "ERROR: syntax error"
+
+
+def test_one_warning_line():
+    record = parse_line("WARNING: signal has no driver")
+    assert record is not None
+    assert record["severity"] == "warning"
+    assert record["message"] == "signal has no driver"
+
+
+def test_one_info_line():
+    record = parse_line("INFO: elaboration started")
+    assert record is not None
+    assert record["severity"] == "info"
+    assert record["message"] == "elaboration started"
+
+
+def test_mixed_error_warning_info():
+    records = parse_text((FIXTURES / "mixed.log").read_text(encoding="utf-8"))
+    assert [r["severity"] for r in records] == [
+        "info",
+        "warning",
+        "error",
+        "warning",
+        "error",
+    ]
+
+
+def test_file_line_parsing():
+    record = parse_line("src/top.sv:12: error: module declaration failed")
+    assert record is not None
+    assert record["file"] == "src/top.sv"
+    assert record["line"] == 12
+    assert "column" not in record
+    assert record["severity"] == "error"
+
+
+def test_file_line_column_parsing():
+    record = parse_line("src/warn.sv:7:5: warning: implicit net created")
+    assert record is not None
+    assert record["file"] == "src/warn.sv"
+    assert record["line"] == 7
+    assert record["column"] == 5
+    assert record["severity"] == "warning"
+
+
+def test_bracket_code_parsing():
+    record = parse_line("ERROR: [VRFC 10-1234] syntax error near token ';'")
+    assert record is not None
+    assert record["severity"] == "error"
+    assert record["code"] == "VRFC 10-1234"
+    assert record["message"] == "syntax error near token ';'"
+
+
+def test_bracket_code_parsing_after_file_location():
+    record = parse_line("src/top.sv:12: error: [VRFC 10-1234] failed")
+    assert record is not None
+    assert record["code"] == "VRFC 10-1234"
+    assert record["message"] == "failed"
+
+
+def test_unknown_lines_do_not_crash():
+    records = parse_text((FIXTURES / "unknown_lines.log").read_text(encoding="utf-8"))
+    assert len(records) == 1
+    assert records[0]["severity"] == "info"
+
+
+def test_missing_log_path_exits_nonzero():
+    result = _run_cli("xsim-log", str(FIXTURES / "missing.log"), "--format", "json")
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
+def test_invalid_format_exits_nonzero():
+    result = _run_cli("xsim-log", str(FIXTURES / "clean.log"), "--format", "xml")
+    assert result.returncode != 0
+    assert "invalid choice" in result.stderr
+
+
+def test_text_output_includes_source_count_message():
+    result = _run_cli("xsim-log", str(FIXTURES / "mixed.log"), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert f"source: {FIXTURES / 'mixed.log'}" in result.stdout
+    assert "5 diagnostics" in result.stdout
+    assert "elaboration started" in result.stdout
+    assert "src/top.sv:12: error: module declaration failed" in result.stdout
+
+
+def test_json_output_shape_is_stable():
+    result = _run_cli("xsim-log", str(FIXTURES / "errors.log"), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert sorted(payload.keys()) == ["diagnostics", "kind", "source", "tool"]
+    assert payload["tool"] == "pccx-ide-cli"
+    assert payload["kind"] == "xsim-log"
+    assert payload["source"] == str(FIXTURES / "errors.log")
+    assert len(payload["diagnostics"]) == 2
+    assert sorted(payload["diagnostics"][0].keys()) == [
+        "code",
+        "message",
+        "raw_line",
+        "severity",
+    ]
+    assert sorted(payload["diagnostics"][1].keys()) == [
+        "file",
+        "line",
+        "message",
+        "raw_line",
+        "severity",
+    ]
+
+
+def test_build_envelope_shape():
+    envelope = build_envelope("synthetic.log", [])
+    assert envelope == {
+        "diagnostics": [],
+        "kind": "xsim-log",
+        "source": "synthetic.log",
+        "tool": "pccx-ide-cli",
+    }
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Add an early `xsim-log` handoff scaffold to parse existing xsim-style log files into deterministic diagnostics-like JSON/text output.

## Model

Main Codex session under the requested high-reasoning routing for a new CLI surface and output contract. No Spark/subagents used.

## Command Added

```bash
python -m pccx_ide_cli xsim-log <log-file> --format json
python -m pccx_ide_cli xsim-log <log-file> --format text
```

## Output Shape

JSON output is pre-stable and includes:

```json
{
  "tool": "pccx-ide-cli",
  "kind": "xsim-log",
  "source": "<path passed on CLI>",
  "diagnostics": []
}
```

Diagnostic records include `severity`, `message`, and `raw_line`, plus optional `code`, `file`, `line`, and `column` when parsed.

Text output includes `source:`, diagnostic count, and one human-readable line per diagnostic.

## Parser Limitations

- Parses existing log files only.
- Does not run xsim or Vivado.
- Supports only simple `ERROR:`, `WARNING:`, `INFO:` lines, `file:line` / `file:line:column` compile-style lines, and simple bracket codes like `[VRFC 10-1234]`.
- Unknown lines are ignored.
- This is not a full Vivado/xsim parser and not a stable ABI/API.

## Synthetic Fixtures

Added synthetic fixtures under `fixtures/xsim/`:

- `clean.log`
- `errors.log`
- `warnings.log`
- `mixed.log`
- `unknown_lines.log`
- `empty.log`

## Tests Added

Added focused parser/CLI tests for empty and clean logs, severity parsing, mixed logs, file/line/column parsing, bracket codes, unknown lines, missing path, invalid format, text output, and stable JSON shape. Existing diagnostics, index/query/locate, and pccx-lab backend tests still run in the full suite.

## Validation

Local shell has `python3` but no `python` executable, so source-tree validation used `PYTHONPATH=src python3 -m ...` matching the existing CI style.

```bash
python3 -m pytest -q
PYTHONPATH=src python3 -m pccx_ide_cli xsim-log fixtures/xsim/clean.log --format json
PYTHONPATH=src python3 -m pccx_ide_cli xsim-log fixtures/xsim/errors.log --format json
PYTHONPATH=src python3 -m pccx_ide_cli xsim-log fixtures/xsim/mixed.log --format text
PYTHONPATH=src python3 -m pccx_ide_cli index fixtures/modules --format text
PYTHONPATH=src python3 -m pccx_ide_cli locate fixtures/modules/simple_module.sv simple_mod --format text
PYTHONPATH=src python3 -m pccx_ide_cli check fixtures/ok_module.sv --format text
git diff --check
```

Result: `105 passed`; smoke commands and `git diff --check` passed.

## Claims / Boundaries

- No real xsim, Vivado, or hardware execution claim.
- No hardware correctness claim.
- No full parser claim.
- No stable ABI/API claim.
- FPGA repo untouched: `/home/hwkim/Desktop/github/pccxai/pccx-FPGA-NPU-LLM-kv260` was not entered, read, edited, or used.
- No release or tag created.
