### PR TITLE
feat: add editor problem export scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,3 +168,17 @@ jobs:
               fixtures/xsim/mixed.log --format text \
               | grep -q "5 diagnostics"
           echo "xsim-log mixed text smoke ok"
+      - name: cli smoke (problems from-check JSON)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli problems from-check \
+              fixtures/ok_module.sv --format json \
+              | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='editor-problems'; assert d['problems']==[]"
+          echo "problems from-check JSON smoke ok"
+      - name: cli smoke (problems from-xsim-log text)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli problems from-xsim-log \
+              fixtures/xsim/mixed.log --format text \
+              | grep -q "5 problems"
+          echo "problems from-xsim-log text smoke ok"

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ python -m pccx_ide_cli locate fixtures/modules/ simple_mod --format text
 python -m pccx_ide_cli xsim-log fixtures/xsim/mixed.log --format json
 python -m pccx_ide_cli xsim-log fixtures/xsim/mixed.log --format text
 
+# Editor problem export scaffold (pre-stable)
+python -m pccx_ide_cli problems from-check fixtures/missing_endmodule.sv --format json
+python -m pccx_ide_cli problems from-xsim-log fixtures/xsim/mixed.log --format text
+
 # Print the diagnostics schema
 python -m pccx_ide_cli schema
 ```
@@ -116,6 +120,12 @@ xsim-style log files into diagnostics-like JSON or text output. It does
 not run xsim or Vivado, does not prove hardware correctness, and does
 not claim full Vivado/xsim coverage. The output shape is pre-stable; a
 future `pccx-lab` integration may provide richer log and report handoff.
+
+`problems` is an early editor bridge scaffold. It exports
+editor-friendly problem records from existing local diagnostics and
+xsim-log parsing. It does not implement LSP, a VS Code extension,
+a JetBrains plugin, or any GUI. It does not run xsim or Vivado. The
+output shape is pre-stable; future editor bridges may consume it.
 
 Tests are run with:
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -228,6 +228,54 @@ python -m pccx_ide_cli xsim-log fixtures/xsim/mixed.log --format text
 
 ---
 
+## editor problem export scaffold (active, pre-stable)
+
+`pccx-ide problems` exports editor-friendly problem records from
+existing local diagnostics and xsim-log parsing.  It is a bridge surface
+for future editor integration, not an editor integration by itself.
+
+### Usage
+
+```bash
+python -m pccx_ide_cli problems from-check fixtures/missing_endmodule.sv --format json
+python -m pccx_ide_cli problems from-xsim-log fixtures/xsim/mixed.log --format text
+```
+
+### Output shape (JSON)
+
+```json
+{
+  "tool": "pccx-ide-cli",
+  "kind": "editor-problems",
+  "source_kind": "check",
+  "source": "<path passed on CLI>",
+  "problems": [
+    {
+      "source_kind": "check",
+      "severity": "error",
+      "code": "PCCX-SCAFFOLD-003",
+      "message": "`module` declared but no matching `endmodule` found",
+      "file": "<source file>",
+      "line": 1,
+      "column": 1
+    }
+  ]
+}
+```
+
+### Scope
+
+- `from-check` uses the built-in scaffold diagnostics path only.
+- `from-xsim-log` uses the local xsim-log parser.
+- Valid inputs exit 0 even when problems are exported; path and format
+  errors fail clearly.
+- Does not implement LSP, a VS Code extension, a JetBrains plugin, or a
+  GUI.
+- Does not run xsim or Vivado.
+- Output is pre-stable.  Future editor bridges may consume this shape.
+
+---
+
 ## Open questions
 
 - Whether the envelope grows a `metadata` object at v1, and what

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -108,6 +108,44 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    problems = sub.add_parser(
+        "problems",
+        help="Export editor-friendly problems from existing local outputs.",
+    )
+    problems_sub = problems.add_subparsers(dest="problems_source", required=True)
+
+    problems_check = problems_sub.add_parser(
+        "from-check",
+        help="Export problems from the built-in scaffold diagnostics check.",
+    )
+    problems_check.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv / .svh file.",
+    )
+    problems_check.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
+    problems_xsim = problems_sub.add_parser(
+        "from-xsim-log",
+        help="Export problems from an existing xsim-style log file.",
+    )
+    problems_xsim.add_argument(
+        "log_file",
+        type=Path,
+        help="Path to an existing xsim-style log file.",
+    )
+    problems_xsim.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     sub.add_parser(
         "schema",
         help="Print the diagnostics envelope JSON schema.",
@@ -245,6 +283,53 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_text(envelope))
+        return 0
+
+    if args.command == "problems":
+        from .problem_export import (
+            build_export,
+            format_text,
+            from_check_envelope,
+            from_xsim_log_envelope,
+        )
+
+        if args.problems_source == "from-check":
+            if not args.path.exists():
+                sys.stderr.write(f"error: input file does not exist: {args.path}\n")
+                return 2
+            if not args.path.is_file():
+                sys.stderr.write(f"error: input path is not a file: {args.path}\n")
+                return 2
+            check_envelope = scan_file(args.path)
+            export = build_export(
+                "check",
+                str(args.path),
+                from_check_envelope(check_envelope),
+            )
+        elif args.problems_source == "from-xsim-log":
+            from .xsim_log import parse_log_file
+
+            if not args.log_file.exists():
+                sys.stderr.write(f"error: log file does not exist: {args.log_file}\n")
+                return 2
+            if not args.log_file.is_file():
+                sys.stderr.write(f"error: log path is not a file: {args.log_file}\n")
+                return 2
+            xsim_envelope = parse_log_file(args.log_file)
+            export = build_export(
+                "xsim-log",
+                str(args.log_file),
+                from_xsim_log_envelope(xsim_envelope),
+            )
+        else:
+            parser.error(f"unknown problems source: {args.problems_source}")
+            return 2
+
+        if args.format == "json":
+            json.dump(export, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_text(export))
         return 0
 
     parser.error(f"unknown command: {args.command}")

--- a/src/pccx_ide_cli/problem_export.py
+++ b/src/pccx_ide_cli/problem_export.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from typing import Any
+
+Problem = dict[str, Any]
+
+
+def _problem_sort_key(problem: Problem) -> tuple[str, int, int, str, str, str]:
+    line = problem.get("line")
+    column = problem.get("column")
+    return (
+        str(problem.get("file") or ""),
+        line if isinstance(line, int) else 0,
+        column if isinstance(column, int) else 0,
+        str(problem.get("severity") or ""),
+        str(problem.get("code") or ""),
+        str(problem.get("message") or ""),
+    )
+
+
+def _sorted_problems(problems: list[Problem]) -> list[Problem]:
+    return sorted(problems, key=_problem_sort_key)
+
+
+def _copy_if_present(target: Problem, source: dict[str, Any], key: str) -> None:
+    value = source.get(key)
+    if value is not None:
+        target[key] = value
+
+
+def from_check_envelope(envelope: dict[str, Any]) -> list[Problem]:
+    problems: list[Problem] = []
+    source = str(envelope.get("source", ""))
+
+    for diagnostic in envelope.get("diagnostics", []):
+        problem: Problem = {
+            "source_kind": "check",
+            "severity": diagnostic["severity"],
+            "message": diagnostic["message"],
+        }
+        if source:
+            problem["file"] = source
+        _copy_if_present(problem, diagnostic, "line")
+        _copy_if_present(problem, diagnostic, "column")
+        _copy_if_present(problem, diagnostic, "code")
+        problems.append(problem)
+
+    return _sorted_problems(problems)
+
+
+def from_xsim_log_envelope(envelope: dict[str, Any]) -> list[Problem]:
+    problems: list[Problem] = []
+
+    for diagnostic in envelope.get("diagnostics", []):
+        problem: Problem = {
+            "source_kind": "xsim-log",
+            "severity": diagnostic["severity"],
+            "message": diagnostic["message"],
+        }
+        _copy_if_present(problem, diagnostic, "file")
+        _copy_if_present(problem, diagnostic, "line")
+        _copy_if_present(problem, diagnostic, "column")
+        _copy_if_present(problem, diagnostic, "code")
+        raw = diagnostic.get("raw_line")
+        if raw is not None:
+            problem["raw"] = raw
+        problems.append(problem)
+
+    return _sorted_problems(problems)
+
+
+def build_export(source_kind: str, source: str, problems: list[Problem]) -> dict[str, Any]:
+    return {
+        "kind": "editor-problems",
+        "problems": _sorted_problems(problems),
+        "source": source,
+        "source_kind": source_kind,
+        "tool": "pccx-ide-cli",
+    }
+
+
+def format_text(export: dict[str, Any]) -> str:
+    problems = export["problems"]
+    count = len(problems)
+    plural = "s" if count != 1 else ""
+    lines = [
+        f"source: {export['source']}",
+        f"source-kind: {export['source_kind']}",
+        f"{count} problem{plural}",
+    ]
+
+    for problem in problems:
+        severity = problem["severity"]
+        message = problem["message"]
+        code = problem.get("code")
+        message_part = f"{code}: {message}" if code else message
+
+        file = problem.get("file")
+        line = problem.get("line")
+        column = problem.get("column")
+        if file is not None and line is not None:
+            location = f"{file}:{line}"
+            if column is not None:
+                location = f"{location}:{column}"
+            lines.append(f"{location}: {severity}: {message_part}")
+        elif file is not None:
+            lines.append(f"{file}: {severity}: {message_part}")
+        else:
+            lines.append(f"{severity}: {message_part}")
+
+    return "\n".join(lines) + "\n"

--- a/tests/test_problem_export.py
+++ b/tests/test_problem_export.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+SV_FIXTURES = REPO_ROOT / "fixtures"
+XSIM_FIXTURES = REPO_ROOT / "fixtures" / "xsim"
+
+sys.path.insert(0, str(SRC))
+
+from pccx_ide_cli.problem_export import (  # noqa: E402
+    build_export,
+    from_check_envelope,
+    from_xsim_log_envelope,
+)
+from pccx_ide_cli.diagnostics import scan_file  # noqa: E402
+from pccx_ide_cli.xsim_log import parse_log_file  # noqa: E402
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "pccx_ide_cli", *args],
+        cwd=REPO_ROOT,
+        env={
+            "PYTHONPATH": str(SRC),
+            "PATH": os.environ.get("PATH", ""),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_from_check_ok_module_zero_problems_exit_zero():
+    result = _run_cli(
+        "problems",
+        "from-check",
+        str(SV_FIXTURES / "ok_module.sv"),
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["problems"] == []
+
+
+def test_from_check_missing_endmodule_produces_problem():
+    result = _run_cli(
+        "problems",
+        "from-check",
+        str(SV_FIXTURES / "missing_endmodule.sv"),
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert len(payload["problems"]) >= 1
+    assert payload["problems"][0]["code"] == "PCCX-SCAFFOLD-003"
+    assert payload["problems"][0]["file"] == str(SV_FIXTURES / "missing_endmodule.sv")
+
+
+def test_from_check_text_includes_source_kind_count():
+    result = _run_cli(
+        "problems",
+        "from-check",
+        str(SV_FIXTURES / "missing_endmodule.sv"),
+        "--format",
+        "text",
+    )
+    assert result.returncode == 0, result.stderr
+    assert f"source: {SV_FIXTURES / 'missing_endmodule.sv'}" in result.stdout
+    assert "source-kind: check" in result.stdout
+    assert "1 problem" in result.stdout
+    assert "PCCX-SCAFFOLD-003" in result.stdout
+
+
+def test_from_check_json_output_shape_is_stable():
+    result = _run_cli(
+        "problems",
+        "from-check",
+        str(SV_FIXTURES / "missing_endmodule.sv"),
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert sorted(payload.keys()) == [
+        "kind",
+        "problems",
+        "source",
+        "source_kind",
+        "tool",
+    ]
+    assert payload["kind"] == "editor-problems"
+    assert payload["tool"] == "pccx-ide-cli"
+    assert payload["source_kind"] == "check"
+    assert sorted(payload["problems"][0].keys()) == [
+        "code",
+        "column",
+        "file",
+        "line",
+        "message",
+        "severity",
+        "source_kind",
+    ]
+
+
+def test_from_check_invalid_format_fails_clearly():
+    result = _run_cli(
+        "problems",
+        "from-check",
+        str(SV_FIXTURES / "ok_module.sv"),
+        "--format",
+        "xml",
+    )
+    assert result.returncode != 0
+    assert "invalid choice" in result.stderr
+
+
+def test_from_check_missing_file_fails_clearly():
+    result = _run_cli(
+        "problems",
+        "from-check",
+        str(SV_FIXTURES / "does_not_exist.sv"),
+        "--format",
+        "json",
+    )
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
+@pytest.mark.parametrize("fixture", ["clean.log", "empty.log"])
+def test_from_xsim_log_clean_or_empty_zero_problems_exit_zero(fixture: str):
+    result = _run_cli(
+        "problems",
+        "from-xsim-log",
+        str(XSIM_FIXTURES / fixture),
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["problems"] == []
+
+
+def test_from_xsim_log_mixed_produces_problems():
+    result = _run_cli(
+        "problems",
+        "from-xsim-log",
+        str(XSIM_FIXTURES / "mixed.log"),
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert len(payload["problems"]) == 5
+    assert {p["source_kind"] for p in payload["problems"]} == {"xsim-log"}
+
+
+def test_from_xsim_log_preserves_file_line_column():
+    payload = json.loads(
+        _run_cli(
+            "problems",
+            "from-xsim-log",
+            str(XSIM_FIXTURES / "warnings.log"),
+            "--format",
+            "json",
+        ).stdout
+    )
+    located = [p for p in payload["problems"] if p.get("file") == "src/warn.sv"]
+    assert len(located) == 1
+    assert located[0]["line"] == 7
+    assert located[0]["column"] == 5
+
+
+def test_from_xsim_log_preserves_bracket_code():
+    payload = json.loads(
+        _run_cli(
+            "problems",
+            "from-xsim-log",
+            str(XSIM_FIXTURES / "errors.log"),
+            "--format",
+            "json",
+        ).stdout
+    )
+    codes = {p.get("code") for p in payload["problems"]}
+    assert "VRFC 10-1234" in codes
+
+
+def test_from_xsim_log_unknown_lines_do_not_crash():
+    result = _run_cli(
+        "problems",
+        "from-xsim-log",
+        str(XSIM_FIXTURES / "unknown_lines.log"),
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert len(payload["problems"]) == 1
+    assert payload["problems"][0]["severity"] == "info"
+
+
+def test_from_xsim_log_text_includes_source_kind_count():
+    result = _run_cli(
+        "problems",
+        "from-xsim-log",
+        str(XSIM_FIXTURES / "mixed.log"),
+        "--format",
+        "text",
+    )
+    assert result.returncode == 0, result.stderr
+    assert f"source: {XSIM_FIXTURES / 'mixed.log'}" in result.stdout
+    assert "source-kind: xsim-log" in result.stdout
+    assert "5 problems" in result.stdout
+    assert "src/warn.sv:7:5: warning: implicit net created" in result.stdout
+
+
+def test_from_xsim_log_json_output_shape_is_stable():
+    result = _run_cli(
+        "problems",
+        "from-xsim-log",
+        str(XSIM_FIXTURES / "errors.log"),
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert sorted(payload.keys()) == [
+        "kind",
+        "problems",
+        "source",
+        "source_kind",
+        "tool",
+    ]
+    assert payload["kind"] == "editor-problems"
+    assert payload["source_kind"] == "xsim-log"
+    assert payload["source"] == str(XSIM_FIXTURES / "errors.log")
+    assert any("raw" in p for p in payload["problems"])
+
+
+def test_from_xsim_log_invalid_format_fails_clearly():
+    result = _run_cli(
+        "problems",
+        "from-xsim-log",
+        str(XSIM_FIXTURES / "clean.log"),
+        "--format",
+        "xml",
+    )
+    assert result.returncode != 0
+    assert "invalid choice" in result.stderr
+
+
+def test_from_xsim_log_missing_log_fails_clearly():
+    result = _run_cli(
+        "problems",
+        "from-xsim-log",
+        str(XSIM_FIXTURES / "missing.log"),
+        "--format",
+        "json",
+    )
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
+def test_problem_conversion_sorts_deterministically():
+    export = build_export(
+        "xsim-log",
+        "synthetic.log",
+        [
+            {
+                "source_kind": "xsim-log",
+                "severity": "warning",
+                "message": "b",
+                "file": "b.sv",
+                "line": 2,
+                "column": 1,
+            },
+            {
+                "source_kind": "xsim-log",
+                "severity": "error",
+                "message": "a",
+                "file": "a.sv",
+                "line": 1,
+                "column": 1,
+            },
+        ],
+    )
+    assert [p["file"] for p in export["problems"]] == ["a.sv", "b.sv"]
+
+
+def test_helper_from_check_envelope():
+    envelope = scan_file(SV_FIXTURES / "missing_endmodule.sv")
+    problems = from_check_envelope(envelope)
+    assert problems[0]["source_kind"] == "check"
+    assert problems[0]["file"] == str(SV_FIXTURES / "missing_endmodule.sv")
+
+
+def test_helper_from_xsim_log_envelope():
+    envelope = parse_log_file(XSIM_FIXTURES / "errors.log")
+    problems = from_xsim_log_envelope(envelope)
+    assert any(p.get("raw") for p in problems)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Add an early `problems` export scaffold that converts existing local diagnostics and xsim-log parser output into deterministic editor-friendly problem records.

## Model

Main high-reasoning Codex path used because this defines a new CLI/output boundary. No Spark/subagents used.

## Commands Added

```bash
python -m pccx_ide_cli problems from-check <sv-file> --format json
python -m pccx_ide_cli problems from-check <sv-file> --format text
python -m pccx_ide_cli problems from-xsim-log <log-file> --format json
python -m pccx_ide_cli problems from-xsim-log <log-file> --format text
```

`from-check` uses the built-in scaffold diagnostics path only. It does not silently use the pccx-lab backend.

## Output Shape

JSON output is pre-stable and includes:

```json
{
  "tool": "pccx-ide-cli",
  "kind": "editor-problems",
  "source_kind": "check",
  "source": "<path passed on CLI>",
  "problems": []
}
```

Problem records include `source_kind`, `severity`, and `message`, plus optional `file`, `line`, `column`, `code`, and `raw` when available.

Text output includes `source:`, `source-kind:`, count, and one problem line per record.

## Limitations

- Early editor bridge scaffold only.
- No LSP server claim.
- No VS Code extension claim.
- No JetBrains plugin claim.
- No GUI claim.
- No stable ABI/API claim.
- Does not run xsim or Vivado.
- No hardware correctness claim.
- `from-xsim-log` is limited by the existing conservative synthetic xsim-log parser.

## Tests Added

Added `tests/test_problem_export.py` covering:

- `from-check` zero-problem and diagnostic cases
- JSON/text output shape
- missing path and invalid format failures
- `from-xsim-log` clean/empty/mixed logs
- file/line/column preservation
- bracket code preservation
- unknown lines
- deterministic ordering
- helper-level conversion

Existing diagnostics, pccx-lab backend, index/query/locate, and xsim-log tests still run in the full suite.

## Validation

Local shell has `python3` but no `python` executable, so source-tree validation used the existing project-compatible pattern `PYTHONPATH=src python3 -m ...`.

```bash
python3 -m pytest -q
PYTHONPATH=src python3 -m pccx_ide_cli problems from-check fixtures/ok_module.sv --format json
PYTHONPATH=src python3 -m pccx_ide_cli problems from-check fixtures/missing_endmodule.sv --format text
PYTHONPATH=src python3 -m pccx_ide_cli problems from-xsim-log fixtures/xsim/clean.log --format json
PYTHONPATH=src python3 -m pccx_ide_cli problems from-xsim-log fixtures/xsim/mixed.log --format text
PYTHONPATH=src python3 -m pccx_ide_cli xsim-log fixtures/xsim/mixed.log --format text
PYTHONPATH=src python3 -m pccx_ide_cli index fixtures/modules --format text
PYTHONPATH=src python3 -m pccx_ide_cli locate fixtures/modules/simple_module.sv simple_mod --format text
PYTHONPATH=src python3 -m pccx_ide_cli check fixtures/ok_module.sv --format text
git diff --check
```

Result: `124 passed`; smoke commands and `git diff --check` passed.

## Boundaries

- No real xsim, Vivado, hardware, LSP, VS Code, JetBrains, or GUI integration claim.
- No stable ABI/API claim.
- FPGA repo untouched: `/home/hwkim/Desktop/github/pccxai/pccx-FPGA-NPU-LLM-kv260` was not entered, read, edited, or used.
- No release or tag created.
