### PR TITLE
docs: add editor bridge contract scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,3 +182,5 @@ jobs:
               fixtures/xsim/mixed.log --format text \
               | grep -q "5 problems"
           echo "problems from-xsim-log text smoke ok"
+      - name: editor bridge smoke script
+        run: bash scripts/editor-bridge-smoke.sh

--- a/README.md
+++ b/README.md
@@ -127,10 +127,15 @@ xsim-log parsing. It does not implement LSP, a VS Code extension,
 a JetBrains plugin, or any GUI. It does not run xsim or Vivado. The
 output shape is pre-stable; future editor bridges may consume it.
 
+The external editor bridge CLI contract is documented in
+[`docs/EDITOR_BRIDGE_CONTRACT.md`](./docs/EDITOR_BRIDGE_CONTRACT.md).
+It is a pre-stable CLI contract, not an editor extension implementation.
+
 Tests are run with:
 
 ```bash
 python -m pytest -q
+bash scripts/editor-bridge-smoke.sh
 ```
 
 The envelope shape is fixed in [`schema/diagnostics-v0.json`](./schema/diagnostics-v0.json).

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -1,0 +1,72 @@
+# Editor Bridge Contract
+
+## Status
+
+This is an early, pre-stable CLI contract for external editor bridges.
+It is not an LSP server, a VS Code extension, a JetBrains plugin, or a
+stable ABI/API.  Treat all JSON shapes as subject to change while the
+`pccx-lab` boundary and IDE surface mature.
+
+## Intended Consumers
+
+- Future VS Code extension work.
+- Future JetBrains or other editor bridges.
+- Local scripts that need deterministic JSON.
+- CI or headless checks that need diagnostics, problem lists, or module
+  navigation records.
+
+## Core Flows
+
+For tool integrations, prefer JSON output:
+
+```bash
+# File diagnostics as editor problems
+python -m pccx_ide_cli problems from-check <sv-file> --format json
+
+# Existing xsim-style log diagnostics as editor problems
+python -m pccx_ide_cli problems from-xsim-log <log-file> --format json
+
+# Module index for project/file navigation
+python -m pccx_ide_cli index <path> --format json
+
+# Locate one module by exact name
+python -m pccx_ide_cli locate <path> <module-name> --format json
+
+# Opt-in pccx-lab diagnostics backend
+python -m pccx_ide_cli check <sv-file> --backend pccx-lab --format json
+```
+
+## Output Handling Guidance
+
+- Consume JSON for tools; text output is for humans.
+- Preserve process exit codes.  For example, `locate` uses non-zero
+  exits for no match or ambiguous matches.
+- Do not silently fall back when an explicit backend is requested.  If
+  `--backend pccx-lab` is configured and the binary is missing or
+  returns invalid output, surface that failure.
+- Treat all output shapes as pre-stable.  Bridge code should keep its
+  adapter layer small and easy to update.
+
+## Data Movement
+
+The intended data path is explicit:
+
+```text
+SystemVerilog source or existing log file
+  -> pccx_ide_cli command
+  -> JSON output
+  -> editor problem list or navigation entry
+```
+
+`problems` converts local diagnostics and log records into
+editor-friendly problem records.  `index` and `locate` provide
+navigation-oriented records.
+
+## Limitations
+
+- Scanner-based scaffolds, not full SystemVerilog parsing.
+- No LSP server in this repository today.
+- No editor extension is implemented here.
+- No stable schema yet.
+- No real xsim or Vivado execution.
+- No hardware access or hardware correctness claim.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -233,6 +233,8 @@ python -m pccx_ide_cli xsim-log fixtures/xsim/mixed.log --format text
 `pccx-ide problems` exports editor-friendly problem records from
 existing local diagnostics and xsim-log parsing.  It is a bridge surface
 for future editor integration, not an editor integration by itself.
+The external editor bridge contract is tracked in
+[`EDITOR_BRIDGE_CONTRACT.md`](./EDITOR_BRIDGE_CONTRACT.md).
 
 ### Usage
 

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if command -v python >/dev/null 2>&1; then
+  PY=python
+elif command -v python3 >/dev/null 2>&1; then
+  PY=python3
+else
+  echo "error: python or python3 is required" >&2
+  exit 127
+fi
+
+export PYTHONPATH="$ROOT/src${PYTHONPATH:+:$PYTHONPATH}"
+cd "$ROOT"
+
+run_json() {
+  local expected_kind="$1"
+  shift
+  "$PY" -m pccx_ide_cli "$@" \
+    | "$PY" -c "import json,sys; d=json.load(sys.stdin); assert d.get('kind') == '$expected_kind', d"
+}
+
+run_json editor-problems problems from-check fixtures/ok_module.sv --format json
+run_json editor-problems problems from-check fixtures/missing_endmodule.sv --format json
+run_json editor-problems problems from-xsim-log fixtures/xsim/mixed.log --format json
+run_json module-index index fixtures/modules --format json
+run_json locate locate fixtures/modules/simple_module.sv simple_mod --format json
+
+echo "editor bridge smoke ok"


### PR DESCRIPTION
## Summary

Add a short external editor bridge contract scaffold for the existing CLI surfaces and a lightweight smoke script for editor-facing JSON flows.

## Model

Main high-reasoning Codex path used because this defines an integration contract. No Spark/subagents used.

## Contract Scope

The new `docs/EDITOR_BRIDGE_CONTRACT.md` defines how external editor bridges should call the existing CLI and handle output. It is explicitly early/pre-stable and not a stable ABI/API.

## Commands Documented

```bash
python -m pccx_ide_cli problems from-check <sv-file> --format json
python -m pccx_ide_cli problems from-xsim-log <log-file> --format json
python -m pccx_ide_cli index <path> --format json
python -m pccx_ide_cli locate <path> <module-name> --format json
python -m pccx_ide_cli check <sv-file> --backend pccx-lab --format json
```

The doc also states that tools should consume JSON, text is for humans, exit codes should be preserved, and explicit backend failures must not silently fall back.

## Smoke Script

Added `scripts/editor-bridge-smoke.sh`. It:

- uses `python` if available, otherwise `python3`
- sets `PYTHONPATH=src`
- runs fixture-based editor-facing JSON commands
- validates top-level JSON `kind`
- requires no pccx-lab binary, Vivado, xsim, hardware, or editor dependency

CI now runs this script in the existing scaffold smoke job.

## Validation

Local shell uses `python3`; CLI smokes used `PYTHONPATH=src python3 -m ...`.

```bash
python3 -m pytest -q
bash scripts/editor-bridge-smoke.sh
PYTHONPATH=src python3 -m pccx_ide_cli problems from-check fixtures/ok_module.sv --format json
PYTHONPATH=src python3 -m pccx_ide_cli problems from-xsim-log fixtures/xsim/mixed.log --format json
PYTHONPATH=src python3 -m pccx_ide_cli index fixtures/modules --format json
PYTHONPATH=src python3 -m pccx_ide_cli locate fixtures/modules/simple_module.sv simple_mod --format json
git diff --check
```

Result: `124 passed`; smoke script and JSON flows passed; `git diff --check` passed.

## Boundaries

- No LSP server claim.
- No VS Code extension claim.
- No JetBrains plugin claim.
- No GUI claim.
- No stable ABI/API claim.
- No real xsim/Vivado/hardware claim.
- FPGA repo untouched: `/home/hwkim/Desktop/github/pccxai/pccx-FPGA-NPU-LLM-kv260` was not entered, read, edited, or used.
- No release or tag created.
