### PR TITLE
feat: index package and interface declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ python -m pccx_ide_cli check fixtures/missing_endmodule.sv --format text
 PCCX_LAB_BIN=/path/to/pccx-lab \
     python -m pccx_ide_cli check fixtures/ok_module.sv --backend pccx-lab --format text
 
-# Module index (early scaffold — not a full parser)
+# Module/declaration index (early scaffold — not a full parser)
 python -m pccx_ide_cli index fixtures/modules/simple_module.sv
 python -m pccx_ide_cli index fixtures/modules/ --format text
 
@@ -103,6 +103,10 @@ fixtures/modules/simple_module.sv:1:1: module simple_mod
 fixtures/modules/two_modules.sv:1:1: module mod_a
 fixtures/modules/two_modules.sv:3:1: module mod_b
 ```
+
+`index` also emits a pre-stable `declarations[]` JSON list for simple
+`module`, `package`, and `interface` declarations.  This is scanner-based
+navigation support, not semantic resolution or a full parser.
 
 Module locate text output format (one match, exit 0):
 ```

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -26,7 +26,7 @@ python -m pccx_ide_cli problems from-check <sv-file> --format json
 # Existing xsim-style log diagnostics as editor problems
 python -m pccx_ide_cli problems from-xsim-log <log-file> --format json
 
-# Module index for project/file navigation
+# Declaration index for project/file navigation
 python -m pccx_ide_cli index <path> --format json
 
 # Locate one module by exact name
@@ -59,8 +59,9 @@ SystemVerilog source or existing log file
 ```
 
 `problems` converts local diagnostics and log records into
-editor-friendly problem records.  `index` and `locate` provide
-navigation-oriented records.
+editor-friendly problem records.  `index` provides scanner-based
+module/package/interface declaration records.  `locate` remains
+module-oriented.
 
 ## Limitations
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -88,10 +88,10 @@ exit 2 with a message on stderr.
 
 ## module index scaffold (active, pre-stable)
 
-`pccx-ide index` scans `.sv` and `.v` files for `module` declarations and
-emits a lightweight index.  This is an early scaffold intended to support
-future navigation and editor-bridge work — it is not a full SystemVerilog
-parser.
+`pccx-ide index` scans `.sv` and `.v` files for simple `module`,
+`package`, and `interface` declarations and emits a lightweight index.
+This is an early scaffold intended to support future navigation and
+editor-bridge work — it is not a full SystemVerilog parser.
 
 ### Usage
 
@@ -110,6 +110,9 @@ python -m pccx_ide_cli index fixtures/modules/ --format text
   "kind": "module-index",
   "tool": "pccx-ide-scaffold",
   "source": "<path passed on CLI>",
+  "declarations": [
+    { "kind": "module", "name": "simple_mod", "file": "<abs-path>", "line": 1, "column": 1 }
+  ],
   "modules": [
     { "name": "simple_mod", "file": "<abs-path>", "line": 1, "column": 1 }
   ]
@@ -119,16 +122,21 @@ python -m pccx_ide_cli index fixtures/modules/ --format text
 ### Parser limitations
 
 - Single-line `//` comments are skipped.
-- Block comments (`/* ... */`) are **not** parsed — a `module` keyword
-  inside a block comment will be reported as a false positive.
-- `package`, `interface`, and `class` declarations are ignored.
-- No semantic analysis.  Column is the 1-indexed position of the `module`
-  keyword.
+- Non-nested block comments (`/* ... */`) are stripped by the scanner;
+  nested block comments are not supported.
+- `package` and `interface` support is scanner-based: simple declaration
+  lines only, no imports, modports, macro expansion, or semantic resolution.
+- `class`, `program`, and `checker` declarations are ignored.
+- No semantic analysis.  Column is the 1-indexed position of the
+  `module`, `package`, or `interface` keyword.
 
 ### Scope
 
 - pccx-lab backend is diagnostics-only for now.  `index` always uses the
   built-in scaffold scanner.
+- `modules[]` remains for compatibility; `declarations[]` carries the
+  declaration kind.
+- `locate` remains module-only.  Package/interface locate is future work.
 - No stable ABI or API contract — the output shape may change before v1.
 
 ---

--- a/fixtures/modules/commented_package_interface.sv
+++ b/fixtures/modules/commented_package_interface.sv
@@ -1,0 +1,13 @@
+// package commented_pkg;
+// interface commented_if;
+
+/*
+package block_pkg;
+interface block_if;
+*/
+
+package real_pkg;
+endpackage
+
+interface real_if;
+endinterface

--- a/fixtures/modules/interface_decl.sv
+++ b/fixtures/modules/interface_decl.sv
@@ -1,0 +1,6 @@
+interface bus_if #(
+    parameter int WIDTH = 32
+) (
+    input logic clk
+);
+endinterface

--- a/fixtures/modules/mixed_declarations.sv
+++ b/fixtures/modules/mixed_declarations.sv
@@ -1,0 +1,8 @@
+package mixed_pkg;
+endpackage
+
+interface mixed_if;
+endinterface
+
+module mixed_mod;
+endmodule

--- a/fixtures/modules/package_decl.sv
+++ b/fixtures/modules/package_decl.sv
@@ -1,0 +1,2 @@
+package util_pkg;
+endpackage

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -197,28 +197,31 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0 if not envelope["diagnostics"] else 1
 
     if args.command == "index":
-        from .module_index import build_index, filter_modules, scan_path
+        from .module_index import build_index, filter_declarations, scan_path
 
         if not args.path.exists():
             sys.stderr.write(f"error: path does not exist: {args.path}\n")
             return 2
 
-        modules = scan_path(args.path)
+        declarations = scan_path(args.path)
         if args.query is not None:
-            modules = filter_modules(modules, args.query)
-        index = build_index(str(args.path), modules)
+            declarations = filter_declarations(declarations, args.query)
+        index = build_index(str(args.path), declarations)
 
         if args.format == "json":
             json.dump(index, sys.stdout, indent=2, sort_keys=True)
             sys.stdout.write("\n")
         else:
-            count = len(modules)
+            count = len(declarations)
+            module_only = all(d["kind"] == "module" for d in declarations)
+            noun = "module" if module_only else "declaration"
             plural = "s" if count != 1 else ""
             sys.stdout.write(f"source: {index['source']}\n")
-            sys.stdout.write(f"{count} module{plural}\n")
-            for m in modules:
+            sys.stdout.write(f"{count} {noun}{plural}\n")
+            for d in declarations:
                 sys.stdout.write(
-                    f"{m['file']}:{m['line']}:{m['column']}: module {m['name']}\n"
+                    f"{d['file']}:{d['line']}:{d['column']}: "
+                    f"{d['kind']} {d['name']}\n"
                 )
         return 0
 

--- a/src/pccx_ide_cli/module_index.py
+++ b/src/pccx_ide_cli/module_index.py
@@ -4,13 +4,16 @@ import re
 from pathlib import Path
 from typing import Any
 
-# Matches `module <name>` at the start of a line (optional leading whitespace).
-# Conservative: handles  module foo;  /  module foo #(  /  module foo (
-# Column convention: 1-based character offset of the `module` keyword.
+# Matches simple declaration lines at the start of a line (optional leading
+# whitespace). Conservative: handles:
+#   module foo; / module foo #( / module foo (
+#   package foo;
+#   interface bus_if; / interface bus_if #( / interface bus_if (
+# Column convention: 1-based character offset of the declaration keyword.
 # Limitation: column reflects the visible text after block-comment removal;
-# if /* */ spans precede `module` on the same line the column is scanner-based,
-# not byte-offset in the original source.
-_MODULE_LINE_RE = re.compile(r"^(\s*)module\s+(\w+)")
+# if /* */ spans precede a declaration on the same line the column is
+# scanner-based, not byte-offset in the original source.
+_DECL_LINE_RE = re.compile(r"^(\s*)(module|package|interface)\s+(\w+)")
 
 _IGNORE_DIRS: frozenset[str] = frozenset({".git", "__pycache__", "build", "dist", "target"})
 _SV_SUFFIXES: frozenset[str] = frozenset({".sv", ".v"})
@@ -50,10 +53,11 @@ def _scan_text(text: str, source: str) -> list[dict[str, Any]]:
         visible, in_block_comment = _strip_block_comments(line, in_block_comment)
         if visible.lstrip().startswith("//"):
             continue
-        m = _MODULE_LINE_RE.match(visible)
+        m = _DECL_LINE_RE.match(visible)
         if m:
             results.append({
-                "name": m.group(2),
+                "kind": m.group(2),
+                "name": m.group(3),
                 "file": source,
                 "line": line_num,
                 "column": len(m.group(1)) + 1,
@@ -67,7 +71,7 @@ def scan_file(path: Path) -> list[dict[str, Any]]:
 
 
 def scan_path(path: Path) -> list[dict[str, Any]]:
-    """Return module records for a single file or a directory tree.
+    """Return declaration records for a single file or a directory tree.
 
     Directory scan skips _IGNORE_DIRS and collects .sv and .v files only.
     Output is sorted by (file, line, name) for determinism.
@@ -81,16 +85,31 @@ def scan_path(path: Path) -> list[dict[str, Any]]:
         for f in path.rglob(f"*{suffix}")
         if not any(part in _IGNORE_DIRS for part in f.parts)
     )
-    modules: list[dict[str, Any]] = []
+    declarations: list[dict[str, Any]] = []
     for f in sv_files:
-        modules.extend(scan_file(f))
+        declarations.extend(scan_file(f))
 
-    modules.sort(key=lambda m: (m["file"], m["line"], m["name"]))
-    return modules
+    declarations.sort(key=lambda d: (d["file"], d["line"], d["kind"], d["name"]))
+    return declarations
 
 
-def build_index(source: str, modules: list[dict[str, Any]]) -> dict[str, Any]:
+def _legacy_module_record(declaration: dict[str, Any]) -> dict[str, Any]:
     return {
+        "name": declaration["name"],
+        "file": declaration["file"],
+        "line": declaration["line"],
+        "column": declaration["column"],
+    }
+
+
+def build_index(source: str, declarations: list[dict[str, Any]]) -> dict[str, Any]:
+    modules = [
+        _legacy_module_record(d)
+        for d in declarations
+        if d["kind"] == "module"
+    ]
+    return {
+        "declarations": declarations,
         "kind": "module-index",
         "modules": modules,
         "source": source,
@@ -98,11 +117,18 @@ def build_index(source: str, modules: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def filter_modules(
+def filter_declarations(
     entries: list[dict[str, Any]], query: str
 ) -> list[dict[str, Any]]:
     """Return entries whose 'name' exactly matches query (case-sensitive)."""
     return [e for e in entries if e["name"] == query]
+
+
+def filter_modules(
+    entries: list[dict[str, Any]], query: str
+) -> list[dict[str, Any]]:
+    """Backward-compatible alias for exact declaration-name filtering."""
+    return filter_declarations(entries, query)
 
 
 def locate_module(path: Path, name: str) -> list[dict[str, Any]]:
@@ -123,7 +149,7 @@ def locate_module(path: Path, name: str) -> list[dict[str, Any]]:
             "column": m["column"],
         }
         for m in raw
-        if m["name"] == name
+        if m["kind"] == "module" and m["name"] == name
     ]
     matches.sort(key=lambda m: (m["file"], m["line"]))
     return matches

--- a/tests/test_editor_bridge_contract.py
+++ b/tests/test_editor_bridge_contract.py
@@ -101,6 +101,8 @@ def test_contract_index_modules_json():
     assert payload["kind"] == "module-index"
     assert isinstance(payload["modules"], list)
     assert payload["modules"]
+    assert isinstance(payload["declarations"], list)
+    assert payload["declarations"]
 
 
 def test_contract_locate_simple_module_json():

--- a/tests/test_locate.py
+++ b/tests/test_locate.py
@@ -112,6 +112,11 @@ def test_locate_module_directory_recursive():
     assert matches[0]["module"] == "child_mod"
 
 
+def test_locate_module_ignores_package_with_same_name():
+    matches = locate_module(FIXTURES / "package_decl.sv", "util_pkg")
+    assert matches == []
+
+
 # ── CLI: index --query ────────────────────────────────────────────────────────
 
 def test_cli_index_query_exact_match_json():

--- a/tests/test_module_index.py
+++ b/tests/test_module_index.py
@@ -57,6 +57,7 @@ def test_strip_inline_comment_then_module():
 def test_single_file_one_module():
     mods = scan_file(FIXTURES / "simple_module.sv")
     assert len(mods) == 1
+    assert mods[0]["kind"] == "module"
     assert mods[0]["name"] == "simple_mod"
     assert mods[0]["line"] == 1
     assert mods[0]["column"] == 1
@@ -117,7 +118,51 @@ def test_real_module_after_block_comment_found():
 def test_v_extension_scanned():
     mods = scan_file(FIXTURES / "nested_dir" / "extra_v_mod.v")
     assert len(mods) == 1
+    assert mods[0]["kind"] == "module"
     assert mods[0]["name"] == "extra_v_mod"
+
+
+def test_package_declaration_found():
+    declarations = scan_file(FIXTURES / "package_decl.sv")
+    assert declarations == [
+        {
+            "kind": "package",
+            "name": "util_pkg",
+            "file": str(FIXTURES / "package_decl.sv"),
+            "line": 1,
+            "column": 1,
+        }
+    ]
+
+
+def test_interface_declaration_found():
+    declarations = scan_file(FIXTURES / "interface_decl.sv")
+    assert len(declarations) == 1
+    assert declarations[0]["kind"] == "interface"
+    assert declarations[0]["name"] == "bus_if"
+    assert declarations[0]["line"] == 1
+    assert declarations[0]["column"] == 1
+
+
+def test_mixed_declarations_found():
+    declarations = scan_file(FIXTURES / "mixed_declarations.sv")
+    kinds_names = [(d["kind"], d["name"]) for d in declarations]
+    assert kinds_names == [
+        ("package", "mixed_pkg"),
+        ("interface", "mixed_if"),
+        ("module", "mixed_mod"),
+    ]
+
+
+def test_commented_package_interface_ignored():
+    declarations = scan_file(FIXTURES / "commented_package_interface.sv")
+    names = {d["name"] for d in declarations}
+    assert "commented_pkg" not in names
+    assert "commented_if" not in names
+    assert "block_pkg" not in names
+    assert "block_if" not in names
+    assert "real_pkg" in names
+    assert "real_if" in names
 
 
 # ── unit: directory scanning ──────────────────────────────────────────────────
@@ -134,10 +179,19 @@ def test_scan_directory_finds_all_modules():
     assert "indented_mod" in names
     assert "block_real_mod" in names
     assert "after_block_mod" in names
+    assert "util_pkg" in names
+    assert "bus_if" in names
+    assert "mixed_pkg" in names
+    assert "mixed_if" in names
+    assert "mixed_mod" in names
+    assert "real_pkg" in names
+    assert "real_if" in names
     # block-commented fakes must not appear
     assert "fake_mod" not in names
     assert "block_fake_mod" not in names
     assert "multi_fake_mod" not in names
+    assert "block_pkg" not in names
+    assert "block_if" not in names
 
 
 def test_scan_directory_deterministic():
@@ -158,6 +212,7 @@ def test_build_index_shape():
     assert idx["tool"] == "pccx-ide-scaffold"
     assert idx["kind"] == "module-index"
     assert idx["source"] == "fixtures/modules/simple_module.sv"
+    assert idx["declarations"] == mods
     assert len(idx["modules"]) == 1
 
 
@@ -166,6 +221,24 @@ def test_build_index_module_record_fields():
     assert all(
         {"name", "file", "line", "column"} <= set(m.keys()) for m in mods
     )
+
+
+def test_build_index_keeps_legacy_modules_shape():
+    declarations = scan_file(FIXTURES / "mixed_declarations.sv")
+    idx = build_index("fixtures/modules/mixed_declarations.sv", declarations)
+    assert [d["kind"] for d in idx["declarations"]] == [
+        "package",
+        "interface",
+        "module",
+    ]
+    assert idx["modules"] == [
+        {
+            "name": "mixed_mod",
+            "file": str(FIXTURES / "mixed_declarations.sv"),
+            "line": 7,
+            "column": 1,
+        }
+    ]
 
 
 # ── CLI helpers ───────────────────────────────────────────────────────────────
@@ -208,16 +281,33 @@ def test_cli_index_json_directory():
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
     names = {m["name"] for m in payload["modules"]}
+    declaration_names = {d["name"] for d in payload["declarations"]}
     assert "simple_mod" in names
     assert "child_mod" in names
     assert "extra_v_mod" in names
     assert "fake_mod" not in names
+    assert "util_pkg" in declaration_names
+    assert "bus_if" in declaration_names
 
 
 def test_cli_index_json_has_required_keys():
     result = _run_cli("index", str(FIXTURES / "simple_module.sv"))
     payload = json.loads(result.stdout)
-    assert {"kind", "tool", "source", "modules"} <= payload.keys()
+    assert {"kind", "tool", "source", "modules", "declarations"} <= payload.keys()
+
+
+def test_cli_index_json_package_interface_shape():
+    result = _run_cli("index", str(FIXTURES / "mixed_declarations.sv"))
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    declarations = payload["declarations"]
+    assert [d["kind"] for d in declarations] == ["package", "interface", "module"]
+    assert {d["name"] for d in declarations} == {
+        "mixed_pkg",
+        "mixed_if",
+        "mixed_mod",
+    }
+    assert [m["name"] for m in payload["modules"]] == ["mixed_mod"]
 
 
 # ── CLI: text output ──────────────────────────────────────────────────────────
@@ -244,6 +334,17 @@ def test_cli_index_text_two_modules():
     assert "mod_b" in result.stdout
 
 
+def test_cli_index_text_mixed_declarations_includes_kind():
+    result = _run_cli(
+        "index", "--format", "text", str(FIXTURES / "mixed_declarations.sv")
+    )
+    assert result.returncode == 0
+    assert "3 declarations" in result.stdout
+    assert "package mixed_pkg" in result.stdout
+    assert "interface mixed_if" in result.stdout
+    assert "module mixed_mod" in result.stdout
+
+
 def test_cli_index_text_format_has_path_line_col():
     result = _run_cli("index", "--format", "text", str(FIXTURES / "simple_module.sv"))
     # Diagnostic lines have the form: path:line:col: module <name>
@@ -266,6 +367,23 @@ def test_cli_existing_check_still_works():
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
     assert payload["envelope"] == "0"
+
+
+def test_cli_index_query_package_json_exit_zero():
+    result = _run_cli("index", str(FIXTURES), "--query", "util_pkg", "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["modules"] == []
+    assert len(payload["declarations"]) == 1
+    assert payload["declarations"][0]["kind"] == "package"
+    assert payload["declarations"][0]["name"] == "util_pkg"
+
+
+def test_cli_index_query_interface_text():
+    result = _run_cli("index", str(FIXTURES), "--query", "bus_if", "--format", "text")
+    assert result.returncode == 0
+    assert "1 declaration" in result.stdout
+    assert "interface bus_if" in result.stdout
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Extend the existing scanner/index scaffold to recognize simple SystemVerilog `package` and `interface` declarations alongside modules.

## Model

Main high-reasoning Codex path used because this extends the index/navigation contract. No subagents used.

## Output Compatibility Decision

Kept the existing top-level JSON `kind: module-index` and preserved legacy `modules[]` as module-only records with the existing fields:

```json
{ "name": "...", "file": "...", "line": 1, "column": 1 }
```

Added pre-stable `declarations[]` records for all scanner-supported declaration kinds:

```json
{ "kind": "package|interface|module", "name": "...", "file": "...", "line": 1, "column": 1 }
```

Text output remains module-oriented when all results are modules. When packages/interfaces are present, text output reports `declaration(s)` and prints the declaration kind.

## Declarations Added

The scanner now recognizes simple line-start declarations:

- `module <name>`
- `package <name>`
- `interface <name>`

It continues to skip `//` comments and non-nested block comments.

## Query / Locate Behavior

- `index --query <name>` now filters across all declaration kinds and returns matching entries in `declarations[]`.
- `modules[]` remains module-only after filtering.
- `locate <path> <name>` remains module-only for compatibility. Package/interface locate is deferred.

## Tests Added

Added/updated tests for:

- package declaration scanning
- interface declaration scanning
- mixed module/package/interface fixtures
- commented-out and block-comment package/interface false positives
- declaration JSON shape
- legacy `modules[]` shape compatibility
- text output with declaration kind
- `index --query` for package/interface declarations
- module-only locate compatibility
- editor bridge contract index shape compatibility

## Validation

Local shell uses `python3`; CLI smokes used `PYTHONPATH=src python3 -m ...`.

```bash
python3 -m pytest -q
PYTHONPATH=src python3 -m pccx_ide_cli index fixtures/modules --format json
PYTHONPATH=src python3 -m pccx_ide_cli index fixtures/modules --format text
PYTHONPATH=src python3 -m pccx_ide_cli index fixtures/modules --query simple_mod --format json
PYTHONPATH=src python3 -m pccx_ide_cli locate fixtures/modules/simple_module.sv simple_mod --format json
PYTHONPATH=src python3 -m pccx_ide_cli problems from-check fixtures/ok_module.sv --format json
bash scripts/editor-bridge-smoke.sh
git diff --check
```

Result: `143 passed`; smoke commands and `git diff --check` passed.

## Boundaries

- No full SystemVerilog parser claim.
- No semantic resolution claim.
- No LSP/editor-extension/GUI claim.
- No stable ABI/API claim.
- No pccx-lab code changes.
- FPGA repo untouched: `/home/hwkim/Desktop/github/pccxai/pccx-FPGA-NPU-LLM-kv260` was not entered, read, edited, or used.
- No release or tag created.
