### PR TITLE
feat: add declaration kind locate support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,12 @@ jobs:
           PYTHONPATH=src python -m pccx_ide_cli index fixtures/modules \
               | python -c "import json,sys; d=json.load(sys.stdin); assert len(d['modules'])>0"
           echo "index directory smoke ok"
+      - name: cli smoke (declarations directory exits zero)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli declarations fixtures/modules \
+              | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='declarations'; assert len(d['declarations'])>0"
+          echo "declarations directory smoke ok"
       - name: cli smoke (index missing path exits non-zero)
         run: |
           set -e

--- a/README.md
+++ b/README.md
@@ -71,9 +71,14 @@ python -m pccx_ide_cli index fixtures/modules/ --format text
 python -m pccx_ide_cli index fixtures/modules/ --query simple_mod
 python -m pccx_ide_cli index fixtures/modules/ --query simple_mod --format text
 
-# Module locate (early navigation scaffold — not LSP, not stable API)
+# Declaration locate (early navigation scaffold — not LSP, not stable API)
 python -m pccx_ide_cli locate fixtures/modules/ simple_mod
+python -m pccx_ide_cli locate fixtures/modules/ pkg_defs --kind package
+python -m pccx_ide_cli locate fixtures/modules/ bus_if --kind interface
 python -m pccx_ide_cli locate fixtures/modules/ simple_mod --format text
+
+# Declaration export for editor bridge consumers (pre-stable)
+python -m pccx_ide_cli declarations fixtures/modules/ --format json
 
 # xsim log handoff scaffold (parses existing log files only)
 python -m pccx_ide_cli xsim-log fixtures/xsim/mixed.log --format json
@@ -108,16 +113,21 @@ fixtures/modules/two_modules.sv:3:1: module mod_b
 `module`, `package`, and `interface` declarations.  This is scanner-based
 navigation support, not semantic resolution or a full parser.
 
-Module locate text output format (one match, exit 0):
+Declaration locate text output format (one match, exit 0):
 ```
 module simple_mod
-fixtures/modules/simple_module.sv:1:0
+fixtures/modules/simple_module.sv:1:1
 ```
 
 No match exits 1. Multiple matches exit 2 with all candidates listed.
-`locate` is an early navigation scaffold, exact name only, not semantic
-navigation, not LSP, not a stable API. A future editor bridge can consume
-this output.
+`locate` defaults to module-only compatibility and can target
+`--kind module|package|interface|any`. It is an early scanner-based
+navigation scaffold, exact name only, not semantic navigation, not LSP,
+not a stable API. A future editor bridge can consume this output.
+
+`declarations` exports the same pre-stable module/package/interface
+records used by `index` without the legacy module-only wrapper. It is a
+CLI bridge scaffold, not semantic resolution or a full parser.
 
 `xsim-log` is an early handoff scaffold. It parses existing synthetic
 xsim-style log files into diagnostics-like JSON or text output. It does

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -29,8 +29,14 @@ python -m pccx_ide_cli problems from-xsim-log <log-file> --format json
 # Declaration index for project/file navigation
 python -m pccx_ide_cli index <path> --format json
 
-# Locate one module by exact name
-python -m pccx_ide_cli locate <path> <module-name> --format json
+# Direct declaration export for editor navigation
+python -m pccx_ide_cli declarations <path> --format json
+
+# Locate one declaration by exact name
+python -m pccx_ide_cli locate <path> <name> --kind module --format json
+python -m pccx_ide_cli locate <path> <name> --kind package --format json
+python -m pccx_ide_cli locate <path> <name> --kind interface --format json
+python -m pccx_ide_cli locate <path> <name> --kind any --format json
 
 # Opt-in pccx-lab diagnostics backend
 python -m pccx_ide_cli check <sv-file> --backend pccx-lab --format json
@@ -58,10 +64,10 @@ SystemVerilog source or existing log file
   -> editor problem list or navigation entry
 ```
 
-`problems` converts local diagnostics and log records into
-editor-friendly problem records.  `index` provides scanner-based
-module/package/interface declaration records.  `locate` remains
-module-oriented.
+`problems` converts local diagnostics and log records into editor-friendly
+problem records.  `index` provides scanner-based module/package/interface
+declaration records.  `declarations` exports those records directly, and
+`locate` resolves exact declaration names by requested kind.
 
 ## Limitations
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -136,23 +136,30 @@ python -m pccx_ide_cli index fixtures/modules/ --format text
   built-in scaffold scanner.
 - `modules[]` remains for compatibility; `declarations[]` carries the
   declaration kind.
-- `locate` remains module-only.  Package/interface locate is future work.
+- `locate` defaults to module-only compatibility and can opt into
+  `--kind package`, `--kind interface`, or `--kind any`.
 - No stable ABI or API contract — the output shape may change before v1.
 
 ---
 
-## module locate scaffold (active, pre-stable)
+## declaration locate scaffold (active, pre-stable)
 
-`pccx-ide locate` scans `.sv` and `.v` files for a single module declaration
-by exact name.  This is an early navigation scaffold — not semantic navigation,
-not an LSP implementation, and not a stable API.  A future editor bridge can
-consume this output, but the shape may change before v1.
+`pccx-ide locate` scans `.sv` and `.v` files for a single declaration by
+exact name.  The default remains module-only for compatibility; callers can
+opt into `--kind module|package|interface|any`.  This is an early navigation
+scaffold — not semantic navigation, not an LSP implementation, and not a
+stable API.  A future editor bridge can consume this output, but the shape may
+change before v1.
 
 ### Usage
 
 ```bash
 # Locate a module — JSON output (default)
 python -m pccx_ide_cli locate fixtures/modules/ simple_mod
+
+# Locate a package or interface
+python -m pccx_ide_cli locate fixtures/modules/ pkg_defs --kind package
+python -m pccx_ide_cli locate fixtures/modules/ bus_if --kind interface
 
 # Locate — human-readable text output
 python -m pccx_ide_cli locate fixtures/modules/ simple_mod --format text
@@ -166,8 +173,9 @@ python -m pccx_ide_cli locate fixtures/modules/ simple_mod --format text
   "tool": "pccx-ide-cli",
   "source": "line-scanner",
   "query": "simple_mod",
+  "declaration_kind": "module",
   "matches": [
-    { "module": "simple_mod", "file": "<path>", "line": 1, "column": 0 }
+    { "kind": "module", "name": "simple_mod", "module": "simple_mod", "file": "<path>", "line": 1, "column": 1 }
   ]
 }
 ```
@@ -184,10 +192,38 @@ python -m pccx_ide_cli locate fixtures/modules/ simple_mod --format text
 
 - Exact case-sensitive name match only.
 - Uses the same line scanner as `index` — same parser limitations apply
-  (no block comment handling, no semantic analysis).
-- `column` is always 0 in locate output (column position not resolved at
-  this stage).
+  (scanner-based block comment handling, no semantic analysis).
+- `column` is the same 1-indexed keyword column emitted by `index`.
 - Output shape is pre-stable; not a committed API contract.
+
+---
+
+## declaration export scaffold (active, pre-stable)
+
+`pccx-ide declarations` exposes the scanner declaration records directly for
+editor bridge consumers.  It is a thin wrapper over the `index`
+`declarations[]` data and keeps legacy module-only `modules[]` out of the
+result.
+
+```bash
+python -m pccx_ide_cli declarations fixtures/modules/ --format json
+python -m pccx_ide_cli declarations fixtures/modules/ --format text
+```
+
+JSON output uses:
+
+```json
+{
+  "kind": "declarations",
+  "tool": "pccx-ide-cli",
+  "source": "<path passed on CLI>",
+  "declarations": [
+    { "kind": "package", "name": "pkg_defs", "file": "<path>", "line": 1, "column": 1 }
+  ]
+}
+```
+
+The output is pre-stable, scanner-based, and not semantic resolution.
 
 ---
 

--- a/fixtures/modules/package_defs.sv
+++ b/fixtures/modules/package_defs.sv
@@ -1,0 +1,2 @@
+package pkg_defs;
+endpackage

--- a/fixtures/modules/same_name_declarations.sv
+++ b/fixtures/modules/same_name_declarations.sv
@@ -1,0 +1,8 @@
+package shared_decl;
+endpackage
+
+interface shared_decl;
+endinterface
+
+module shared_decl;
+endmodule

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -26,6 +26,7 @@ run_json editor-problems problems from-check fixtures/ok_module.sv --format json
 run_json editor-problems problems from-check fixtures/missing_endmodule.sv --format json
 run_json editor-problems problems from-xsim-log fixtures/xsim/mixed.log --format json
 run_json module-index index fixtures/modules --format json
+run_json declarations declarations fixtures/modules --format json
 run_json locate locate fixtures/modules/simple_module.sv simple_mod --format json
 
 echo "editor bridge smoke ok"

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -72,9 +72,25 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Filter results to modules with this exact name (case-sensitive).",
     )
 
+    declarations_cmd = sub.add_parser(
+        "declarations",
+        help="Export scanner-based module/package/interface declaration records.",
+    )
+    declarations_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    declarations_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     locate_cmd = sub.add_parser(
         "locate",
-        help="Locate a module by exact name in a .sv/.v file or directory.",
+        help="Locate a declaration by exact name in a .sv/.v file or directory.",
     )
     locate_cmd.add_argument(
         "path",
@@ -83,7 +99,13 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     locate_cmd.add_argument(
         "name",
-        help="Module name to locate (exact, case-sensitive).",
+        help="Declaration name to locate (exact, case-sensitive).",
+    )
+    locate_cmd.add_argument(
+        "--kind",
+        choices=("module", "package", "interface", "any"),
+        default="module",
+        help="Declaration kind to locate (default: module).",
     )
     locate_cmd.add_argument(
         "--format",
@@ -222,20 +244,46 @@ def main(argv: Sequence[str] | None = None) -> int:
                 sys.stdout.write(
                     f"{d['file']}:{d['line']}:{d['column']}: "
                     f"{d['kind']} {d['name']}\n"
-                )
+            )
         return 0
 
-    if args.command == "locate":
-        from .module_index import locate_module
+    if args.command == "declarations":
+        from .module_index import build_declarations_export, scan_path
 
         if not args.path.exists():
             sys.stderr.write(f"error: path does not exist: {args.path}\n")
             return 2
 
-        matches = locate_module(args.path, args.name)
+        declarations = scan_path(args.path)
+        export = build_declarations_export(str(args.path), declarations)
+
+        if args.format == "json":
+            json.dump(export, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            count = len(declarations)
+            plural = "s" if count != 1 else ""
+            sys.stdout.write(f"source: {export['source']}\n")
+            sys.stdout.write(f"{count} declaration{plural}\n")
+            for d in declarations:
+                sys.stdout.write(
+                    f"{d['file']}:{d['line']}:{d['column']}: "
+                    f"{d['kind']} {d['name']}\n"
+                )
+        return 0
+
+    if args.command == "locate":
+        from .module_index import locate_declaration
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        matches = locate_declaration(args.path, args.name, args.kind)
 
         if args.format == "json":
             envelope = {
+                "declaration_kind": args.kind,
                 "kind": "locate",
                 "matches": matches,
                 "query": args.name,
@@ -247,25 +295,35 @@ def main(argv: Sequence[str] | None = None) -> int:
         else:
             count = len(matches)
             if count == 1:
-                sys.stdout.write(f"module {matches[0]['module']}\n")
+                sys.stdout.write(f"{matches[0]['kind']} {matches[0]['name']}\n")
                 sys.stdout.write(
                     f"{matches[0]['file']}:{matches[0]['line']}:{matches[0]['column']}\n"
                 )
             elif count == 0:
-                sys.stdout.write(f"module {args.name}: not found\n")
+                label = "declaration" if args.kind == "any" else args.kind
+                sys.stdout.write(f"{label} {args.name}: not found\n")
             else:
+                label = "declaration" if args.kind == "any" else args.kind
                 sys.stdout.write(
-                    f"module {args.name}: {count} matches (ambiguous)\n"
+                    f"{label} {args.name}: {count} matches (ambiguous)\n"
                 )
                 for m in matches:
-                    sys.stdout.write(f"{m['file']}:{m['line']}:{m['column']}\n")
+                    if args.kind == "module":
+                        sys.stdout.write(f"{m['file']}:{m['line']}:{m['column']}\n")
+                    else:
+                        sys.stdout.write(
+                            f"{m['file']}:{m['line']}:{m['column']}: "
+                            f"{m['kind']} {m['name']}\n"
+                        )
 
         if len(matches) == 0:
-            sys.stderr.write(f"error: module not found: {args.name}\n")
+            label = "declaration" if args.kind == "any" else args.kind
+            sys.stderr.write(f"error: {label} not found: {args.name}\n")
             return 1
         if len(matches) > 1:
+            label = "declaration" if args.kind == "any" else args.kind
             sys.stderr.write(
-                f"error: ambiguous: {len(matches)} matches for module {args.name}\n"
+                f"error: ambiguous: {len(matches)} matches for {label} {args.name}\n"
             )
             return 2
         return 0

--- a/src/pccx_ide_cli/module_index.py
+++ b/src/pccx_ide_cli/module_index.py
@@ -17,6 +17,8 @@ _DECL_LINE_RE = re.compile(r"^(\s*)(module|package|interface)\s+(\w+)")
 
 _IGNORE_DIRS: frozenset[str] = frozenset({".git", "__pycache__", "build", "dist", "target"})
 _SV_SUFFIXES: frozenset[str] = frozenset({".sv", ".v"})
+DECLARATION_KINDS: tuple[str, ...] = ("module", "package", "interface")
+LOCATE_KINDS: tuple[str, ...] = (*DECLARATION_KINDS, "any")
 
 
 def _strip_block_comments(line: str, in_comment: bool) -> tuple[str, bool]:
@@ -117,6 +119,17 @@ def build_index(source: str, declarations: list[dict[str, Any]]) -> dict[str, An
     }
 
 
+def build_declarations_export(
+    source: str, declarations: list[dict[str, Any]]
+) -> dict[str, Any]:
+    return {
+        "declarations": declarations,
+        "kind": "declarations",
+        "source": source,
+        "tool": "pccx-ide-cli",
+    }
+
+
 def filter_declarations(
     entries: list[dict[str, Any]], query: str
 ) -> list[dict[str, Any]]:
@@ -131,25 +144,44 @@ def filter_modules(
     return filter_declarations(entries, query)
 
 
-def locate_module(path: Path, name: str) -> list[dict[str, Any]]:
-    """Scan path for exact case-sensitive module name matches.
+def _locate_record(declaration: dict[str, Any]) -> dict[str, Any]:
+    record = {
+        "kind": declaration["kind"],
+        "name": declaration["name"],
+        "file": declaration["file"],
+        "line": declaration["line"],
+        "column": declaration["column"],
+    }
+    if declaration["kind"] == "module":
+        record["module"] = declaration["name"]
+    return record
 
-    Returns a list of locate-shaped records:
-      {"module": <name>, "file": <path>, "line": N, "column": C}
 
-    Column is the same 1-based character offset as the index command.
-    Sorted deterministically by (file, line).
+def locate_declaration(
+    path: Path, name: str, declaration_kind: str = "module"
+) -> list[dict[str, Any]]:
+    """Scan path for exact case-sensitive declaration name matches.
+
+    declaration_kind may be module/package/interface/any.  Module matches keep
+    the legacy "module" field while also exposing generic kind/name fields.
     """
+    if declaration_kind not in LOCATE_KINDS:
+        raise ValueError(f"unsupported declaration kind: {declaration_kind}")
+
     raw = scan_path(path)
     matches = [
-        {
-            "module": m["name"],
-            "file": m["file"],
-            "line": m["line"],
-            "column": m["column"],
-        }
-        for m in raw
-        if m["kind"] == "module" and m["name"] == name
+        _locate_record(declaration)
+        for declaration in raw
+        if declaration["name"] == name
+        and (
+            declaration_kind == "any"
+            or declaration["kind"] == declaration_kind
+        )
     ]
-    matches.sort(key=lambda m: (m["file"], m["line"]))
+    matches.sort(key=lambda m: (m["file"], m["line"], m["column"], m["kind"], m["name"]))
     return matches
+
+
+def locate_module(path: Path, name: str) -> list[dict[str, Any]]:
+    """Backward-compatible module-only locate wrapper."""
+    return locate_declaration(path, name, "module")

--- a/tests/test_editor_bridge_contract.py
+++ b/tests/test_editor_bridge_contract.py
@@ -105,6 +105,19 @@ def test_contract_index_modules_json():
     assert payload["declarations"]
 
 
+def test_contract_declarations_json():
+    result = _run_cli("declarations", "fixtures/modules", "--format", "json")
+    assert result.returncode == 0, result.stderr
+
+    payload = _json_stdout(result)
+    assert payload["kind"] == "declarations"
+    assert payload["source"] == "fixtures/modules"
+    assert isinstance(payload["declarations"], list)
+    assert payload["declarations"]
+    kinds = {declaration["kind"] for declaration in payload["declarations"]}
+    assert {"module", "package", "interface"} <= kinds
+
+
 def test_contract_locate_simple_module_json():
     result = _run_cli(
         "locate",
@@ -124,6 +137,8 @@ def test_contract_locate_simple_module_json():
 
     match = payload["matches"][0]
     assert match["module"] == "simple_mod"
+    assert match["kind"] == "module"
+    assert match["name"] == "simple_mod"
     assert match["file"] == "fixtures/modules/simple_module.sv"
     assert match["line"] == 1
     assert match["column"] == 1
@@ -176,7 +191,10 @@ def test_contract_doc_mentions_core_flows_and_limitations():
     assert "problems from-check" in text
     assert "problems from-xsim-log" in text
     assert "index <path>" in text
-    assert "locate <path> <module-name>" in text
+    assert "declarations <path>" in text
+    assert "locate <path> <name>" in text
+    assert "--kind package" in text
+    assert "--kind interface" in text
     assert "--backend pccx-lab" in text
     assert "not an lsp server" in lowered
     assert "stable abi/api" in lowered

--- a/tests/test_locate.py
+++ b/tests/test_locate.py
@@ -14,7 +14,12 @@ FIXTURES = REPO_ROOT / "fixtures" / "modules"
 
 sys.path.insert(0, str(SRC))
 
-from pccx_ide_cli.module_index import filter_modules, locate_module, scan_path  # noqa: E402
+from pccx_ide_cli.module_index import (  # noqa: E402
+    filter_modules,
+    locate_declaration,
+    locate_module,
+    scan_path,
+)
 
 
 # ── helpers ───────────────────────────────────────────────────────────────────
@@ -73,6 +78,8 @@ def test_locate_module_one_match_shape():
     assert len(matches) == 1
     m = matches[0]
     assert m["module"] == "simple_mod"
+    assert m["kind"] == "module"
+    assert m["name"] == "simple_mod"
     assert "file" in m
     assert m["line"] == 1
     assert m["column"] == 1  # `module` starts at column 1 (no leading whitespace)
@@ -115,6 +122,36 @@ def test_locate_module_directory_recursive():
 def test_locate_module_ignores_package_with_same_name():
     matches = locate_module(FIXTURES / "package_decl.sv", "util_pkg")
     assert matches == []
+
+
+def test_locate_declaration_package_match():
+    matches = locate_declaration(FIXTURES, "pkg_defs", "package")
+    assert len(matches) == 1
+    assert matches[0]["kind"] == "package"
+    assert matches[0]["name"] == "pkg_defs"
+
+
+def test_locate_declaration_interface_match():
+    matches = locate_declaration(FIXTURES, "bus_if", "interface")
+    assert len(matches) == 1
+    assert matches[0]["kind"] == "interface"
+    assert matches[0]["name"] == "bus_if"
+
+
+def test_locate_declaration_any_finds_package_interface_module():
+    assert locate_declaration(FIXTURES, "pkg_defs", "any")[0]["kind"] == "package"
+    assert locate_declaration(FIXTURES, "bus_if", "any")[0]["kind"] == "interface"
+    assert locate_declaration(FIXTURES, "child_mod", "any")[0]["kind"] == "module"
+
+
+def test_locate_declaration_same_name_across_kinds():
+    matches = locate_declaration(FIXTURES, "shared_decl", "any")
+    assert [m["kind"] for m in matches] == ["package", "interface", "module"]
+
+
+def test_locate_declaration_invalid_kind_raises():
+    with pytest.raises(ValueError):
+        locate_declaration(FIXTURES, "simple_mod", "class")
 
 
 # ── CLI: index --query ────────────────────────────────────────────────────────
@@ -191,6 +228,8 @@ def test_cli_locate_one_match_json():
     assert len(payload["matches"]) == 1
     m = payload["matches"][0]
     assert m["module"] == "simple_mod"
+    assert m["kind"] == "module"
+    assert m["name"] == "simple_mod"
     assert "file" in m
     assert isinstance(m["line"], int)
     assert m["column"] == 1  # `module` at column 1 (no leading whitespace in simple_module.sv)
@@ -208,6 +247,83 @@ def test_cli_locate_one_match_text():
     assert lines[1].endswith(":1:1")
 
 
+def test_cli_locate_explicit_module_kind_json():
+    result = _run_cli(
+        "locate", str(FIXTURES / "simple_module.sv"), "simple_mod",
+        "--kind", "module", "--format", "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["declaration_kind"] == "module"
+    assert payload["matches"][0]["module"] == "simple_mod"
+    assert payload["matches"][0]["kind"] == "module"
+
+
+def test_cli_locate_package_kind_json():
+    result = _run_cli(
+        "locate", str(FIXTURES), "pkg_defs",
+        "--kind", "package", "--format", "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["declaration_kind"] == "package"
+    assert len(payload["matches"]) == 1
+    assert payload["matches"][0]["kind"] == "package"
+    assert payload["matches"][0]["name"] == "pkg_defs"
+
+
+def test_cli_locate_interface_kind_json():
+    result = _run_cli(
+        "locate", str(FIXTURES), "bus_if",
+        "--kind", "interface", "--format", "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["declaration_kind"] == "interface"
+    assert len(payload["matches"]) == 1
+    assert payload["matches"][0]["kind"] == "interface"
+    assert payload["matches"][0]["name"] == "bus_if"
+
+
+def test_cli_locate_any_kind_json():
+    result = _run_cli(
+        "locate", str(FIXTURES), "bus_if",
+        "--kind", "any", "--format", "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["declaration_kind"] == "any"
+    assert len(payload["matches"]) == 1
+    assert payload["matches"][0]["kind"] == "interface"
+
+
+def test_cli_locate_same_name_across_kinds_exit_2():
+    result = _run_cli(
+        "locate", str(FIXTURES), "shared_decl",
+        "--kind", "any", "--format", "json",
+    )
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    assert payload["declaration_kind"] == "any"
+    assert [m["kind"] for m in payload["matches"]] == [
+        "package",
+        "interface",
+        "module",
+    ]
+    assert "ambiguous" in result.stderr.lower()
+
+
+def test_cli_locate_package_text_includes_kind_name_location():
+    result = _run_cli(
+        "locate", str(FIXTURES), "pkg_defs",
+        "--kind", "package", "--format", "text",
+    )
+    assert result.returncode == 0, result.stderr
+    lines = result.stdout.splitlines()
+    assert lines[0] == "package pkg_defs"
+    assert lines[1].endswith(":1:1")
+
+
 def test_cli_locate_no_match_exit_1():
     result = _run_cli(
         "locate", str(FIXTURES / "simple_module.sv"), "no_such_mod",
@@ -219,6 +335,18 @@ def test_cli_locate_no_match_exit_1():
     assert "not found" in result.stderr.lower() or "not found" in result.stdout.lower()
 
 
+def test_cli_locate_package_no_match_exit_1():
+    result = _run_cli(
+        "locate", str(FIXTURES), "no_such_pkg",
+        "--kind", "package", "--format", "json",
+    )
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["declaration_kind"] == "package"
+    assert payload["matches"] == []
+    assert "package not found" in result.stderr
+
+
 def test_cli_locate_multiple_matches_exit_2():
     # FIXTURES dir has both simple_module.sv and dup_simple_mod.sv → ambiguous
     result = _run_cli(
@@ -228,6 +356,7 @@ def test_cli_locate_multiple_matches_exit_2():
     payload = json.loads(result.stdout)
     assert len(payload["matches"]) >= 2
     assert all(m["module"] == "simple_mod" for m in payload["matches"])
+    assert all(m["kind"] == "module" for m in payload["matches"])
 
 
 def test_cli_locate_multiple_matches_text_lists_all():

--- a/tests/test_module_index.py
+++ b/tests/test_module_index.py
@@ -14,7 +14,12 @@ FIXTURES = REPO_ROOT / "fixtures" / "modules"
 
 sys.path.insert(0, str(SRC))
 
-from pccx_ide_cli.module_index import build_index, scan_file, scan_path  # noqa: E402
+from pccx_ide_cli.module_index import (  # noqa: E402
+    build_declarations_export,
+    build_index,
+    scan_file,
+    scan_path,
+)
 from pccx_ide_cli.module_index import _strip_block_comments  # noqa: E402
 
 
@@ -241,6 +246,18 @@ def test_build_index_keeps_legacy_modules_shape():
     ]
 
 
+def test_build_declarations_export_shape():
+    declarations = scan_file(FIXTURES / "mixed_declarations.sv")
+    export = build_declarations_export(
+        "fixtures/modules/mixed_declarations.sv",
+        declarations,
+    )
+    assert export["tool"] == "pccx-ide-cli"
+    assert export["kind"] == "declarations"
+    assert export["source"] == "fixtures/modules/mixed_declarations.sv"
+    assert export["declarations"] == declarations
+
+
 # ── CLI helpers ───────────────────────────────────────────────────────────────
 
 def _run_cli(*args: str) -> subprocess.CompletedProcess:
@@ -352,6 +369,41 @@ def test_cli_index_text_format_has_path_line_col():
     assert diag_lines, "expected a diagnostic line containing 'module simple_mod'"
     # path:line:col: module name  →  at least 3 colons
     assert diag_lines[0].count(":") >= 3
+
+
+def test_cli_declarations_json_directory():
+    result = _run_cli("declarations", str(FIXTURES), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "declarations"
+    assert payload["tool"] == "pccx-ide-cli"
+    assert payload["source"] == str(FIXTURES)
+    kinds_names = {(d["kind"], d["name"]) for d in payload["declarations"]}
+    assert ("module", "simple_mod") in kinds_names
+    assert ("package", "pkg_defs") in kinds_names
+    assert ("interface", "bus_if") in kinds_names
+
+
+def test_cli_declarations_text_directory():
+    result = _run_cli("declarations", str(FIXTURES), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "source:" in result.stdout
+    assert "declarations" in result.stdout
+    assert "package pkg_defs" in result.stdout
+    assert "interface bus_if" in result.stdout
+    assert "module simple_mod" in result.stdout
+
+
+def test_cli_declarations_missing_path_exits_nonzero():
+    result = _run_cli("declarations", str(FIXTURES / "does_not_exist.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
+def test_cli_declarations_invalid_format_fails():
+    result = _run_cli("declarations", str(FIXTURES), "--format", "xml")
+    assert result.returncode != 0
+    assert "invalid choice" in result.stderr
 
 
 # ── CLI: error cases ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `locate --kind module|package|interface|any`, with default `module` for compatibility.
- Add a thin pre-stable `declarations <path> --format json|text` export over existing declaration scanner records.
- Extend editor bridge smoke and CI smoke coverage for declaration export.

## Model Used And Why

GPT-5.5 xhigh was used because this touches a CLI/output boundary and compatibility behavior. Spark was not used.

## Locate Kind Behavior

- `--kind module`: module declarations only; default remains module-only.
- `--kind package`: package declarations only.
- `--kind interface`: interface declarations only.
- `--kind any`: any matching declaration kind.
- Exact, case-sensitive matching.
- Exit 0 for one match, 1 for no match, 2 for ambiguity.

## Declaration Export Decision

Implemented `declarations` as a thin editor-facing export over the existing `index` scanner data. It does not add parser semantics.

## Output Compatibility Notes

- Top-level locate `kind` remains `locate`.
- Existing module locate calls remain valid.
- Module matches keep the legacy `module` field and now also include generic `kind` and `name`.
- `index` top-level `kind: module-index`, legacy `modules[]`, and pre-stable `declarations[]` remain intact.
- Output remains pre-stable; no stable ABI/API claim.

## Tests Added

- Unit coverage for package/interface/any declaration locate.
- CLI coverage for locate kind success, no-match, same-kind ambiguity, cross-kind ambiguity, text output, and JSON shape.
- CLI coverage for `declarations` JSON/text, missing path, and invalid format.
- Editor bridge contract coverage for `declarations`.
- Smoke script coverage for `declarations`.

## Validation Commands Run

- `python3 -m pytest tests/test_locate.py tests/test_module_index.py tests/test_editor_bridge_contract.py -q` -> 90 passed.
- `python3 -m pytest -q` -> 161 passed.
- `PYTHONPATH=src python3 -m pccx_ide_cli locate fixtures/modules/simple_module.sv simple_mod --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli locate fixtures/modules simple_mod --format json` -> exit 2 expected because existing fixtures contain duplicate `simple_mod` modules.
- `PYTHONPATH=src python3 -m pccx_ide_cli locate fixtures/modules --kind package pkg_defs --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli locate fixtures/modules --kind interface bus_if --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli locate fixtures/modules --kind any simple_mod --format text` -> exit 2 expected because existing fixtures contain duplicate `simple_mod` modules.
- `PYTHONPATH=src python3 -m pccx_ide_cli index fixtures/modules --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli problems from-check fixtures/ok_module.sv --format json`
- `bash scripts/editor-bridge-smoke.sh`
- `PYTHONPATH=src python3 -m pccx_ide_cli declarations fixtures/modules --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli declarations fixtures/modules --format text`
- `git diff --check`
- Local CI claim-scan snippet -> clean.

## Non-Claims And Scope

- No full SystemVerilog parser claim.
- No LSP/editor-extension/GUI claim.
- No semantic resolver claim.
- No stable ABI/API claim.
- No real xsim/Vivado/hardware claim.
- No release/tag created.

## FPGA Repo Confirmation

The excluded FPGA repository path was not read, entered, edited, or used.

## Token-Saving / Compact Handoff Note

Change is intentionally small: focused scanner locate helper, thin CLI wrappers, fixtures, tests, docs, smoke. If context is compacted, resume from this PR and CI status.
