### PR TITLE
test: add editor bridge JSON contract examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,3 +190,5 @@ jobs:
           echo "problems from-xsim-log text smoke ok"
       - name: editor bridge smoke script
         run: bash scripts/editor-bridge-smoke.sh
+      - name: editor bridge example drift check
+        run: bash scripts/check-editor-bridge-examples.sh

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -53,6 +53,21 @@ python -m pccx_ide_cli check <sv-file> --backend pccx-lab --format json
 - Treat all output shapes as pre-stable.  Bridge code should keep its
   adapter layer small and easy to update.
 
+## Checked Examples
+
+The pre-stable contract examples are checked in under
+`docs/examples/editor-bridge`.  They are generated from synthetic
+fixtures and are intended as adapter guidance, not a stable ABI/API.
+The example drift check is:
+
+```bash
+bash scripts/check-editor-bridge-examples.sh
+```
+
+The module locate example uses the single-file fixture so the sample is
+unambiguous; the full fixture directory intentionally contains duplicate
+module names for ambiguity tests.
+
 ## Data Movement
 
 The intended data path is explicit:

--- a/docs/examples/editor-bridge/declarations.example.json
+++ b/docs/examples/editor-bridge/declarations.example.json
@@ -1,0 +1,154 @@
+{
+  "declarations": [
+    {
+      "column": 1,
+      "file": "fixtures/modules/block_comment_module.sv",
+      "kind": "module",
+      "line": 2,
+      "name": "block_real_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/commented_module.sv",
+      "kind": "module",
+      "line": 2,
+      "name": "real_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/commented_package_interface.sv",
+      "kind": "package",
+      "line": 9,
+      "name": "real_pkg"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/commented_package_interface.sv",
+      "kind": "interface",
+      "line": 12,
+      "name": "real_if"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/dup_simple_mod.sv",
+      "kind": "module",
+      "line": 2,
+      "name": "simple_mod"
+    },
+    {
+      "column": 5,
+      "file": "fixtures/modules/indented_module.sv",
+      "kind": "module",
+      "line": 1,
+      "name": "indented_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/interface_decl.sv",
+      "kind": "interface",
+      "line": 1,
+      "name": "bus_if"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/mixed_declarations.sv",
+      "kind": "package",
+      "line": 1,
+      "name": "mixed_pkg"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/mixed_declarations.sv",
+      "kind": "interface",
+      "line": 4,
+      "name": "mixed_if"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/mixed_declarations.sv",
+      "kind": "module",
+      "line": 7,
+      "name": "mixed_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/multiline_block_comment.sv",
+      "kind": "module",
+      "line": 4,
+      "name": "after_block_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/nested_dir/child_module.sv",
+      "kind": "module",
+      "line": 1,
+      "name": "child_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/nested_dir/extra_v_mod.v",
+      "kind": "module",
+      "line": 2,
+      "name": "extra_v_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/package_decl.sv",
+      "kind": "package",
+      "line": 1,
+      "name": "util_pkg"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/package_defs.sv",
+      "kind": "package",
+      "line": 1,
+      "name": "pkg_defs"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/same_name_declarations.sv",
+      "kind": "package",
+      "line": 1,
+      "name": "shared_decl"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/same_name_declarations.sv",
+      "kind": "interface",
+      "line": 4,
+      "name": "shared_decl"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/same_name_declarations.sv",
+      "kind": "module",
+      "line": 7,
+      "name": "shared_decl"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/simple_module.sv",
+      "kind": "module",
+      "line": 1,
+      "name": "simple_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/two_modules.sv",
+      "kind": "module",
+      "line": 1,
+      "name": "mod_a"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/two_modules.sv",
+      "kind": "module",
+      "line": 4,
+      "name": "mod_b"
+    }
+  ],
+  "kind": "declarations",
+  "source": "fixtures/modules",
+  "tool": "pccx-ide-cli"
+}

--- a/docs/examples/editor-bridge/index-modules.example.json
+++ b/docs/examples/editor-bridge/index-modules.example.json
@@ -1,0 +1,228 @@
+{
+  "declarations": [
+    {
+      "column": 1,
+      "file": "fixtures/modules/block_comment_module.sv",
+      "kind": "module",
+      "line": 2,
+      "name": "block_real_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/commented_module.sv",
+      "kind": "module",
+      "line": 2,
+      "name": "real_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/commented_package_interface.sv",
+      "kind": "package",
+      "line": 9,
+      "name": "real_pkg"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/commented_package_interface.sv",
+      "kind": "interface",
+      "line": 12,
+      "name": "real_if"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/dup_simple_mod.sv",
+      "kind": "module",
+      "line": 2,
+      "name": "simple_mod"
+    },
+    {
+      "column": 5,
+      "file": "fixtures/modules/indented_module.sv",
+      "kind": "module",
+      "line": 1,
+      "name": "indented_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/interface_decl.sv",
+      "kind": "interface",
+      "line": 1,
+      "name": "bus_if"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/mixed_declarations.sv",
+      "kind": "package",
+      "line": 1,
+      "name": "mixed_pkg"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/mixed_declarations.sv",
+      "kind": "interface",
+      "line": 4,
+      "name": "mixed_if"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/mixed_declarations.sv",
+      "kind": "module",
+      "line": 7,
+      "name": "mixed_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/multiline_block_comment.sv",
+      "kind": "module",
+      "line": 4,
+      "name": "after_block_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/nested_dir/child_module.sv",
+      "kind": "module",
+      "line": 1,
+      "name": "child_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/nested_dir/extra_v_mod.v",
+      "kind": "module",
+      "line": 2,
+      "name": "extra_v_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/package_decl.sv",
+      "kind": "package",
+      "line": 1,
+      "name": "util_pkg"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/package_defs.sv",
+      "kind": "package",
+      "line": 1,
+      "name": "pkg_defs"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/same_name_declarations.sv",
+      "kind": "package",
+      "line": 1,
+      "name": "shared_decl"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/same_name_declarations.sv",
+      "kind": "interface",
+      "line": 4,
+      "name": "shared_decl"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/same_name_declarations.sv",
+      "kind": "module",
+      "line": 7,
+      "name": "shared_decl"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/simple_module.sv",
+      "kind": "module",
+      "line": 1,
+      "name": "simple_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/two_modules.sv",
+      "kind": "module",
+      "line": 1,
+      "name": "mod_a"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/two_modules.sv",
+      "kind": "module",
+      "line": 4,
+      "name": "mod_b"
+    }
+  ],
+  "kind": "module-index",
+  "modules": [
+    {
+      "column": 1,
+      "file": "fixtures/modules/block_comment_module.sv",
+      "line": 2,
+      "name": "block_real_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/commented_module.sv",
+      "line": 2,
+      "name": "real_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/dup_simple_mod.sv",
+      "line": 2,
+      "name": "simple_mod"
+    },
+    {
+      "column": 5,
+      "file": "fixtures/modules/indented_module.sv",
+      "line": 1,
+      "name": "indented_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/mixed_declarations.sv",
+      "line": 7,
+      "name": "mixed_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/multiline_block_comment.sv",
+      "line": 4,
+      "name": "after_block_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/nested_dir/child_module.sv",
+      "line": 1,
+      "name": "child_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/nested_dir/extra_v_mod.v",
+      "line": 2,
+      "name": "extra_v_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/same_name_declarations.sv",
+      "line": 7,
+      "name": "shared_decl"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/simple_module.sv",
+      "line": 1,
+      "name": "simple_mod"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/two_modules.sv",
+      "line": 1,
+      "name": "mod_a"
+    },
+    {
+      "column": 1,
+      "file": "fixtures/modules/two_modules.sv",
+      "line": 4,
+      "name": "mod_b"
+    }
+  ],
+  "source": "fixtures/modules",
+  "tool": "pccx-ide-scaffold"
+}

--- a/docs/examples/editor-bridge/locate-interface.example.json
+++ b/docs/examples/editor-bridge/locate-interface.example.json
@@ -1,0 +1,16 @@
+{
+  "declaration_kind": "interface",
+  "kind": "locate",
+  "matches": [
+    {
+      "column": 1,
+      "file": "fixtures/modules/interface_decl.sv",
+      "kind": "interface",
+      "line": 1,
+      "name": "bus_if"
+    }
+  ],
+  "query": "bus_if",
+  "source": "line-scanner",
+  "tool": "pccx-ide-cli"
+}

--- a/docs/examples/editor-bridge/locate-module.example.json
+++ b/docs/examples/editor-bridge/locate-module.example.json
@@ -1,0 +1,17 @@
+{
+  "declaration_kind": "module",
+  "kind": "locate",
+  "matches": [
+    {
+      "column": 1,
+      "file": "fixtures/modules/simple_module.sv",
+      "kind": "module",
+      "line": 1,
+      "module": "simple_mod",
+      "name": "simple_mod"
+    }
+  ],
+  "query": "simple_mod",
+  "source": "line-scanner",
+  "tool": "pccx-ide-cli"
+}

--- a/docs/examples/editor-bridge/locate-package.example.json
+++ b/docs/examples/editor-bridge/locate-package.example.json
@@ -1,0 +1,16 @@
+{
+  "declaration_kind": "package",
+  "kind": "locate",
+  "matches": [
+    {
+      "column": 1,
+      "file": "fixtures/modules/package_defs.sv",
+      "kind": "package",
+      "line": 1,
+      "name": "pkg_defs"
+    }
+  ],
+  "query": "pkg_defs",
+  "source": "line-scanner",
+  "tool": "pccx-ide-cli"
+}

--- a/docs/examples/editor-bridge/problems-check-missing-endmodule.example.json
+++ b/docs/examples/editor-bridge/problems-check-missing-endmodule.example.json
@@ -1,0 +1,17 @@
+{
+  "kind": "editor-problems",
+  "problems": [
+    {
+      "code": "PCCX-SCAFFOLD-003",
+      "column": 1,
+      "file": "fixtures/missing_endmodule.sv",
+      "line": 1,
+      "message": "`module` declared but no matching `endmodule` found",
+      "severity": "error",
+      "source_kind": "check"
+    }
+  ],
+  "source": "fixtures/missing_endmodule.sv",
+  "source_kind": "check",
+  "tool": "pccx-ide-cli"
+}

--- a/docs/examples/editor-bridge/problems-check-ok.example.json
+++ b/docs/examples/editor-bridge/problems-check-ok.example.json
@@ -1,0 +1,7 @@
+{
+  "kind": "editor-problems",
+  "problems": [],
+  "source": "fixtures/ok_module.sv",
+  "source_kind": "check",
+  "tool": "pccx-ide-cli"
+}

--- a/docs/examples/editor-bridge/problems-xsim-mixed.example.json
+++ b/docs/examples/editor-bridge/problems-xsim-mixed.example.json
@@ -1,0 +1,45 @@
+{
+  "kind": "editor-problems",
+  "problems": [
+    {
+      "code": "VRFC 10-1234",
+      "message": "syntax error near token ';'",
+      "raw": "ERROR: [VRFC 10-1234] syntax error near token ';'",
+      "severity": "error",
+      "source_kind": "xsim-log"
+    },
+    {
+      "message": "elaboration started",
+      "raw": "INFO: elaboration started",
+      "severity": "info",
+      "source_kind": "xsim-log"
+    },
+    {
+      "code": "XSIM 43-9999",
+      "message": "signal has no driver",
+      "raw": "WARNING: [XSIM 43-9999] signal has no driver",
+      "severity": "warning",
+      "source_kind": "xsim-log"
+    },
+    {
+      "file": "src/top.sv",
+      "line": 12,
+      "message": "module declaration failed",
+      "raw": "src/top.sv:12: error: module declaration failed",
+      "severity": "error",
+      "source_kind": "xsim-log"
+    },
+    {
+      "column": 5,
+      "file": "src/warn.sv",
+      "line": 7,
+      "message": "implicit net created",
+      "raw": "src/warn.sv:7:5: warning: implicit net created",
+      "severity": "warning",
+      "source_kind": "xsim-log"
+    }
+  ],
+  "source": "fixtures/xsim/mixed.log",
+  "source_kind": "xsim-log",
+  "tool": "pccx-ide-cli"
+}

--- a/scripts/check-editor-bridge-examples.sh
+++ b/scripts/check-editor-bridge-examples.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if command -v python >/dev/null 2>&1; then
+  PY=python
+elif command -v python3 >/dev/null 2>&1; then
+  PY=python3
+else
+  echo "error: python or python3 is required" >&2
+  exit 127
+fi
+
+export PYTHONPATH="$ROOT/src${PYTHONPATH:+:$PYTHONPATH}"
+export ROOT
+cd "$ROOT"
+
+"$PY" - <<'PY'
+from __future__ import annotations
+
+import difflib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(os.environ["ROOT"])
+EXAMPLES = ROOT / "docs" / "examples" / "editor-bridge"
+
+FLOWS: tuple[tuple[str, str, tuple[str, ...]], ...] = (
+    (
+        "problems-check-ok.example.json",
+        "editor-problems",
+        ("problems", "from-check", "fixtures/ok_module.sv", "--format", "json"),
+    ),
+    (
+        "problems-check-missing-endmodule.example.json",
+        "editor-problems",
+        (
+            "problems",
+            "from-check",
+            "fixtures/missing_endmodule.sv",
+            "--format",
+            "json",
+        ),
+    ),
+    (
+        "problems-xsim-mixed.example.json",
+        "editor-problems",
+        ("problems", "from-xsim-log", "fixtures/xsim/mixed.log", "--format", "json"),
+    ),
+    (
+        "index-modules.example.json",
+        "module-index",
+        ("index", "fixtures/modules", "--format", "json"),
+    ),
+    (
+        "declarations.example.json",
+        "declarations",
+        ("declarations", "fixtures/modules", "--format", "json"),
+    ),
+    (
+        "locate-module.example.json",
+        "locate",
+        (
+            "locate",
+            "fixtures/modules/simple_module.sv",
+            "simple_mod",
+            "--kind",
+            "module",
+            "--format",
+            "json",
+        ),
+    ),
+    (
+        "locate-package.example.json",
+        "locate",
+        (
+            "locate",
+            "fixtures/modules",
+            "pkg_defs",
+            "--kind",
+            "package",
+            "--format",
+            "json",
+        ),
+    ),
+    (
+        "locate-interface.example.json",
+        "locate",
+        (
+            "locate",
+            "fixtures/modules",
+            "bus_if",
+            "--kind",
+            "interface",
+            "--format",
+            "json",
+        ),
+    ),
+)
+
+
+def normalized(payload: object) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def run_flow(args: tuple[str, ...]) -> object:
+    result = subprocess.run(
+        [sys.executable, "-m", "pccx_ide_cli", *args],
+        cwd=ROOT,
+        env=os.environ.copy(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(f"error: command failed: {' '.join(args)}\n")
+        sys.stderr.write(result.stderr)
+        sys.stderr.write(result.stdout)
+        raise SystemExit(result.returncode)
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"error: command did not emit JSON: {' '.join(args)}\n")
+        sys.stderr.write(f"{exc}\n")
+        raise SystemExit(1) from exc
+
+
+failures = 0
+for filename, expected_kind, args in FLOWS:
+    path = EXAMPLES / filename
+    expected = json.loads(path.read_text(encoding="utf-8"))
+    actual = run_flow(args)
+    if actual.get("kind") != expected_kind:
+        sys.stderr.write(
+            f"error: {filename} expected kind {expected_kind!r}, "
+            f"got {actual.get('kind')!r}\n"
+        )
+        failures += 1
+        continue
+    if actual != expected:
+        failures += 1
+        diff = difflib.unified_diff(
+            normalized(expected).splitlines(),
+            normalized(actual).splitlines(),
+            fromfile=str(path),
+            tofile=f"generated:{' '.join(args)}",
+            lineterm="",
+        )
+        sys.stderr.write("\n".join(diff))
+        sys.stderr.write("\n")
+
+if failures:
+    sys.stderr.write(f"error: {failures} editor bridge example(s) drifted\n")
+    raise SystemExit(1)
+
+print(f"editor bridge examples ok ({len(FLOWS)} checked)")
+PY

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -29,4 +29,6 @@ run_json module-index index fixtures/modules --format json
 run_json declarations declarations fixtures/modules --format json
 run_json locate locate fixtures/modules/simple_module.sv simple_mod --format json
 
+bash scripts/check-editor-bridge-examples.sh
+
 echo "editor bridge smoke ok"

--- a/tests/test_editor_bridge_examples.py
+++ b/tests/test_editor_bridge_examples.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES_DIR = REPO_ROOT / "docs" / "examples" / "editor-bridge"
+CONTRACT_DOC = REPO_ROOT / "docs" / "EDITOR_BRIDGE_CONTRACT.md"
+
+EXPECTED_KINDS = {
+    "problems-check-ok.example.json": "editor-problems",
+    "problems-check-missing-endmodule.example.json": "editor-problems",
+    "problems-xsim-mixed.example.json": "editor-problems",
+    "index-modules.example.json": "module-index",
+    "declarations.example.json": "declarations",
+    "locate-module.example.json": "locate",
+    "locate-package.example.json": "locate",
+    "locate-interface.example.json": "locate",
+}
+
+
+def test_editor_bridge_examples_are_valid_json_with_expected_kinds():
+    actual_files = {path.name for path in EXAMPLES_DIR.glob("*.example.json")}
+    assert actual_files == set(EXPECTED_KINDS)
+
+    for filename, expected_kind in EXPECTED_KINDS.items():
+        payload = json.loads((EXAMPLES_DIR / filename).read_text(encoding="utf-8"))
+        assert payload["kind"] == expected_kind
+
+
+def test_editor_bridge_example_check_script_exits_zero():
+    result = subprocess.run(
+        ["bash", "scripts/check-editor-bridge-examples.sh"],
+        cwd=REPO_ROOT,
+        env={
+            "PYTHONPATH": str(REPO_ROOT / "src"),
+            "PATH": os.environ.get("PATH", ""),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "editor bridge examples ok" in result.stdout
+
+
+def test_contract_doc_mentions_checked_examples():
+    text = CONTRACT_DOC.read_text(encoding="utf-8")
+    assert "docs/examples/editor-bridge" in text
+    assert "pre-stable contract examples" in text
+    assert "not a stable ABI/API" in text


### PR DESCRIPTION
## Model used and why

GPT-5.5 xhigh path for this batch because it locks down an editor-facing contract surface and example compatibility. Spark was not used.

## Examples added

- `docs/examples/editor-bridge/problems-check-ok.example.json`
- `docs/examples/editor-bridge/problems-check-missing-endmodule.example.json`
- `docs/examples/editor-bridge/problems-xsim-mixed.example.json`
- `docs/examples/editor-bridge/index-modules.example.json`
- `docs/examples/editor-bridge/declarations.example.json`
- `docs/examples/editor-bridge/locate-module.example.json`
- `docs/examples/editor-bridge/locate-package.example.json`
- `docs/examples/editor-bridge/locate-interface.example.json`

The module locate example uses `fixtures/modules/simple_module.sv` so the sample remains unambiguous; the full fixture directory intentionally contains duplicate `simple_mod` modules for ambiguity tests.

## Drift check behavior

Added `scripts/check-editor-bridge-examples.sh`. It selects `python` or `python3`, sets `PYTHONPATH=src`, runs each editor-facing JSON command, parses JSON with the Python standard library, and compares normalized payloads against the checked examples. Mismatches print a unified diff and fail non-zero.

## Tests added

Added `tests/test_editor_bridge_examples.py` to verify:

- every checked example is valid JSON
- expected top-level `kind` values are present
- the drift check script exits 0
- the editor bridge contract doc references the checked examples

CI now runs the drift check, and `scripts/editor-bridge-smoke.sh` invokes it as part of the local editor bridge smoke path.

## Validation commands run

- `python3 -m pytest tests/test_editor_bridge_examples.py tests/test_editor_bridge_contract.py -q` -> 13 passed
- `python3 -m pytest -q` -> 164 passed
- `bash scripts/editor-bridge-smoke.sh` -> passed
- `bash scripts/check-editor-bridge-examples.sh` -> passed, 8 checked
- `PYTHONPATH=src python3 -m pccx_ide_cli declarations fixtures/modules --format json` -> passed
- `PYTHONPATH=src python3 -m pccx_ide_cli locate fixtures/modules pkg_defs --kind package --format json` -> passed
- `PYTHONPATH=src python3 -m pccx_ide_cli locate fixtures/modules bus_if --kind interface --format json` -> passed
- `git diff --check` -> passed

## Non-claims

- No LSP server or editor extension was added.
- No VS Code or JetBrains implementation claim.
- No stable ABI/API claim; examples are pre-stable contract guidance.
- No real xsim, Vivado, or hardware execution claim.

## FPGA repo untouched confirmation

The excluded FPGA repository path was not entered, read, edited, or used.

## Token-saving / compact handoff note

This batch only adds checked JSON examples, a small drift script, focused pytest coverage, a tiny contract doc note, and CI/smoke hooks. It is intended as the compact handoff point before real editor adapter work.
