### PR TITLE
feat: add experimental VS Code adapter prototype

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,3 +192,5 @@ jobs:
         run: bash scripts/editor-bridge-smoke.sh
       - name: editor bridge example drift check
         run: bash scripts/check-editor-bridge-examples.sh
+      - name: VS Code adapter prototype smoke
+        run: bash scripts/vscode-adapter-smoke.sh

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -68,6 +68,16 @@ The module locate example uses the single-file fixture so the sample is
 unambiguous; the full fixture directory intentionally contains duplicate
 module names for ambiguity tests.
 
+## Experimental Adapter Prototype
+
+`editors/vscode-prototype` contains a local VS Code-style adapter
+prototype that consumes the checked JSON examples and translates them
+into diagnostic and navigation records.  It is not a VS Code extension,
+is not published, does not implement LSP, and does not make the JSON
+shape a stable ABI/API.  The prototype documents the 1-based CLI
+position to 0-based editor position conversion expected by editor
+adapters.
+
 ## Data Movement
 
 The intended data path is explicit:

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -1,0 +1,41 @@
+# VS Code Prototype Adapter
+
+This directory is an experimental local prototype for translating the
+pre-stable editor bridge JSON examples into VS Code-style data records.
+
+It is not a VS Code extension, is not published to the marketplace, does
+not implement LSP, and does not define a stable ABI/API.  It consumes the
+checked examples under `docs/examples/editor-bridge` so the adapter layer
+can be tested without a VS Code GUI, npm install, Vivado, xsim, or hardware.
+
+## Data Mapping
+
+Problem payloads become diagnostic-like records:
+
+- `error` -> `Error`
+- `warning` -> `Warning`
+- `info` or unknown severities -> `Information`
+- CLI 1-based `line` / `column` values become 0-based
+  `range.start.line` / `range.start.character`
+- missing locations safely fall back to line `0`, character `0`
+
+Declaration and locate payloads become navigation items that preserve
+`name`, `kind`, `file`, `line`, and `column`, with additional 0-based
+position fields for editor consumers.
+
+## Local Smoke
+
+```bash
+node editors/vscode-prototype/test/adapter.test.mjs
+bash scripts/vscode-adapter-smoke.sh
+```
+
+The adapter can also print translated examples:
+
+```bash
+node editors/vscode-prototype/src/adapter.mjs diagnostics \
+  docs/examples/editor-bridge/problems-xsim-mixed.example.json
+
+node editors/vscode-prototype/src/adapter.mjs navigation \
+  docs/examples/editor-bridge/declarations.example.json
+```

--- a/editors/vscode-prototype/src/adapter.mjs
+++ b/editors/vscode-prototype/src/adapter.mjs
@@ -1,0 +1,118 @@
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_SOURCE = "pccx_ide_cli";
+
+export function severityToVsCode(severity) {
+  const normalized = String(severity ?? "").toLowerCase();
+  if (normalized === "error") {
+    return "Error";
+  }
+  if (normalized === "warning") {
+    return "Warning";
+  }
+  return "Information";
+}
+
+export function toZeroBasedPosition(value) {
+  return Number.isInteger(value) && value > 0 ? value - 1 : 0;
+}
+
+function oneBasedOrNull(value) {
+  return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function stringOrEmpty(value) {
+  return value == null ? "" : String(value);
+}
+
+export function problemToDiagnostic(problem, payload = {}) {
+  const startLine = toZeroBasedPosition(problem.line);
+  const startCharacter = toZeroBasedPosition(problem.column);
+  const diagnostic = {
+    file: stringOrEmpty(problem.file ?? payload.source),
+    range: {
+      start: {
+        line: startLine,
+        character: startCharacter,
+      },
+      end: {
+        line: startLine,
+        character: startCharacter + 1,
+      },
+    },
+    severity: severityToVsCode(problem.severity),
+    message: stringOrEmpty(problem.message),
+    source: stringOrEmpty(problem.source_kind ?? payload.source_kind ?? DEFAULT_SOURCE),
+  };
+
+  if (problem.code != null) {
+    diagnostic.code = String(problem.code);
+  }
+  if (problem.raw != null) {
+    diagnostic.raw = String(problem.raw);
+  }
+
+  return diagnostic;
+}
+
+export function problemsPayloadToDiagnostics(payload) {
+  const problems = Array.isArray(payload.problems) ? payload.problems : [];
+  return problems.map((problem) => problemToDiagnostic(problem, payload));
+}
+
+export function declarationToNavigationItem(declaration) {
+  return {
+    name: stringOrEmpty(declaration.name),
+    kind: stringOrEmpty(declaration.kind),
+    file: stringOrEmpty(declaration.file),
+    line: oneBasedOrNull(declaration.line),
+    column: oneBasedOrNull(declaration.column),
+    zero_based_line: toZeroBasedPosition(declaration.line),
+    zero_based_column: toZeroBasedPosition(declaration.column),
+  };
+}
+
+export function declarationsPayloadToNavigationItems(payload) {
+  const declarations = Array.isArray(payload.declarations) ? payload.declarations : [];
+  return declarations.map(declarationToNavigationItem);
+}
+
+export function locatePayloadToNavigationItems(payload) {
+  const matches = Array.isArray(payload.matches) ? payload.matches : [];
+  return matches.map(declarationToNavigationItem);
+}
+
+export function payloadToNavigationItems(payload) {
+  if (Array.isArray(payload.declarations)) {
+    return declarationsPayloadToNavigationItems(payload);
+  }
+  return locatePayloadToNavigationItems(payload);
+}
+
+export async function readJsonPayload(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+async function main(argv) {
+  const [mode, jsonPath] = argv;
+  if (!["diagnostics", "navigation"].includes(mode) || !jsonPath) {
+    process.stderr.write(
+      "usage: node editors/vscode-prototype/src/adapter.mjs " +
+        "diagnostics|navigation <editor-bridge-json>\n",
+    );
+    return 2;
+  }
+
+  const payload = await readJsonPayload(jsonPath);
+  const output = mode === "diagnostics"
+    ? problemsPayloadToDiagnostics(payload)
+    : payloadToNavigationItems(payload);
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+  return 0;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const exitCode = await main(process.argv.slice(2));
+  process.exitCode = exitCode;
+}

--- a/editors/vscode-prototype/test/adapter.test.mjs
+++ b/editors/vscode-prototype/test/adapter.test.mjs
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  declarationToNavigationItem,
+  declarationsPayloadToNavigationItems,
+  locatePayloadToNavigationItems,
+  problemsPayloadToDiagnostics,
+  readJsonPayload,
+  severityToVsCode,
+} from "../src/adapter.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const EXAMPLES = resolve(ROOT, "docs/examples/editor-bridge");
+
+async function example(name) {
+  return readJsonPayload(resolve(EXAMPLES, name));
+}
+
+async function testDiagnosticsFromProblems() {
+  const payload = await example("problems-check-missing-endmodule.example.json");
+  const diagnostics = problemsPayloadToDiagnostics(payload);
+
+  assert.equal(diagnostics.length, 1);
+  assert.deepEqual(diagnostics[0], {
+    file: "fixtures/missing_endmodule.sv",
+    range: {
+      start: { line: 0, character: 0 },
+      end: { line: 0, character: 1 },
+    },
+    severity: "Error",
+    message: "`module` declared but no matching `endmodule` found",
+    source: "check",
+    code: "PCCX-SCAFFOLD-003",
+  });
+}
+
+async function testDiagnosticsFromXsimLog() {
+  const payload = await example("problems-xsim-mixed.example.json");
+  const diagnostics = problemsPayloadToDiagnostics(payload);
+
+  assert.equal(diagnostics.length, 5);
+  assert.deepEqual(
+    diagnostics.map((diagnostic) => diagnostic.severity),
+    ["Error", "Information", "Warning", "Error", "Warning"],
+  );
+
+  const fileDiagnostic = diagnostics.find((diagnostic) => diagnostic.file === "src/warn.sv");
+  assert.ok(fileDiagnostic);
+  assert.equal(fileDiagnostic.range.start.line, 6);
+  assert.equal(fileDiagnostic.range.start.character, 4);
+  assert.equal(fileDiagnostic.code, undefined);
+
+  const noLocationDiagnostic = diagnostics[0];
+  assert.equal(noLocationDiagnostic.file, "fixtures/xsim/mixed.log");
+  assert.equal(noLocationDiagnostic.range.start.line, 0);
+  assert.equal(noLocationDiagnostic.range.start.character, 0);
+}
+
+async function testDeclarationNavigation() {
+  const payload = await example("declarations.example.json");
+  const items = declarationsPayloadToNavigationItems(payload);
+
+  assert.ok(items.length > 0);
+  assert.ok(items.some((item) => item.kind === "module" && item.name === "simple_mod"));
+  assert.ok(items.some((item) => item.kind === "package" && item.name === "pkg_defs"));
+  assert.ok(items.some((item) => item.kind === "interface" && item.name === "bus_if"));
+
+  const pkg = items.find((item) => item.kind === "package" && item.name === "pkg_defs");
+  assert.ok(pkg);
+  assert.equal(pkg.file, "fixtures/modules/package_defs.sv");
+  assert.equal(pkg.line, 1);
+  assert.equal(pkg.column, 1);
+  assert.equal(pkg.zero_based_line, 0);
+  assert.equal(pkg.zero_based_column, 0);
+}
+
+async function testLocateNavigation() {
+  for (const [filename, expectedKind, expectedName] of [
+    ["locate-module.example.json", "module", "simple_mod"],
+    ["locate-package.example.json", "package", "pkg_defs"],
+    ["locate-interface.example.json", "interface", "bus_if"],
+  ]) {
+    const items = locatePayloadToNavigationItems(await example(filename));
+    assert.equal(items.length, 1);
+    assert.equal(items[0].kind, expectedKind);
+    assert.equal(items[0].name, expectedName);
+    assert.equal(items[0].line, 1);
+    assert.equal(items[0].zero_based_line, 0);
+  }
+}
+
+function testFallbacks() {
+  assert.equal(severityToVsCode("notice"), "Information");
+  assert.deepEqual(
+    declarationToNavigationItem({ name: "loose", kind: "module", file: "loose.sv" }),
+    {
+      name: "loose",
+      kind: "module",
+      file: "loose.sv",
+      line: null,
+      column: null,
+      zero_based_line: 0,
+      zero_based_column: 0,
+    },
+  );
+}
+
+await testDiagnosticsFromProblems();
+await testDiagnosticsFromXsimLog();
+await testDeclarationNavigation();
+await testLocateNavigation();
+testFallbacks();
+
+console.log("vscode adapter prototype tests ok");

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "error: node is required for the VS Code adapter prototype smoke" >&2
+  exit 127
+fi
+
+node editors/vscode-prototype/test/adapter.test.mjs
+node editors/vscode-prototype/src/adapter.mjs diagnostics \
+  docs/examples/editor-bridge/problems-xsim-mixed.example.json \
+  | node -e "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{const d=JSON.parse(s);if(!Array.isArray(d)||d.length===0)process.exit(1);})"
+node editors/vscode-prototype/src/adapter.mjs navigation \
+  docs/examples/editor-bridge/declarations.example.json \
+  | node -e "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{const d=JSON.parse(s);if(!Array.isArray(d)||!d.some(x=>x.kind==='package'))process.exit(1);})"
+
+echo "vscode adapter prototype smoke ok"


### PR DESCRIPTION
## Model used and why

GPT-5.5 xhigh was used because this batch defines the first VS Code-style adapter boundary on top of the existing editor bridge contract. Spark was not used.

## Adapter scope

Adds an experimental local scaffold under `editors/vscode-prototype/`. It consumes checked editor bridge JSON examples and translates them into VS Code-style diagnostic and navigation records. It does not call the CLI, does not require VS Code, and does not install npm dependencies.

## Translation behavior

- Problem payloads map to diagnostic-like records with `file`, `range`, `severity`, `code`, `message`, and `source`.
- Declaration and locate payloads map to navigation items with `name`, `kind`, `file`, `line`, `column`, and 0-based position fields.
- CLI 1-based line/column values convert to 0-based editor positions.
- `error` maps to `Error`, `warning` maps to `Warning`, and `info`/unknown severities map to `Information`.
- Missing optional locations fall back safely to 0-based line/character 0.

## Tests / smoke added

- `editors/vscode-prototype/test/adapter.test.mjs` covers checked JSON examples, severity mapping, 1-based to 0-based conversion, navigation mapping, and missing optional positions.
- `scripts/vscode-adapter-smoke.sh` runs the adapter test and direct translation smoke commands.
- CI now runs the VS Code adapter prototype smoke.

## Validation commands run

```bash
python3 -m pytest -q
bash scripts/editor-bridge-smoke.sh
bash scripts/check-editor-bridge-examples.sh
node editors/vscode-prototype/test/adapter.test.mjs
bash scripts/vscode-adapter-smoke.sh
git diff --check
```

Also ran the lightweight claim-scan equivalent locally.

## Non-claims

- No LSP implementation.
- No published VS Code extension or marketplace package.
- No stable ABI/API claim.
- No real xsim, Vivado, or hardware claim.
- No pccx-lab code changes.

## FPGA repo untouched

Confirmed: the excluded FPGA repository path was not entered, read, edited, or used.

## Token-saving / compact handoff note

This is intentionally a small local prototype: examples in, adapter records out, smoke-tested without GUI/editor dependencies.