### PR TITLE
feat: add live CLI runner for VS Code prototype

### DIFF
--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -71,12 +71,12 @@ module names for ambiguity tests.
 ## Experimental Adapter Prototype
 
 `editors/vscode-prototype` contains a local VS Code-style adapter
-prototype that consumes the checked JSON examples and translates them
-into diagnostic and navigation records.  It is not a VS Code extension,
-is not published, does not implement LSP, and does not make the JSON
-shape a stable ABI/API.  The prototype documents the 1-based CLI
-position to 0-based editor position conversion expected by editor
-adapters.
+prototype that consumes the checked JSON examples or limited live
+`pccx_ide_cli` JSON flows and translates them into diagnostic and
+navigation records.  It is not a VS Code extension, is not published,
+does not implement LSP, and does not make the JSON shape a stable
+ABI/API.  The prototype documents the 1-based CLI position to 0-based
+editor position conversion expected by editor adapters.
 
 ## Data Movement
 

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -1,12 +1,13 @@
 # VS Code Prototype Adapter
 
-This directory is an experimental local prototype for translating the
-pre-stable editor bridge JSON examples into VS Code-style data records.
+This directory is an experimental local prototype for translating
+pre-stable editor bridge JSON into VS Code-style data records.
 
 It is not a VS Code extension, is not published to the marketplace, does
-not implement LSP, and does not define a stable ABI/API.  It consumes the
-checked examples under `docs/examples/editor-bridge` so the adapter layer
-can be tested without a VS Code GUI, npm install, Vivado, xsim, or hardware.
+not implement LSP, and does not define a stable ABI/API.  It can consume
+the checked examples under `docs/examples/editor-bridge` and can also run
+limited live `pccx_ide_cli` JSON flows from this source tree.  Both paths
+are tested without a VS Code GUI, npm install, Vivado, xsim, or hardware.
 
 ## Data Mapping
 
@@ -23,10 +24,28 @@ Declaration and locate payloads become navigation items that preserve
 `name`, `kind`, `file`, `line`, and `column`, with additional 0-based
 position fields for editor consumers.
 
+## Live CLI Runner
+
+`src/cli-runner.mjs` is the only subprocess layer.  It uses Node built-ins,
+prefers `python` and falls back to `python3`, sets `PYTHONPATH=src`, runs
+from the repository root, and passes arguments as arrays instead of shell
+strings.  It only exposes helpers for known `pccx_ide_cli` JSON flows:
+
+- `problems from-check <file> --format json`
+- `problems from-xsim-log <log> --format json`
+- `declarations <path> --format json`
+- `locate <path> <name> --kind <kind> --format json`
+
+`src/live-adapter.mjs` calls those known flows and translates successful
+JSON payloads through the same adapter functions used by the checked
+example path.  Failures return structured `ok`, `exitCode`, `stdout`,
+`stderr`, and `error` fields for callers to surface.
+
 ## Local Smoke
 
 ```bash
 node editors/vscode-prototype/test/adapter.test.mjs
+node editors/vscode-prototype/test/cli-runner.test.mjs
 bash scripts/vscode-adapter-smoke.sh
 ```
 

--- a/editors/vscode-prototype/src/cli-runner.mjs
+++ b/editors/vscode-prototype/src/cli-runner.mjs
@@ -1,0 +1,138 @@
+import { execFile } from "node:child_process";
+import { dirname, delimiter, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const LOCATE_KINDS = new Set(["module", "package", "interface", "any"]);
+
+function captureExec(command, args, options) {
+  return new Promise((resolveResult) => {
+    execFile(
+      command,
+      args,
+      {
+        cwd: options.cwd,
+        encoding: "utf8",
+        env: options.env,
+        maxBuffer: 1024 * 1024,
+      },
+      (error, stdout, stderr) => {
+        if (error && typeof error.code !== "number") {
+          resolveResult({
+            ok: false,
+            exitCode: null,
+            stdout: stdout ?? "",
+            stderr: stderr ?? "",
+            error: error.message,
+          });
+          return;
+        }
+
+        const exitCode = error && typeof error.code === "number" ? error.code : 0;
+        resolveResult({
+          ok: exitCode === 0,
+          exitCode,
+          stdout: stdout ?? "",
+          stderr: stderr ?? "",
+        });
+      },
+    );
+  });
+}
+
+async function commandExists(command, cwd, env) {
+  const result = await captureExec(command, ["--version"], { cwd, env });
+  return result.exitCode === 0;
+}
+
+async function findPython(cwd, env) {
+  if (await commandExists("python", cwd, env)) {
+    return "python";
+  }
+  if (await commandExists("python3", cwd, env)) {
+    return "python3";
+  }
+  return null;
+}
+
+function cliEnv(repoRoot, baseEnv) {
+  const env = { ...baseEnv };
+  const srcPath = join(repoRoot, "src");
+  env.PYTHONPATH = env.PYTHONPATH ? `${srcPath}${delimiter}${env.PYTHONPATH}` : srcPath;
+  return env;
+}
+
+function structuredError(message) {
+  return {
+    ok: false,
+    exitCode: null,
+    stdout: "",
+    stderr: "",
+    error: message,
+  };
+}
+
+async function runKnownJsonFlow(args, options = {}) {
+  const repoRoot = options.repoRoot ? resolve(options.repoRoot) : ROOT;
+  const env = cliEnv(repoRoot, { ...process.env, ...(options.env ?? {}) });
+  const python = await findPython(repoRoot, env);
+
+  if (!python) {
+    return structuredError("python or python3 is required to run pccx_ide_cli");
+  }
+
+  return withParsedJson(await captureExec(
+    python,
+    ["-m", "pccx_ide_cli", ...args],
+    { cwd: repoRoot, env },
+  ));
+}
+
+export function repoRoot() {
+  return ROOT;
+}
+
+export function withParsedJson(result) {
+  const parsed = { ...result };
+  if (parsed.stdout.trim()) {
+    try {
+      parsed.json = JSON.parse(parsed.stdout);
+    } catch (error) {
+      parsed.ok = false;
+      parsed.error = `failed to parse JSON stdout: ${error.message}`;
+    }
+  }
+  return parsed;
+}
+
+export function runProblemsFromCheckPayload(filePath, options = {}) {
+  return runKnownJsonFlow(
+    ["problems", "from-check", filePath, "--format", "json"],
+    options,
+  );
+}
+
+export function runProblemsFromXsimLogPayload(logPath, options = {}) {
+  return runKnownJsonFlow(
+    ["problems", "from-xsim-log", logPath, "--format", "json"],
+    options,
+  );
+}
+
+export function runDeclarationsPayload(path, options = {}) {
+  return runKnownJsonFlow(
+    ["declarations", path, "--format", "json"],
+    options,
+  );
+}
+
+export function runLocateDeclarationPayload(path, name, kind = "module", options = {}) {
+  if (!LOCATE_KINDS.has(kind)) {
+    return Promise.resolve(structuredError(`unsupported locate kind: ${kind}`));
+  }
+
+  return runKnownJsonFlow(
+    ["locate", path, name, "--kind", kind, "--format", "json"],
+    options,
+  );
+}

--- a/editors/vscode-prototype/src/live-adapter.mjs
+++ b/editors/vscode-prototype/src/live-adapter.mjs
@@ -1,0 +1,50 @@
+import {
+  declarationsPayloadToNavigationItems,
+  locatePayloadToNavigationItems,
+  problemsPayloadToDiagnostics,
+} from "./adapter.mjs";
+import {
+  runDeclarationsPayload,
+  runLocateDeclarationPayload,
+  runProblemsFromCheckPayload,
+  runProblemsFromXsimLogPayload,
+} from "./cli-runner.mjs";
+
+function withDiagnostics(result) {
+  return {
+    ...result,
+    diagnostics: result.json ? problemsPayloadToDiagnostics(result.json) : [],
+  };
+}
+
+function withDeclarationNavigation(result) {
+  return {
+    ...result,
+    navigationItems: result.json ? declarationsPayloadToNavigationItems(result.json) : [],
+  };
+}
+
+function withLocateNavigation(result) {
+  return {
+    ...result,
+    navigationItems: result.json ? locatePayloadToNavigationItems(result.json) : [],
+  };
+}
+
+export async function getProblemsFromCheck(filePath, options = {}) {
+  return withDiagnostics(await runProblemsFromCheckPayload(filePath, options));
+}
+
+export async function getProblemsFromXsimLog(logPath, options = {}) {
+  return withDiagnostics(await runProblemsFromXsimLogPayload(logPath, options));
+}
+
+export async function getDeclarations(path, options = {}) {
+  return withDeclarationNavigation(await runDeclarationsPayload(path, options));
+}
+
+export async function locateDeclaration(path, name, kind = "module", options = {}) {
+  return withLocateNavigation(
+    await runLocateDeclarationPayload(path, name, kind, options),
+  );
+}

--- a/editors/vscode-prototype/test/cli-runner.test.mjs
+++ b/editors/vscode-prototype/test/cli-runner.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+
+import { withParsedJson } from "../src/cli-runner.mjs";
+import {
+  getDeclarations,
+  getProblemsFromCheck,
+  getProblemsFromXsimLog,
+  locateDeclaration,
+} from "../src/live-adapter.mjs";
+
+async function testLiveProblemsFromCheckOk() {
+  const result = await getProblemsFromCheck("fixtures/ok_module.sv");
+  assert.equal(result.ok, true, result.stderr || result.error);
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.json.kind, "editor-problems");
+  assert.deepEqual(result.diagnostics, []);
+}
+
+async function testLiveProblemsFromCheckMissingEndmodule() {
+  const result = await getProblemsFromCheck("fixtures/missing_endmodule.sv");
+  assert.equal(result.ok, true, result.stderr || result.error);
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.diagnostics.length, 1);
+  assert.equal(result.diagnostics[0].severity, "Error");
+  assert.equal(result.diagnostics[0].range.start.line, 0);
+  assert.equal(result.diagnostics[0].range.start.character, 0);
+}
+
+async function testLiveXsimMixedLog() {
+  const result = await getProblemsFromXsimLog("fixtures/xsim/mixed.log");
+  assert.equal(result.ok, true, result.stderr || result.error);
+  assert.equal(result.json.source_kind, "xsim-log");
+  assert.equal(result.diagnostics.length, 5);
+  assert.ok(result.diagnostics.some((diagnostic) => diagnostic.code === "VRFC 10-1234"));
+}
+
+async function testLiveDeclarations() {
+  const result = await getDeclarations("fixtures/modules");
+  assert.equal(result.ok, true, result.stderr || result.error);
+  assert.equal(result.json.kind, "declarations");
+
+  const seen = new Set(result.navigationItems.map((item) => `${item.kind}:${item.name}`));
+  assert.ok(seen.has("module:simple_mod"));
+  assert.ok(seen.has("package:pkg_defs"));
+  assert.ok(seen.has("interface:bus_if"));
+}
+
+async function testLiveLocatePackageAndInterface() {
+  const pkg = await locateDeclaration("fixtures/modules", "pkg_defs", "package");
+  assert.equal(pkg.ok, true, pkg.stderr || pkg.error);
+  assert.equal(pkg.navigationItems.length, 1);
+  assert.equal(pkg.navigationItems[0].kind, "package");
+  assert.equal(pkg.navigationItems[0].zero_based_line, 0);
+
+  const intf = await locateDeclaration("fixtures/modules", "bus_if", "interface");
+  assert.equal(intf.ok, true, intf.stderr || intf.error);
+  assert.equal(intf.navigationItems.length, 1);
+  assert.equal(intf.navigationItems[0].kind, "interface");
+  assert.equal(intf.navigationItems[0].zero_based_column, 0);
+}
+
+async function testMissingPathReturnsStructuredFailure() {
+  const result = await getProblemsFromCheck("fixtures/does_not_exist.sv");
+  assert.equal(result.ok, false);
+  assert.equal(result.exitCode, 2);
+  assert.match(result.stderr, /does not exist/);
+  assert.deepEqual(result.diagnostics, []);
+}
+
+async function testJsonParseFailureReturnsStructuredFailure() {
+  const result = withParsedJson({
+    ok: true,
+    exitCode: 0,
+    stdout: "not json\n",
+    stderr: "",
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.exitCode, 0);
+  assert.match(result.error, /failed to parse JSON stdout/);
+}
+
+await testLiveProblemsFromCheckOk();
+await testLiveProblemsFromCheckMissingEndmodule();
+await testLiveXsimMixedLog();
+await testLiveDeclarations();
+await testLiveLocatePackageAndInterface();
+await testMissingPathReturnsStructuredFailure();
+await testJsonParseFailureReturnsStructuredFailure();
+
+console.log("vscode live cli runner tests ok");

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -10,6 +10,7 @@ if ! command -v node >/dev/null 2>&1; then
 fi
 
 node editors/vscode-prototype/test/adapter.test.mjs
+node editors/vscode-prototype/test/cli-runner.test.mjs
 node editors/vscode-prototype/src/adapter.mjs diagnostics \
   docs/examples/editor-bridge/problems-xsim-mixed.example.json \
   | node -e "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{const d=JSON.parse(s);if(!Array.isArray(d)||d.length===0)process.exit(1);})"


### PR DESCRIPTION
## Model used and why

GPT-5.5 xhigh was used because this batch extends the experimental adapter boundary with subprocess behavior and live CLI flow handling. Spark was not used.

## Live CLI runner scope

Adds `editors/vscode-prototype/src/cli-runner.mjs` as the isolated subprocess layer for known `pccx_ide_cli` JSON flows only:

- `problems from-check <file> --format json`
- `problems from-xsim-log <log> --format json`
- `declarations <path> --format json`
- `locate <path> <name> --kind <kind> --format json`

## Subprocess safety notes

- Uses Node built-ins only.
- Prefers `python`, falls back to `python3`.
- Sets `PYTHONPATH=src` and runs from the repo root.
- Uses `execFile` with argument arrays, not shell strings.
- Does not expose arbitrary command execution.
- Captures `ok`, `exitCode`, `stdout`, `stderr`, parsed `json`, and controlled parse errors.

## Adapter live-flow behavior

Adds `editors/vscode-prototype/src/live-adapter.mjs`, which calls the known live JSON flows and translates payloads through the existing adapter functions into VS Code-style diagnostics and navigation items. The checked-example adapter path remains intact.

## Tests / smoke added

- `editors/vscode-prototype/test/cli-runner.test.mjs` covers live check, xsim-log, declarations, locate package/interface, missing path structured failure, and JSON parse failure handling.
- `scripts/vscode-adapter-smoke.sh` now runs both the example adapter test and live CLI runner test.

## Validation commands run

```bash
python3 -m pytest -q
bash scripts/editor-bridge-smoke.sh
bash scripts/check-editor-bridge-examples.sh
node editors/vscode-prototype/test/adapter.test.mjs
node editors/vscode-prototype/test/cli-runner.test.mjs
bash scripts/vscode-adapter-smoke.sh
git diff --check
```

Also ran the lightweight claim-scan equivalent locally.

## Non-claims

- No LSP implementation.
- No published VS Code extension or marketplace package.
- No stable ABI/API claim.
- No real xsim, Vivado, or hardware claim.
- No pccx-lab code changes.

## FPGA repo untouched

Confirmed: the excluded FPGA repository path was not entered, read, edited, or used.

## Token-saving / compact handoff note

This remains a small local prototype: synthetic fixture path -> known live CLI subprocess -> JSON -> adapter records, with no GUI/editor dependency and no npm install.