### PR TITLE
feat: add VS Code prototype command facade

### DIFF
--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -73,10 +73,12 @@ module names for ambiguity tests.
 `editors/vscode-prototype` contains a local VS Code-style adapter
 prototype that consumes the checked JSON examples or limited live
 `pccx_ide_cli` JSON flows and translates them into diagnostic and
-navigation records.  It is not a VS Code extension, is not published,
-does not implement LSP, and does not make the JSON shape a stable
-ABI/API.  The prototype documents the 1-based CLI position to 0-based
-editor position conversion expected by editor adapters.
+navigation records.  Its local command facade requires explicit
+checked-example or live mode selection and emits VS Code-style JSON for
+known flows only.  It is not a VS Code extension, is not published, does
+not implement LSP, and does not make the JSON shape a stable ABI/API.
+The prototype documents the 1-based CLI position to 0-based editor
+position conversion expected by editor adapters.
 
 ## Data Movement
 

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -41,11 +41,38 @@ JSON payloads through the same adapter functions used by the checked
 example path.  Failures return structured `ok`, `exitCode`, `stdout`,
 `stderr`, and `error` fields for callers to surface.
 
+## Command Facade
+
+`bin/pccx-vscode-prototype.mjs` is a local command facade for the same
+prototype translation layer.  It emits JSON only and requires callers to
+choose an explicit mode:
+
+```bash
+node editors/vscode-prototype/bin/pccx-vscode-prototype.mjs diagnostics \
+  --mode example --source check-missing-endmodule
+
+node editors/vscode-prototype/bin/pccx-vscode-prototype.mjs diagnostics \
+  --mode live --from-check fixtures/missing_endmodule.sv
+
+node editors/vscode-prototype/bin/pccx-vscode-prototype.mjs navigation \
+  --mode example --source declarations
+
+node editors/vscode-prototype/bin/pccx-vscode-prototype.mjs navigation \
+  --mode live --locate fixtures/modules pkg_defs --kind package
+```
+
+The facade supports checked-example mode and live CLI mode for known
+flows only.  It does not silently fall back between modes, does not use
+shell interpolation, and does not accept arbitrary command strings.
+This is still not a VS Code extension package, not LSP, not a stable
+ABI/API, and not a marketplace publishing path.
+
 ## Local Smoke
 
 ```bash
 node editors/vscode-prototype/test/adapter.test.mjs
 node editors/vscode-prototype/test/cli-runner.test.mjs
+node editors/vscode-prototype/test/facade.test.mjs
 bash scripts/vscode-adapter-smoke.sh
 ```
 

--- a/editors/vscode-prototype/bin/pccx-vscode-prototype.mjs
+++ b/editors/vscode-prototype/bin/pccx-vscode-prototype.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+import { dirname, resolve } from "node:path";
+import { pathToFileURL, fileURLToPath } from "node:url";
+
+import {
+  payloadToNavigationItems,
+  problemsPayloadToDiagnostics,
+  readJsonPayload,
+} from "../src/adapter.mjs";
+import {
+  getDeclarations,
+  getProblemsFromCheck,
+  getProblemsFromXsimLog,
+  locateDeclaration,
+} from "../src/live-adapter.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const EXAMPLES = resolve(ROOT, "docs/examples/editor-bridge");
+const LOCATE_KINDS = new Set(["module", "package", "interface", "any"]);
+
+const DIAGNOSTIC_EXAMPLES = new Map([
+  ["check-ok", "problems-check-ok.example.json"],
+  ["check-missing-endmodule", "problems-check-missing-endmodule.example.json"],
+  ["xsim-mixed", "problems-xsim-mixed.example.json"],
+]);
+
+const NAVIGATION_EXAMPLES = new Map([
+  ["declarations", "declarations.example.json"],
+  ["locate-module", "locate-module.example.json"],
+  ["locate-package", "locate-package.example.json"],
+  ["locate-interface", "locate-interface.example.json"],
+]);
+
+function usage() {
+  return [
+    "usage:",
+    "  node editors/vscode-prototype/bin/pccx-vscode-prototype.mjs diagnostics --mode example --source check-missing-endmodule",
+    "  node editors/vscode-prototype/bin/pccx-vscode-prototype.mjs diagnostics --mode live --from-check <sv-file>",
+    "  node editors/vscode-prototype/bin/pccx-vscode-prototype.mjs diagnostics --mode live --from-xsim-log <log-file>",
+    "  node editors/vscode-prototype/bin/pccx-vscode-prototype.mjs navigation --mode example --source declarations",
+    "  node editors/vscode-prototype/bin/pccx-vscode-prototype.mjs navigation --mode live --declarations <path>",
+    "  node editors/vscode-prototype/bin/pccx-vscode-prototype.mjs navigation --mode live --locate <path> <name> --kind <kind>",
+  ].join("\n");
+}
+
+function fail(message, exitCode = 2) {
+  process.stderr.write(`error: ${message}\n${usage()}\n`);
+  return exitCode;
+}
+
+function takeValue(argv, index, option) {
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${option} requires a value`);
+  }
+  return value;
+}
+
+function parseOptions(argv) {
+  const options = {};
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--mode") {
+      options.mode = takeValue(argv, i, arg);
+      i += 1;
+    } else if (arg === "--source") {
+      options.source = takeValue(argv, i, arg);
+      i += 1;
+    } else if (arg === "--from-check") {
+      options.fromCheck = takeValue(argv, i, arg);
+      i += 1;
+    } else if (arg === "--from-xsim-log") {
+      options.fromXsimLog = takeValue(argv, i, arg);
+      i += 1;
+    } else if (arg === "--declarations") {
+      options.declarations = takeValue(argv, i, arg);
+      i += 1;
+    } else if (arg === "--locate") {
+      const path = takeValue(argv, i, arg);
+      const name = argv[i + 2];
+      if (!name || name.startsWith("--")) {
+        throw new Error("--locate requires a path and name");
+      }
+      options.locate = { path, name };
+      i += 2;
+    } else if (arg === "--kind") {
+      options.kind = takeValue(argv, i, arg);
+      i += 1;
+    } else if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else if (arg.startsWith("--")) {
+      throw new Error(`unknown option: ${arg}`);
+    } else {
+      throw new Error(`unexpected argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function exactlyOne(values) {
+  return values.filter(Boolean).length === 1;
+}
+
+function hasAny(values) {
+  return values.some(Boolean);
+}
+
+function emitJson(payload) {
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function outputPayload(kind, mode, records) {
+  if (kind === "diagnostics") {
+    return {
+      tool: "pccx-vscode-prototype",
+      kind: "vscode-diagnostics",
+      mode,
+      diagnostics: records,
+    };
+  }
+
+  return {
+    tool: "pccx-vscode-prototype",
+    kind: "vscode-navigation",
+    mode,
+    items: records,
+  };
+}
+
+async function readExample(kind, source) {
+  const examples = kind === "diagnostics" ? DIAGNOSTIC_EXAMPLES : NAVIGATION_EXAMPLES;
+  const filename = examples.get(source);
+  if (!filename) {
+    throw new Error(`unknown ${kind} example source: ${source}`);
+  }
+  return readJsonPayload(resolve(EXAMPLES, filename));
+}
+
+function writeLiveFailure(result, label) {
+  process.stderr.write(`error: ${label} failed\n`);
+  if (result.stderr) {
+    process.stderr.write(result.stderr.endsWith("\n") ? result.stderr : `${result.stderr}\n`);
+  }
+  if (result.error) {
+    process.stderr.write(`${result.error}\n`);
+  }
+}
+
+async function runDiagnostics(options) {
+  if (options.mode === "example") {
+    if (
+      !options.source ||
+      hasAny([options.fromCheck, options.fromXsimLog, options.declarations, options.locate, options.kind])
+    ) {
+      return fail("example diagnostics requires only --source");
+    }
+    const payload = await readExample("diagnostics", options.source);
+    emitJson(outputPayload("diagnostics", "example", problemsPayloadToDiagnostics(payload)));
+    return 0;
+  }
+
+  if (
+    !exactlyOne([options.fromCheck, options.fromXsimLog]) ||
+    hasAny([options.source, options.declarations, options.locate, options.kind])
+  ) {
+    return fail("live diagnostics requires exactly one of --from-check or --from-xsim-log");
+  }
+
+  const result = options.fromCheck
+    ? await getProblemsFromCheck(options.fromCheck)
+    : await getProblemsFromXsimLog(options.fromXsimLog);
+
+  if (!result.ok) {
+    writeLiveFailure(result, "live diagnostics");
+    return result.exitCode || 1;
+  }
+
+  emitJson(outputPayload("diagnostics", "live", result.diagnostics));
+  return 0;
+}
+
+async function runNavigation(options) {
+  if (options.mode === "example") {
+    if (
+      !options.source ||
+      hasAny([options.declarations, options.locate, options.fromCheck, options.fromXsimLog, options.kind])
+    ) {
+      return fail("example navigation requires only --source");
+    }
+    const payload = await readExample("navigation", options.source);
+    emitJson(outputPayload("navigation", "example", payloadToNavigationItems(payload)));
+    return 0;
+  }
+
+  if (
+    !exactlyOne([options.declarations, options.locate]) ||
+    hasAny([options.source, options.fromCheck, options.fromXsimLog])
+  ) {
+    return fail("live navigation requires exactly one of --declarations or --locate");
+  }
+  if (options.declarations && options.kind) {
+    return fail("live navigation --kind is only valid with --locate");
+  }
+
+  if (options.kind && !LOCATE_KINDS.has(options.kind)) {
+    return fail(`unsupported locate kind: ${options.kind}`);
+  }
+
+  const result = options.declarations
+    ? await getDeclarations(options.declarations)
+    : await locateDeclaration(options.locate.path, options.locate.name, options.kind ?? "module");
+
+  if (!result.ok) {
+    writeLiveFailure(result, "live navigation");
+    return result.exitCode || 1;
+  }
+
+  emitJson(outputPayload("navigation", "live", result.navigationItems));
+  return 0;
+}
+
+async function main(argv) {
+  const [command, ...rest] = argv;
+  if (!["diagnostics", "navigation"].includes(command)) {
+    return fail("expected diagnostics or navigation command");
+  }
+
+  let options;
+  try {
+    options = parseOptions(rest);
+  } catch (error) {
+    return fail(error.message);
+  }
+
+  if (options.help) {
+    process.stdout.write(`${usage()}\n`);
+    return 0;
+  }
+  if (!["example", "live"].includes(options.mode)) {
+    return fail("expected explicit --mode example or --mode live");
+  }
+
+  try {
+    return command === "diagnostics"
+      ? await runDiagnostics(options)
+      : await runNavigation(options);
+  } catch (error) {
+    process.stderr.write(`error: ${error.message}\n`);
+    return 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exitCode = await main(process.argv.slice(2));
+}
+
+export { main };

--- a/editors/vscode-prototype/test/facade.test.mjs
+++ b/editors/vscode-prototype/test/facade.test.mjs
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const FACADE = resolve(ROOT, "editors/vscode-prototype/bin/pccx-vscode-prototype.mjs");
+
+function runFacade(args) {
+  return new Promise((resolveResult) => {
+    execFile(
+      "node",
+      [FACADE, ...args],
+      {
+        cwd: ROOT,
+        encoding: "utf8",
+        maxBuffer: 1024 * 1024,
+      },
+      (error, stdout, stderr) => {
+        resolveResult({
+          exitCode: error && typeof error.code === "number" ? error.code : 0,
+          stdout: stdout ?? "",
+          stderr: stderr ?? "",
+        });
+      },
+    );
+  });
+}
+
+async function runSuccess(args) {
+  const result = await runFacade(args);
+  assert.equal(result.exitCode, 0, result.stderr);
+  return JSON.parse(result.stdout);
+}
+
+async function testDiagnosticsExampleMode() {
+  const output = await runSuccess([
+    "diagnostics",
+    "--mode",
+    "example",
+    "--source",
+    "check-missing-endmodule",
+  ]);
+
+  assert.equal(output.tool, "pccx-vscode-prototype");
+  assert.equal(output.kind, "vscode-diagnostics");
+  assert.equal(output.mode, "example");
+  assert.equal(output.diagnostics.length, 1);
+  assert.equal(output.diagnostics[0].severity, "Error");
+}
+
+async function testDiagnosticsLiveFromCheck() {
+  const output = await runSuccess([
+    "diagnostics",
+    "--mode",
+    "live",
+    "--from-check",
+    "fixtures/missing_endmodule.sv",
+  ]);
+
+  assert.equal(output.kind, "vscode-diagnostics");
+  assert.equal(output.mode, "live");
+  assert.equal(output.diagnostics.length, 1);
+  assert.equal(output.diagnostics[0].range.start.line, 0);
+}
+
+async function testDiagnosticsLiveFromXsimLog() {
+  const output = await runSuccess([
+    "diagnostics",
+    "--mode",
+    "live",
+    "--from-xsim-log",
+    "fixtures/xsim/mixed.log",
+  ]);
+
+  assert.equal(output.kind, "vscode-diagnostics");
+  assert.equal(output.mode, "live");
+  assert.ok(output.diagnostics.some((diagnostic) => diagnostic.code === "VRFC 10-1234"));
+}
+
+async function testNavigationExampleMode() {
+  const output = await runSuccess([
+    "navigation",
+    "--mode",
+    "example",
+    "--source",
+    "declarations",
+  ]);
+
+  assert.equal(output.kind, "vscode-navigation");
+  assert.equal(output.mode, "example");
+  assert.ok(output.items.some((item) => item.kind === "package" && item.name === "pkg_defs"));
+}
+
+async function testNavigationLiveDeclarations() {
+  const output = await runSuccess([
+    "navigation",
+    "--mode",
+    "live",
+    "--declarations",
+    "fixtures/modules",
+  ]);
+
+  assert.equal(output.kind, "vscode-navigation");
+  assert.equal(output.mode, "live");
+  assert.ok(output.items.some((item) => item.kind === "module" && item.name === "simple_mod"));
+  assert.ok(output.items.some((item) => item.kind === "interface" && item.name === "bus_if"));
+}
+
+async function testNavigationLiveLocatePackage() {
+  const output = await runSuccess([
+    "navigation",
+    "--mode",
+    "live",
+    "--locate",
+    "fixtures/modules",
+    "pkg_defs",
+    "--kind",
+    "package",
+  ]);
+
+  assert.equal(output.kind, "vscode-navigation");
+  assert.equal(output.mode, "live");
+  assert.equal(output.items.length, 1);
+  assert.equal(output.items[0].kind, "package");
+  assert.equal(output.items[0].name, "pkg_defs");
+}
+
+async function testInvalidModeFails() {
+  const result = await runFacade([
+    "diagnostics",
+    "--mode",
+    "automatic",
+    "--source",
+    "check-ok",
+  ]);
+  assert.notEqual(result.exitCode, 0);
+  assert.match(result.stderr, /explicit --mode example or --mode live/);
+}
+
+async function testMissingRequiredArgsFail() {
+  const result = await runFacade([
+    "navigation",
+    "--mode",
+    "live",
+    "--locate",
+    "fixtures/modules",
+  ]);
+  assert.notEqual(result.exitCode, 0);
+  assert.match(result.stderr, /--locate requires a path and name/);
+}
+
+async function testNoArbitraryCommandOption() {
+  const result = await runFacade([
+    "diagnostics",
+    "--mode",
+    "live",
+    "--command",
+    "python -c 'print(1)'",
+  ]);
+  assert.notEqual(result.exitCode, 0);
+  assert.match(result.stderr, /unknown option: --command/);
+}
+
+async function testWrongFlowOptionFails() {
+  const result = await runFacade([
+    "navigation",
+    "--mode",
+    "live",
+    "--declarations",
+    "fixtures/modules",
+    "--kind",
+    "package",
+  ]);
+  assert.notEqual(result.exitCode, 0);
+  assert.match(result.stderr, /--kind is only valid with --locate/);
+}
+
+await testDiagnosticsExampleMode();
+await testDiagnosticsLiveFromCheck();
+await testDiagnosticsLiveFromXsimLog();
+await testNavigationExampleMode();
+await testNavigationLiveDeclarations();
+await testNavigationLiveLocatePackage();
+await testInvalidModeFails();
+await testMissingRequiredArgsFail();
+await testNoArbitraryCommandOption();
+await testWrongFlowOptionFails();
+
+console.log("vscode prototype facade tests ok");

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -11,11 +11,18 @@ fi
 
 node editors/vscode-prototype/test/adapter.test.mjs
 node editors/vscode-prototype/test/cli-runner.test.mjs
+node editors/vscode-prototype/test/facade.test.mjs
 node editors/vscode-prototype/src/adapter.mjs diagnostics \
   docs/examples/editor-bridge/problems-xsim-mixed.example.json \
   | node -e "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{const d=JSON.parse(s);if(!Array.isArray(d)||d.length===0)process.exit(1);})"
 node editors/vscode-prototype/src/adapter.mjs navigation \
   docs/examples/editor-bridge/declarations.example.json \
   | node -e "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{const d=JSON.parse(s);if(!Array.isArray(d)||!d.some(x=>x.kind==='package'))process.exit(1);})"
+node editors/vscode-prototype/bin/pccx-vscode-prototype.mjs diagnostics \
+  --mode example --source check-missing-endmodule \
+  | node -e "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{const d=JSON.parse(s);if(d.kind!=='vscode-diagnostics'||d.mode!=='example'||d.diagnostics.length===0)process.exit(1);})"
+node editors/vscode-prototype/bin/pccx-vscode-prototype.mjs navigation \
+  --mode example --source declarations \
+  | node -e "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{const d=JSON.parse(s);if(d.kind!=='vscode-navigation'||!d.items.some(x=>x.kind==='interface'))process.exit(1);})"
 
 echo "vscode adapter prototype smoke ok"


### PR DESCRIPTION
## Summary

Adds a local experimental VS Code prototype command facade:

- `editors/vscode-prototype/bin/pccx-vscode-prototype.mjs`
- explicit checked-example mode
- explicit live CLI mode for known adapter flows
- JSON-only success output for VS Code-style diagnostics/navigation records
- no silent fallback between modes

## Model Used And Why

Used GPT-5.5 xhigh because this defines a local adapter command boundary and touches subprocess-facing behavior. Spark was not used.

## Facade Scope

The facade is a local prototype entry point only. It wraps the existing adapter translator and live adapter helpers under `editors/vscode-prototype`.

Supported example flows:

- diagnostics: `check-ok`, `check-missing-endmodule`, `xsim-mixed`
- navigation: `declarations`, `locate-module`, `locate-package`, `locate-interface`

Supported live flows:

- diagnostics from `problems from-check`
- diagnostics from `problems from-xsim-log`
- navigation from `declarations`
- navigation from `locate --kind module|package|interface|any`

## Mode Behavior

Callers must pass `--mode example` or `--mode live`. The facade does not silently fall back between checked examples and live CLI execution. Successful output shape is:

- `kind: vscode-diagnostics` with `diagnostics[]`
- `kind: vscode-navigation` with `items[]`

## Subprocess Safety Notes

The facade does not accept arbitrary command strings. Live execution stays inside the existing live adapter and `cli-runner.mjs`, which uses Node built-ins and `execFile` argument arrays, not shell interpolation.

## Tests / Smoke Added

- Added `editors/vscode-prototype/test/facade.test.mjs`
- Updated `scripts/vscode-adapter-smoke.sh` to run facade tests and direct facade smoke commands
- Updated prototype README and editor bridge contract wording

## Validation Commands Run

- `python3 -m pytest -q`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `node editors/vscode-prototype/test/adapter.test.mjs`
- `node editors/vscode-prototype/test/cli-runner.test.mjs`
- `node editors/vscode-prototype/test/facade.test.mjs`
- `bash scripts/vscode-adapter-smoke.sh`
- `node editors/vscode-prototype/bin/pccx-vscode-prototype.mjs diagnostics --mode example --source check-missing-endmodule`
- `node editors/vscode-prototype/bin/pccx-vscode-prototype.mjs navigation --mode example --source declarations`
- `git diff --check`

## Non-Claims

- No LSP implementation
- No published VS Code extension
- No VS Code dependency
- No stable ABI/API claim
- No real xsim/Vivado/hardware claim
- No npm dependency install

## FPGA Repo Confirmation

The FPGA repo path was not entered, read, edited, or used.

## Token-Saving / Compact Handoff Note

Kept changes bounded to the prototype facade, tests, smoke script, and short docs updates. Final report will include `COMPACT_HANDOFF`.