### PR TITLE
feat: add minimal VS Code extension scaffold

### DIFF
--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -3,12 +3,13 @@
 ## Status
 
 This is an early, pre-stable CLI contract for external editor bridges.
-It is not an LSP server, a VS Code extension, a JetBrains plugin, or a
-stable ABI/API.  Treat all JSON shapes as subject to change while the
-`pccx-lab` boundary and IDE surface mature.
+It is not an LSP server, a published VS Code extension, a JetBrains
+plugin, or a stable ABI/API.  Treat all JSON shapes as subject to change
+while the `pccx-lab` boundary and IDE surface mature.
 
 ## Intended Consumers
 
+- The experimental local VS Code extension scaffold.
 - Future VS Code extension work.
 - Future JetBrains or other editor bridges.
 - Local scripts that need deterministic JSON.
@@ -75,8 +76,14 @@ prototype that consumes the checked JSON examples or limited live
 `pccx_ide_cli` JSON flows and translates them into diagnostic and
 navigation records.  Its local command facade requires explicit
 checked-example or live mode selection and emits VS Code-style JSON for
-known flows only.  It is not a VS Code extension, is not published, does
-not implement LSP, and does not make the JSON shape a stable ABI/API.
+known flows only.
+
+The same directory now includes an experimental local VS Code extension
+scaffold.  Its command handlers are thin wrappers around the local facade:
+VS Code command -> extension wrapper -> facade -> JSON ->
+diagnostics/navigation records.  The scaffold is not published, is not
+marketplace-ready, has no LSP, and is not a stable ABI/API.  Current
+coverage is static/smoke tests, not VS Code GUI integration tests.
 The prototype documents the 1-based CLI position to 0-based editor
 position conversion expected by editor adapters.
 
@@ -89,6 +96,12 @@ SystemVerilog source or existing log file
   -> pccx_ide_cli command
   -> JSON output
   -> editor problem list or navigation entry
+
+VS Code command
+  -> experimental extension wrapper
+  -> local pccx-vscode-prototype facade
+  -> JSON output
+  -> diagnostics/navigation records
 ```
 
 `problems` converts local diagnostics and log records into editor-friendly
@@ -100,7 +113,8 @@ declaration records.  `declarations` exports those records directly, and
 
 - Scanner-based scaffolds, not full SystemVerilog parsing.
 - No LSP server in this repository today.
-- No editor extension is implemented here.
+- No published or marketplace-ready editor extension is implemented here.
+- No VS Code GUI integration test in this repository today.
 - No stable schema yet.
 - No real xsim or Vivado execution.
 - No hardware access or hardware correctness claim.

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -1,13 +1,15 @@
 # VS Code Prototype Adapter
 
 This directory is an experimental local prototype for translating
-pre-stable editor bridge JSON into VS Code-style data records.
+pre-stable editor bridge JSON into VS Code-style data records and for
+hosting a minimal local VS Code extension package scaffold.
 
-It is not a VS Code extension, is not published to the marketplace, does
-not implement LSP, and does not define a stable ABI/API.  It can consume
-the checked examples under `docs/examples/editor-bridge` and can also run
-limited live `pccx_ide_cli` JSON flows from this source tree.  Both paths
-are tested without a VS Code GUI, npm install, Vivado, xsim, or hardware.
+The extension scaffold is not published, is not marketplace-ready, has no
+LSP, and does not define a stable ABI/API.  It can consume the checked
+examples under `docs/examples/editor-bridge` and can also run limited
+live JSON flows from this source tree through the local command facade.
+The current tests are static/smoke tests, not VS Code GUI integration
+tests, and they run without npm install, Vivado, xsim, or hardware.
 
 ## Data Mapping
 
@@ -64,8 +66,30 @@ node editors/vscode-prototype/bin/pccx-vscode-prototype.mjs navigation \
 The facade supports checked-example mode and live CLI mode for known
 flows only.  It does not silently fall back between modes, does not use
 shell interpolation, and does not accept arbitrary command strings.
-This is still not a VS Code extension package, not LSP, not a stable
-ABI/API, and not a marketplace publishing path.
+
+## Extension Package Scaffold
+
+`package.json` and `src/extension.mjs` define a minimal experimental local
+VS Code extension scaffold.  The package is `private`, has version
+`0.0.0`, and intentionally has no publisher, npm dependencies, VS Code
+test runner, bundler, `vsce`, or marketplace publishing script.
+
+The contributed commands are:
+
+- `pccxSystemVerilog.showDiagnosticsExample`
+- `pccxSystemVerilog.showNavigationExample`
+- `pccxSystemVerilog.runDiagnosticsLive`
+- `pccxSystemVerilog.runNavigationLive`
+
+The command handlers are thin wrappers around the local facade.  They
+build known facade argument arrays and run
+`bin/pccx-vscode-prototype.mjs`; they do not call `pccx_ide_cli`
+directly, do not invoke raw shell command strings, and do not accept
+arbitrary command execution.  Live paths are still prototype-only and are
+passed to known facade flows as argument-array entries.
+
+This scaffold is not LSP, not a full IDE replacement, not a stable
+ABI/API, and not a marketplace-ready or published extension.
 
 ## Local Smoke
 
@@ -73,6 +97,8 @@ ABI/API, and not a marketplace publishing path.
 node editors/vscode-prototype/test/adapter.test.mjs
 node editors/vscode-prototype/test/cli-runner.test.mjs
 node editors/vscode-prototype/test/facade.test.mjs
+node editors/vscode-prototype/test/extension-manifest.test.mjs
+node editors/vscode-prototype/test/extension-entrypoint.test.mjs
 bash scripts/vscode-adapter-smoke.sh
 ```
 

--- a/editors/vscode-prototype/package.json
+++ b/editors/vscode-prototype/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "pccx-systemverilog-ide-prototype",
+  "displayName": "PCCX SystemVerilog IDE Prototype",
+  "description": "Experimental local VS Code extension scaffold for the PCCX SystemVerilog IDE prototype; not published and not marketplace-ready.",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/extension.mjs",
+  "engines": {
+    "vscode": "^1.90.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onCommand:pccxSystemVerilog.showDiagnosticsExample",
+    "onCommand:pccxSystemVerilog.showNavigationExample",
+    "onCommand:pccxSystemVerilog.runDiagnosticsLive",
+    "onCommand:pccxSystemVerilog.runNavigationLive"
+  ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "pccxSystemVerilog.showDiagnosticsExample",
+        "title": "PCCX SystemVerilog: Show Diagnostics Example"
+      },
+      {
+        "command": "pccxSystemVerilog.showNavigationExample",
+        "title": "PCCX SystemVerilog: Show Navigation Example"
+      },
+      {
+        "command": "pccxSystemVerilog.runDiagnosticsLive",
+        "title": "PCCX SystemVerilog: Run Diagnostics Live"
+      },
+      {
+        "command": "pccxSystemVerilog.runNavigationLive",
+        "title": "PCCX SystemVerilog: Run Navigation Live"
+      }
+    ]
+  }
+}

--- a/editors/vscode-prototype/src/extension.mjs
+++ b/editors/vscode-prototype/src/extension.mjs
@@ -1,0 +1,251 @@
+import { execFile } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const EXTENSION_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const DEFAULT_FACADE_PATH = resolve(EXTENSION_ROOT, "bin/pccx-vscode-prototype.mjs");
+const OUTPUT_CHANNEL_NAME = "PCCX SystemVerilog IDE Prototype";
+
+export const COMMAND_IDS = Object.freeze([
+  "pccxSystemVerilog.showDiagnosticsExample",
+  "pccxSystemVerilog.showNavigationExample",
+  "pccxSystemVerilog.runDiagnosticsLive",
+  "pccxSystemVerilog.runNavigationLive",
+]);
+
+const COMMAND_CONFIGS = Object.freeze({
+  "pccxSystemVerilog.showDiagnosticsExample": Object.freeze({
+    facadeKind: "diagnostics",
+    mode: "example",
+    source: "check-missing-endmodule",
+  }),
+  "pccxSystemVerilog.showNavigationExample": Object.freeze({
+    facadeKind: "navigation",
+    mode: "example",
+    source: "declarations",
+  }),
+  "pccxSystemVerilog.runDiagnosticsLive": Object.freeze({
+    facadeKind: "diagnostics",
+    mode: "live",
+    pathOption: "--from-check",
+    requiredPathField: "targetFile",
+  }),
+  "pccxSystemVerilog.runNavigationLive": Object.freeze({
+    facadeKind: "navigation",
+    mode: "live",
+    pathOption: "--declarations",
+    requiredPathField: "targetPath",
+  }),
+});
+
+function commandConfig(commandId) {
+  const config = COMMAND_CONFIGS[commandId];
+  if (!config) {
+    throw new Error(`unknown PCCX SystemVerilog command: ${commandId}`);
+  }
+  return config;
+}
+
+function requiredString(value, label) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label} is required`);
+  }
+  return value;
+}
+
+function pathFromCommandInput(input) {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input?.fsPath) {
+    return input.fsPath;
+  }
+  if (input?.uri?.fsPath) {
+    return input.uri.fsPath;
+  }
+  return null;
+}
+
+export function buildFacadeArgsForCommand(commandId, options = {}) {
+  const config = commandConfig(commandId);
+  const args = [config.facadeKind, "--mode", config.mode];
+
+  if (config.mode === "example") {
+    return [...args, "--source", config.source];
+  }
+
+  return [
+    ...args,
+    config.pathOption,
+    requiredString(options[config.requiredPathField], config.requiredPathField),
+  ];
+}
+
+export function buildFacadeInvocationForCommand(commandId, options = {}, runtime = {}) {
+  return {
+    executable: runtime.nodeExecutable ?? process.execPath,
+    args: [
+      runtime.facadePath ?? DEFAULT_FACADE_PATH,
+      ...buildFacadeArgsForCommand(commandId, options),
+    ],
+    shell: false,
+  };
+}
+
+function captureExecFile(executable, args, options = {}) {
+  const execFileFn = options.execFile ?? execFile;
+  return new Promise((resolveResult) => {
+    execFileFn(
+      executable,
+      args,
+      {
+        cwd: options.cwd ?? EXTENSION_ROOT,
+        encoding: "utf8",
+        maxBuffer: 1024 * 1024,
+      },
+      (error, stdout, stderr) => {
+        const exitCode = error ? (typeof error.code === "number" ? error.code : null) : 0;
+        resolveResult({
+          ok: exitCode === 0 && !error,
+          exitCode,
+          stdout: stdout ?? "",
+          stderr: stderr ?? "",
+          error: error && typeof error.code !== "number" ? error.message : undefined,
+        });
+      },
+    );
+  });
+}
+
+export async function runFacadeInvocation(invocation, runtime = {}) {
+  const result = await captureExecFile(invocation.executable, invocation.args, runtime);
+  if (result.ok && result.stdout.trim()) {
+    try {
+      result.json = JSON.parse(result.stdout);
+    } catch (error) {
+      result.ok = false;
+      result.error = `failed to parse facade JSON stdout: ${error.message}`;
+    }
+  }
+  return result;
+}
+
+export function resolveCommandRequest(commandId, input, vscodeApi) {
+  commandConfig(commandId);
+  const explicitPath = pathFromCommandInput(input);
+
+  if (commandId === "pccxSystemVerilog.runDiagnosticsLive") {
+    return {
+      targetFile: explicitPath ?? vscodeApi?.window?.activeTextEditor?.document?.uri?.fsPath,
+    };
+  }
+
+  if (commandId === "pccxSystemVerilog.runNavigationLive") {
+    return {
+      targetPath: explicitPath ?? vscodeApi?.workspace?.workspaceFolders?.[0]?.uri?.fsPath,
+    };
+  }
+
+  return {};
+}
+
+export async function runFacadeForCommand(commandId, options = {}, runtime = {}) {
+  const invocation = buildFacadeInvocationForCommand(commandId, options, runtime);
+  return runFacadeInvocation(invocation, runtime);
+}
+
+export function summarizeFacadeResult(commandId, result) {
+  if (!result.ok) {
+    return `PCCX facade command failed for ${commandId}`;
+  }
+
+  if (Array.isArray(result.json?.diagnostics)) {
+    return `PCCX facade returned ${result.json.diagnostics.length} diagnostics`;
+  }
+  if (Array.isArray(result.json?.items)) {
+    return `PCCX facade returned ${result.json.items.length} navigation items`;
+  }
+  return "PCCX facade command completed";
+}
+
+function appendFacadeOutput(outputChannel, commandId, result) {
+  if (!outputChannel?.appendLine) {
+    return;
+  }
+
+  outputChannel.appendLine(`[${commandId}]`);
+  if (result.stdout) {
+    outputChannel.appendLine(result.stdout.trimEnd());
+  }
+  if (result.stderr) {
+    outputChannel.appendLine(result.stderr.trimEnd());
+  }
+  if (result.error) {
+    outputChannel.appendLine(result.error);
+  }
+  outputChannel.show?.(true);
+}
+
+export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
+  commandConfig(commandId);
+  return async (input) => {
+    let result;
+    try {
+      const request = resolveCommandRequest(commandId, input, vscodeApi);
+      const run = runtime.runFacadeForCommand ?? runFacadeForCommand;
+      result = await run(commandId, request, runtime);
+    } catch (error) {
+      result = {
+        ok: false,
+        exitCode: null,
+        stdout: "",
+        stderr: "",
+        error: error.message,
+      };
+    }
+    appendFacadeOutput(runtime.outputChannel, commandId, result);
+
+    const message = summarizeFacadeResult(commandId, result);
+    if (result.ok) {
+      vscodeApi?.window?.showInformationMessage?.(message);
+    } else {
+      vscodeApi?.window?.showErrorMessage?.(message);
+    }
+    return result;
+  };
+}
+
+async function loadVscodeApi() {
+  try {
+    return await import("vscode");
+  } catch {
+    return null;
+  }
+}
+
+export async function activate(context, injectedVscodeApi = null, runtime = {}) {
+  const vscodeApi = injectedVscodeApi ?? await loadVscodeApi();
+  if (!vscodeApi?.commands?.registerCommand) {
+    return { registered: [] };
+  }
+
+  const outputChannel = vscodeApi.window?.createOutputChannel?.(OUTPUT_CHANNEL_NAME);
+  const commandRuntime = { ...runtime, outputChannel };
+  const registered = [];
+
+  for (const commandId of COMMAND_IDS) {
+    const disposable = vscodeApi.commands.registerCommand(
+      commandId,
+      createCommandHandler(commandId, vscodeApi, commandRuntime),
+    );
+    context?.subscriptions?.push?.(disposable);
+    registered.push(commandId);
+  }
+
+  if (outputChannel) {
+    context?.subscriptions?.push?.(outputChannel);
+  }
+  return { registered };
+}
+
+export function deactivate() {}

--- a/editors/vscode-prototype/test/extension-entrypoint.test.mjs
+++ b/editors/vscode-prototype/test/extension-entrypoint.test.mjs
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+
+import {
+  COMMAND_IDS,
+  activate,
+  buildFacadeArgsForCommand,
+  buildFacadeInvocationForCommand,
+  createCommandHandler,
+  deactivate,
+  resolveCommandRequest,
+} from "../src/extension.mjs";
+
+const EXPECTED_ARGS = new Map([
+  [
+    "pccxSystemVerilog.showDiagnosticsExample",
+    ["diagnostics", "--mode", "example", "--source", "check-missing-endmodule"],
+  ],
+  [
+    "pccxSystemVerilog.showNavigationExample",
+    ["navigation", "--mode", "example", "--source", "declarations"],
+  ],
+  [
+    "pccxSystemVerilog.runDiagnosticsLive",
+    ["diagnostics", "--mode", "live", "--from-check", "fixtures/missing_endmodule.sv"],
+  ],
+  [
+    "pccxSystemVerilog.runNavigationLive",
+    ["navigation", "--mode", "live", "--declarations", "fixtures/modules"],
+  ],
+]);
+
+function optionsFor(commandId) {
+  if (commandId === "pccxSystemVerilog.runDiagnosticsLive") {
+    return { targetFile: "fixtures/missing_endmodule.sv" };
+  }
+  if (commandId === "pccxSystemVerilog.runNavigationLive") {
+    return { targetPath: "fixtures/modules" };
+  }
+  return {};
+}
+
+function testKnownFacadeArgs() {
+  for (const commandId of COMMAND_IDS) {
+    assert.deepEqual(
+      buildFacadeArgsForCommand(commandId, optionsFor(commandId)),
+      EXPECTED_ARGS.get(commandId),
+    );
+  }
+}
+
+function testUnknownCommandsRejected() {
+  assert.throws(
+    () => buildFacadeArgsForCommand("pccxSystemVerilog.runArbitraryCommand"),
+    /unknown PCCX SystemVerilog command/,
+  );
+}
+
+function testLiveCommandsRequireExplicitPaths() {
+  assert.throws(
+    () => buildFacadeArgsForCommand("pccxSystemVerilog.runDiagnosticsLive"),
+    /targetFile is required/,
+  );
+  assert.throws(
+    () => buildFacadeArgsForCommand("pccxSystemVerilog.runNavigationLive"),
+    /targetPath is required/,
+  );
+}
+
+function testFacadeInvocationIsArgumentArray() {
+  const invocation = buildFacadeInvocationForCommand(
+    "pccxSystemVerilog.runDiagnosticsLive",
+    { targetFile: "fixtures/missing_endmodule.sv" },
+    { nodeExecutable: "node", facadePath: "editors/vscode-prototype/bin/pccx-vscode-prototype.mjs" },
+  );
+
+  assert.equal(invocation.executable, "node");
+  assert.equal(invocation.shell, false);
+  assert.ok(Array.isArray(invocation.args));
+  assert.deepEqual(invocation.args.slice(1), EXPECTED_ARGS.get("pccxSystemVerilog.runDiagnosticsLive"));
+  assert.doesNotMatch(invocation.args.join("\n"), /(?:&&|\|\||;|`|\$\()/);
+}
+
+function testResolveCommandRequestUsesVsCodeState() {
+  const vscodeApi = {
+    window: {
+      activeTextEditor: {
+        document: { uri: { fsPath: "active.sv" } },
+      },
+    },
+    workspace: {
+      workspaceFolders: [{ uri: { fsPath: "workspace-root" } }],
+    },
+  };
+
+  assert.deepEqual(
+    resolveCommandRequest("pccxSystemVerilog.runDiagnosticsLive", undefined, vscodeApi),
+    { targetFile: "active.sv" },
+  );
+  assert.deepEqual(
+    resolveCommandRequest("pccxSystemVerilog.runNavigationLive", undefined, vscodeApi),
+    { targetPath: "workspace-root" },
+  );
+  assert.deepEqual(
+    resolveCommandRequest("pccxSystemVerilog.runDiagnosticsLive", { fsPath: "explicit.sv" }, vscodeApi),
+    { targetFile: "explicit.sv" },
+  );
+}
+
+async function testEntrypointExportsAndActivation() {
+  assert.equal(typeof activate, "function");
+  assert.equal(typeof deactivate, "function");
+
+  const registered = new Map();
+  const subscriptions = [];
+  const outputLines = [];
+  const vscodeApi = {
+    commands: {
+      registerCommand(commandId, handler) {
+        registered.set(commandId, handler);
+        return { dispose() {} };
+      },
+    },
+    window: {
+      createOutputChannel() {
+        return {
+          appendLine(line) {
+            outputLines.push(line);
+          },
+          show() {},
+          dispose() {},
+        };
+      },
+      showInformationMessage() {},
+      showErrorMessage() {},
+    },
+  };
+
+  const activation = await activate(
+    { subscriptions },
+    vscodeApi,
+    {
+      async runFacadeForCommand(commandId) {
+        return {
+          ok: true,
+          exitCode: 0,
+          stdout: JSON.stringify({ kind: "vscode-diagnostics", diagnostics: [] }),
+          stderr: "",
+          json: { kind: "vscode-diagnostics", diagnostics: [] },
+          commandId,
+        };
+      },
+    },
+  );
+
+  assert.deepEqual(activation.registered, COMMAND_IDS);
+  assert.equal(registered.size, COMMAND_IDS.length);
+  assert.equal(subscriptions.length, COMMAND_IDS.length + 1);
+
+  const result = await registered.get("pccxSystemVerilog.showDiagnosticsExample")();
+  assert.equal(result.ok, true);
+  assert.ok(outputLines.some((line) => line.includes("pccxSystemVerilog.showDiagnosticsExample")));
+}
+
+async function testNoVsCodeRuntimeIsANoop() {
+  const activation = await activate({ subscriptions: [] }, { commands: null });
+  assert.deepEqual(activation.registered, []);
+}
+
+async function testCommandHandlerCanBeUsedWithoutRealVsCode() {
+  const handler = createCommandHandler(
+    "pccxSystemVerilog.showNavigationExample",
+    null,
+    {
+      async runFacadeForCommand(commandId) {
+        return {
+          ok: true,
+          exitCode: 0,
+          stdout: JSON.stringify({ kind: "vscode-navigation", items: [] }),
+          stderr: "",
+          json: { kind: "vscode-navigation", items: [] },
+          commandId,
+        };
+      },
+    },
+  );
+
+  const result = await handler();
+  assert.equal(result.ok, true);
+}
+
+testKnownFacadeArgs();
+testUnknownCommandsRejected();
+testLiveCommandsRequireExplicitPaths();
+testFacadeInvocationIsArgumentArray();
+testResolveCommandRequestUsesVsCodeState();
+await testEntrypointExportsAndActivation();
+await testNoVsCodeRuntimeIsANoop();
+await testCommandHandlerCanBeUsedWithoutRealVsCode();
+
+console.log("vscode extension entrypoint tests ok");

--- a/editors/vscode-prototype/test/extension-manifest.test.mjs
+++ b/editors/vscode-prototype/test/extension-manifest.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const EXTENSION_ROOT = resolve(ROOT, "editors/vscode-prototype");
+const COMMAND_IDS = [
+  "pccxSystemVerilog.showDiagnosticsExample",
+  "pccxSystemVerilog.showNavigationExample",
+  "pccxSystemVerilog.runDiagnosticsLive",
+  "pccxSystemVerilog.runNavigationLive",
+];
+
+async function readText(path) {
+  return readFile(path, "utf8");
+}
+
+async function readPackageJson() {
+  return JSON.parse(await readText(resolve(EXTENSION_ROOT, "package.json")));
+}
+
+function allManifestStrings(value, acc = []) {
+  if (typeof value === "string") {
+    acc.push(value);
+  } else if (Array.isArray(value)) {
+    for (const item of value) {
+      allManifestStrings(item, acc);
+    }
+  } else if (value && typeof value === "object") {
+    for (const item of Object.values(value)) {
+      allManifestStrings(item, acc);
+    }
+  }
+  return acc;
+}
+
+async function testPackageManifestShape() {
+  const manifest = await readPackageJson();
+
+  assert.equal(manifest.private, true);
+  assert.equal(manifest.name, "pccx-systemverilog-ide-prototype");
+  assert.equal(manifest.displayName, "PCCX SystemVerilog IDE Prototype");
+  assert.match(manifest.description, /experimental local VS Code extension scaffold/i);
+  assert.match(manifest.description, /not published/i);
+  assert.ok(manifest.engines?.vscode);
+  assert.equal(manifest.main, "./src/extension.mjs");
+}
+
+async function testNoMarketplacePublishingShape() {
+  const manifest = await readPackageJson();
+  const manifestStrings = allManifestStrings(manifest).join("\n");
+
+  assert.equal(Object.hasOwn(manifest, "publisher"), false);
+  assert.equal(Object.hasOwn(manifest, "galleryBanner"), false);
+  assert.doesNotMatch(manifestStrings, /\bvsce\b/i);
+  assert.equal(manifest.scripts?.publish, undefined);
+  assert.equal(manifest.scripts?.package, undefined);
+  assert.equal(manifest.dependencies, undefined);
+  assert.equal(manifest.devDependencies, undefined);
+}
+
+async function testCommandContributions() {
+  const manifest = await readPackageJson();
+  const contributedCommands = new Set(
+    manifest.contributes?.commands?.map((command) => command.command),
+  );
+  const activationEvents = new Set(manifest.activationEvents);
+
+  for (const commandId of COMMAND_IDS) {
+    assert.ok(contributedCommands.has(commandId), `${commandId} missing from contributes.commands`);
+    assert.ok(
+      activationEvents.has(`onCommand:${commandId}`),
+      `${commandId} missing activation event`,
+    );
+  }
+  assert.equal(contributedCommands.size, COMMAND_IDS.length);
+}
+
+async function testDocsKeepExperimentalScope() {
+  const readme = await readText(resolve(EXTENSION_ROOT, "README.md"));
+  const contract = await readText(resolve(ROOT, "docs/EDITOR_BRIDGE_CONTRACT.md"));
+  const combined = `${readme}\n${contract}`;
+
+  assert.match(combined, /experimental local VS Code extension scaffold/i);
+  assert.match(combined, /not published/i);
+  assert.match(combined, /not marketplace-ready/i);
+  assert.match(combined, /no LSP/i);
+  assert.match(combined, /not a stable ABI\/API/i);
+  assert.match(combined, /static\/smoke tests/i);
+}
+
+await testPackageManifestShape();
+await testNoMarketplacePublishingShape();
+await testCommandContributions();
+await testDocsKeepExperimentalScope();
+
+console.log("vscode extension manifest tests ok");

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -12,6 +12,8 @@ fi
 node editors/vscode-prototype/test/adapter.test.mjs
 node editors/vscode-prototype/test/cli-runner.test.mjs
 node editors/vscode-prototype/test/facade.test.mjs
+node editors/vscode-prototype/test/extension-manifest.test.mjs
+node editors/vscode-prototype/test/extension-entrypoint.test.mjs
 node editors/vscode-prototype/src/adapter.mjs diagnostics \
   docs/examples/editor-bridge/problems-xsim-mixed.example.json \
   | node -e "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{const d=JSON.parse(s);if(!Array.isArray(d)||d.length===0)process.exit(1);})"


### PR DESCRIPTION
## Summary
- Model used: GPT-5.5 xhigh requested for extension boundary, command shape, security policy, and merge readiness decisions.
- Spark usage: none.
- Scope: minimal private local VS Code extension package scaffold under `editors/vscode-prototype`.
- Command IDs: `pccxSystemVerilog.showDiagnosticsExample`, `pccxSystemVerilog.showNavigationExample`, `pccxSystemVerilog.runDiagnosticsLive`, `pccxSystemVerilog.runNavigationLive`.
- Facade boundary: activation helpers build known argument arrays for `bin/pccx-vscode-prototype.mjs`; the extension entry point does not call `pccx_ide_cli` directly and does not execute arbitrary shell command strings.
- Tests/smoke added: manifest/static tests, extension entrypoint tests, and updated `scripts/vscode-adapter-smoke.sh` coverage.
- Non-goals held: no LSP, no published extension, no marketplace packaging, no VS Code GUI tests, and no stable ABI/API claim.
- FPGA repo untouched: no reads, writes, git commands, PRs, issues, tags, or releases under `/home/hwkim/Desktop/github/pccxai/pccx-FPGA-NPU-LLM-kv260`.
- Token-saving / compact handoff note: used targeted reads, focused local validation, and will include COMPACT_HANDOFF in the final report.

## Validation
- `python3 -m pytest -q` -> 164 passed
- `bash scripts/editor-bridge-smoke.sh` -> passed
- `bash scripts/check-editor-bridge-examples.sh` -> passed
- `node editors/vscode-prototype/test/adapter.test.mjs` -> passed
- `node editors/vscode-prototype/test/cli-runner.test.mjs` -> passed
- `node editors/vscode-prototype/test/facade.test.mjs` -> passed
- `node editors/vscode-prototype/test/extension-manifest.test.mjs` -> passed
- `node editors/vscode-prototype/test/extension-entrypoint.test.mjs` -> passed
- `bash scripts/vscode-adapter-smoke.sh` -> passed
- `git diff --check` -> passed