### PR TITLE
feat: add VS Code prototype configuration scaffold

### DIFF
--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -80,10 +80,12 @@ known flows only.
 
 The same directory now includes an experimental local VS Code extension
 scaffold.  Its command handlers are thin wrappers around the local facade:
-VS Code command -> extension wrapper -> facade -> JSON ->
-diagnostics/navigation records.  The scaffold is not published, is not
-marketplace-ready, has no LSP, and is not a stable ABI/API.  Current
-coverage is static/smoke tests, not VS Code GUI integration tests.
+VS Code command -> prototype settings -> extension wrapper -> facade ->
+JSON -> diagnostics/navigation records.  The prototype settings are
+validated before command wiring and route only into known facade flows.
+The scaffold is not published, is not marketplace-ready, has no LSP, and
+is not a stable ABI/API.  Current coverage is static/smoke tests, not VS
+Code GUI integration tests.
 The prototype documents the 1-based CLI position to 0-based editor
 position conversion expected by editor adapters.
 
@@ -98,6 +100,7 @@ SystemVerilog source or existing log file
   -> editor problem list or navigation entry
 
 VS Code command
+  -> prototype settings
   -> experimental extension wrapper
   -> local pccx-vscode-prototype facade
   -> JSON output

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -29,6 +29,7 @@ position fields for editor consumers.
 ## Live CLI Runner
 
 `src/cli-runner.mjs` is the only subprocess layer.  It uses Node built-ins,
+honors the facade process `PCCX_IDE_PYTHON` executable when set, otherwise
 prefers `python` and falls back to `python3`, sets `PYTHONPATH=src`, runs
 from the repository root, and passes arguments as arrays instead of shell
 strings.  It only exposes helpers for known `pccx_ide_cli` JSON flows:
@@ -81,15 +82,32 @@ The contributed commands are:
 - `pccxSystemVerilog.runDiagnosticsLive`
 - `pccxSystemVerilog.runNavigationLive`
 
+The prototype-only settings are:
+
+- `pccxSystemVerilog.mode`, default `example`
+- `pccxSystemVerilog.pythonPath`, default `python3`
+- `pccxSystemVerilog.defaultSource`, default `fixtures/missing_endmodule.sv`
+- `pccxSystemVerilog.defaultLog`, default `fixtures/xsim/mixed.log`
+- `pccxSystemVerilog.defaultModule`, default `simple_mod`
+- `pccxSystemVerilog.defaultDeclarationKind`, default `module`
+
+The default mode is checked-example mode.  The explicit example commands
+always build checked-example facade arguments, and the explicit live
+commands always build known live facade arguments.  Live diagnostics uses
+`--from-check <defaultSource>`.  Live navigation uses
+`--locate fixtures/modules <defaultModule> --kind <defaultDeclarationKind>`.
+
 The command handlers are thin wrappers around the local facade.  They
-build known facade argument arrays and run
-`bin/pccx-vscode-prototype.mjs`; they do not call `pccx_ide_cli`
-directly, do not invoke raw shell command strings, and do not accept
-arbitrary command execution.  Live paths are still prototype-only and are
+normalize the prototype-only settings, build known facade argument arrays,
+and run `bin/pccx-vscode-prototype.mjs`; they do not call `pccx_ide_cli`
+directly from the extension entry point, do not invoke raw shell command
+strings, and do not accept arbitrary command execution.  Live mode calls
+only known facade flows.  Live paths are still prototype-only and are
 passed to known facade flows as argument-array entries.
 
 This scaffold is not LSP, not a full IDE replacement, not a stable
 ABI/API, and not a marketplace-ready or published extension.
+There are no VS Code GUI/integration tests yet.
 
 ## Local Smoke
 
@@ -98,6 +116,7 @@ node editors/vscode-prototype/test/adapter.test.mjs
 node editors/vscode-prototype/test/cli-runner.test.mjs
 node editors/vscode-prototype/test/facade.test.mjs
 node editors/vscode-prototype/test/extension-manifest.test.mjs
+node editors/vscode-prototype/test/extension-config.test.mjs
 node editors/vscode-prototype/test/extension-entrypoint.test.mjs
 bash scripts/vscode-adapter-smoke.sh
 ```

--- a/editors/vscode-prototype/package.json
+++ b/editors/vscode-prototype/package.json
@@ -36,6 +36,51 @@
         "command": "pccxSystemVerilog.runNavigationLive",
         "title": "PCCX SystemVerilog: Run Navigation Live"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "PCCX SystemVerilog IDE Prototype",
+      "properties": {
+        "pccxSystemVerilog.mode": {
+          "type": "string",
+          "enum": [
+            "example",
+            "live"
+          ],
+          "default": "example",
+          "description": "Experimental local prototype setting selecting checked-example mode or live CLI mode for prototype commands; not a stable API."
+        },
+        "pccxSystemVerilog.pythonPath": {
+          "type": "string",
+          "default": "python3",
+          "description": "Experimental local prototype Python executable used by the live CLI prototype path; not a stable API."
+        },
+        "pccxSystemVerilog.defaultSource": {
+          "type": "string",
+          "default": "fixtures/missing_endmodule.sv",
+          "description": "Experimental local prototype workspace-relative default SystemVerilog source used by live diagnostics; not a stable API."
+        },
+        "pccxSystemVerilog.defaultLog": {
+          "type": "string",
+          "default": "fixtures/xsim/mixed.log",
+          "description": "Experimental local prototype workspace-relative default synthetic xsim-style log used by live diagnostics; not a stable API."
+        },
+        "pccxSystemVerilog.defaultModule": {
+          "type": "string",
+          "default": "simple_mod",
+          "description": "Experimental local prototype default module name used by navigation examples; not a stable API."
+        },
+        "pccxSystemVerilog.defaultDeclarationKind": {
+          "type": "string",
+          "enum": [
+            "module",
+            "package",
+            "interface",
+            "any"
+          ],
+          "default": "module",
+          "description": "Experimental local prototype default declaration kind used by navigation; not a stable API."
+        }
+      }
+    }
   }
 }

--- a/editors/vscode-prototype/src/cli-runner.mjs
+++ b/editors/vscode-prototype/src/cli-runner.mjs
@@ -46,6 +46,9 @@ async function commandExists(command, cwd, env) {
 }
 
 async function findPython(cwd, env) {
+  if (env.PCCX_IDE_PYTHON) {
+    return env.PCCX_IDE_PYTHON;
+  }
   if (await commandExists("python", cwd, env)) {
     return "python";
   }

--- a/editors/vscode-prototype/src/config.mjs
+++ b/editors/vscode-prototype/src/config.mjs
@@ -1,0 +1,121 @@
+export const CONFIG_SECTION = "pccxSystemVerilog";
+
+export const CONFIG_KEYS = Object.freeze([
+  "mode",
+  "pythonPath",
+  "defaultSource",
+  "defaultLog",
+  "defaultModule",
+  "defaultDeclarationKind",
+]);
+
+export const COMMAND_IDS = Object.freeze([
+  "pccxSystemVerilog.showDiagnosticsExample",
+  "pccxSystemVerilog.showNavigationExample",
+  "pccxSystemVerilog.runDiagnosticsLive",
+  "pccxSystemVerilog.runNavigationLive",
+]);
+
+export const MODES = Object.freeze(["example", "live"]);
+export const DECLARATION_KINDS = Object.freeze(["module", "package", "interface", "any"]);
+
+const DEFAULT_CONFIG = Object.freeze({
+  mode: "example",
+  pythonPath: "python3",
+  defaultSource: "fixtures/missing_endmodule.sv",
+  defaultLog: "fixtures/xsim/mixed.log",
+  defaultModule: "simple_mod",
+  defaultDeclarationKind: "module",
+});
+
+const NAVIGATION_ROOT = "fixtures/modules";
+const SHELL_CONTROL_PATTERN = /(?:&&|\|\||;|`|\$\()/;
+
+function rawConfigValue(rawConfig, key) {
+  if (rawConfig && typeof rawConfig.get === "function") {
+    return rawConfig.get(key);
+  }
+  return rawConfig?.[key];
+}
+
+function stringSetting(rawConfig, key, fallback) {
+  const value = rawConfigValue(rawConfig, key);
+  if (value == null) {
+    return fallback;
+  }
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${CONFIG_SECTION}.${key} must be a non-empty string`);
+  }
+  if (value.includes("\0") || value.includes("\n") || value.includes("\r")) {
+    throw new Error(`${CONFIG_SECTION}.${key} must be a single-line string`);
+  }
+  if (SHELL_CONTROL_PATTERN.test(value)) {
+    throw new Error(`${CONFIG_SECTION}.${key} must not contain shell control syntax`);
+  }
+  return value;
+}
+
+function enumSetting(rawConfig, key, fallback, allowedValues) {
+  const value = stringSetting(rawConfig, key, fallback);
+  if (!allowedValues.includes(value)) {
+    throw new Error(
+      `${CONFIG_SECTION}.${key} must be one of: ${allowedValues.join(", ")}`,
+    );
+  }
+  return value;
+}
+
+export function defaultConfig() {
+  return { ...DEFAULT_CONFIG };
+}
+
+export function normalizeConfig(rawConfig = {}) {
+  return {
+    mode: enumSetting(rawConfig, "mode", DEFAULT_CONFIG.mode, MODES),
+    pythonPath: stringSetting(rawConfig, "pythonPath", DEFAULT_CONFIG.pythonPath),
+    defaultSource: stringSetting(rawConfig, "defaultSource", DEFAULT_CONFIG.defaultSource),
+    defaultLog: stringSetting(rawConfig, "defaultLog", DEFAULT_CONFIG.defaultLog),
+    defaultModule: stringSetting(rawConfig, "defaultModule", DEFAULT_CONFIG.defaultModule),
+    defaultDeclarationKind: enumSetting(
+      rawConfig,
+      "defaultDeclarationKind",
+      DEFAULT_CONFIG.defaultDeclarationKind,
+      DECLARATION_KINDS,
+    ),
+  };
+}
+
+export function buildFacadeArgsForCommand(commandId, rawConfig = {}) {
+  const config = normalizeConfig(rawConfig);
+
+  if (commandId === "pccxSystemVerilog.showDiagnosticsExample") {
+    return ["diagnostics", "--mode", "example", "--source", "check-missing-endmodule"];
+  }
+
+  if (commandId === "pccxSystemVerilog.showNavigationExample") {
+    return ["navigation", "--mode", "example", "--source", "declarations"];
+  }
+
+  if (commandId === "pccxSystemVerilog.runDiagnosticsLive") {
+    return ["diagnostics", "--mode", "live", "--from-check", config.defaultSource];
+  }
+
+  if (commandId === "pccxSystemVerilog.runNavigationLive") {
+    return [
+      "navigation",
+      "--mode",
+      "live",
+      "--locate",
+      NAVIGATION_ROOT,
+      config.defaultModule,
+      "--kind",
+      config.defaultDeclarationKind,
+    ];
+  }
+
+  throw new Error(`unknown PCCX SystemVerilog command: ${commandId}`);
+}
+
+export function isLiveFacadeArgs(args) {
+  return Array.isArray(args) && args[1] === "--mode" && args[2] === "live";
+}

--- a/editors/vscode-prototype/src/extension.mjs
+++ b/editors/vscode-prototype/src/extension.mjs
@@ -2,56 +2,26 @@ import { execFile } from "node:child_process";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  COMMAND_IDS,
+  CONFIG_KEYS,
+  CONFIG_SECTION,
+  buildFacadeArgsForCommand,
+  defaultConfig,
+  isLiveFacadeArgs,
+  normalizeConfig,
+} from "./config.mjs";
+
 const EXTENSION_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_FACADE_PATH = resolve(EXTENSION_ROOT, "bin/pccx-vscode-prototype.mjs");
 const OUTPUT_CHANNEL_NAME = "PCCX SystemVerilog IDE Prototype";
 
-export const COMMAND_IDS = Object.freeze([
-  "pccxSystemVerilog.showDiagnosticsExample",
-  "pccxSystemVerilog.showNavigationExample",
-  "pccxSystemVerilog.runDiagnosticsLive",
-  "pccxSystemVerilog.runNavigationLive",
-]);
-
-const COMMAND_CONFIGS = Object.freeze({
-  "pccxSystemVerilog.showDiagnosticsExample": Object.freeze({
-    facadeKind: "diagnostics",
-    mode: "example",
-    source: "check-missing-endmodule",
-  }),
-  "pccxSystemVerilog.showNavigationExample": Object.freeze({
-    facadeKind: "navigation",
-    mode: "example",
-    source: "declarations",
-  }),
-  "pccxSystemVerilog.runDiagnosticsLive": Object.freeze({
-    facadeKind: "diagnostics",
-    mode: "live",
-    pathOption: "--from-check",
-    requiredPathField: "targetFile",
-  }),
-  "pccxSystemVerilog.runNavigationLive": Object.freeze({
-    facadeKind: "navigation",
-    mode: "live",
-    pathOption: "--declarations",
-    requiredPathField: "targetPath",
-  }),
-});
-
-function commandConfig(commandId) {
-  const config = COMMAND_CONFIGS[commandId];
-  if (!config) {
-    throw new Error(`unknown PCCX SystemVerilog command: ${commandId}`);
-  }
-  return config;
-}
-
-function requiredString(value, label) {
-  if (typeof value !== "string" || value.length === 0) {
-    throw new Error(`${label} is required`);
-  }
-  return value;
-}
+export {
+  COMMAND_IDS,
+  buildFacadeArgsForCommand,
+  defaultConfig,
+  normalizeConfig,
+};
 
 function pathFromCommandInput(input) {
   if (typeof input === "string") {
@@ -66,29 +36,33 @@ function pathFromCommandInput(input) {
   return null;
 }
 
-export function buildFacadeArgsForCommand(commandId, options = {}) {
-  const config = commandConfig(commandId);
-  const args = [config.facadeKind, "--mode", config.mode];
-
-  if (config.mode === "example") {
-    return [...args, "--source", config.source];
-  }
-
-  return [
-    ...args,
-    config.pathOption,
-    requiredString(options[config.requiredPathField], config.requiredPathField),
-  ];
-}
-
 export function buildFacadeInvocationForCommand(commandId, options = {}, runtime = {}) {
-  return {
+  const config = normalizeConfig(options);
+  const facadeArgs = buildFacadeArgsForCommand(commandId, config);
+  const invocation = {
     executable: runtime.nodeExecutable ?? process.execPath,
     args: [
       runtime.facadePath ?? DEFAULT_FACADE_PATH,
-      ...buildFacadeArgsForCommand(commandId, options),
+      ...facadeArgs,
     ],
     shell: false,
+  };
+
+  if (isLiveFacadeArgs(facadeArgs)) {
+    invocation.env = { PCCX_IDE_PYTHON: config.pythonPath };
+  }
+
+  return invocation;
+}
+
+function mergedEnv(invocation, runtime) {
+  if (!invocation.env && !runtime.env) {
+    return process.env;
+  }
+  return {
+    ...process.env,
+    ...(invocation.env ?? {}),
+    ...(runtime.env ?? {}),
   };
 }
 
@@ -101,6 +75,7 @@ function captureExecFile(executable, args, options = {}) {
       {
         cwd: options.cwd ?? EXTENSION_ROOT,
         encoding: "utf8",
+        env: options.env ?? process.env,
         maxBuffer: 1024 * 1024,
       },
       (error, stdout, stderr) => {
@@ -118,7 +93,10 @@ function captureExecFile(executable, args, options = {}) {
 }
 
 export async function runFacadeInvocation(invocation, runtime = {}) {
-  const result = await captureExecFile(invocation.executable, invocation.args, runtime);
+  const result = await captureExecFile(invocation.executable, invocation.args, {
+    ...runtime,
+    env: mergedEnv(invocation, runtime),
+  });
   if (result.ok && result.stdout.trim()) {
     try {
       result.json = JSON.parse(result.stdout);
@@ -130,23 +108,26 @@ export async function runFacadeInvocation(invocation, runtime = {}) {
   return result;
 }
 
-export function resolveCommandRequest(commandId, input, vscodeApi) {
-  commandConfig(commandId);
+export function readExtensionConfig(vscodeApi) {
+  const settings = vscodeApi?.workspace?.getConfiguration?.(CONFIG_SECTION);
+  if (!settings?.get) {
+    return defaultConfig();
+  }
+
+  return normalizeConfig(Object.fromEntries(
+    CONFIG_KEYS.map((key) => [key, settings.get(key)]),
+  ));
+}
+
+export function resolveCommandRequest(commandId, input, vscodeApi, rawConfig = readExtensionConfig(vscodeApi)) {
+  const config = normalizeConfig(rawConfig);
   const explicitPath = pathFromCommandInput(input);
+  const commandConfig = commandId === "pccxSystemVerilog.runDiagnosticsLive" && explicitPath
+    ? normalizeConfig({ ...config, defaultSource: explicitPath })
+    : config;
 
-  if (commandId === "pccxSystemVerilog.runDiagnosticsLive") {
-    return {
-      targetFile: explicitPath ?? vscodeApi?.window?.activeTextEditor?.document?.uri?.fsPath,
-    };
-  }
-
-  if (commandId === "pccxSystemVerilog.runNavigationLive") {
-    return {
-      targetPath: explicitPath ?? vscodeApi?.workspace?.workspaceFolders?.[0]?.uri?.fsPath,
-    };
-  }
-
-  return {};
+  buildFacadeArgsForCommand(commandId, commandConfig);
+  return commandConfig;
 }
 
 export async function runFacadeForCommand(commandId, options = {}, runtime = {}) {
@@ -187,7 +168,7 @@ function appendFacadeOutput(outputChannel, commandId, result) {
 }
 
 export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
-  commandConfig(commandId);
+  buildFacadeArgsForCommand(commandId, defaultConfig());
   return async (input) => {
     let result;
     try {

--- a/editors/vscode-prototype/test/extension-config.test.mjs
+++ b/editors/vscode-prototype/test/extension-config.test.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  DECLARATION_KINDS,
+  MODES,
+  buildFacadeArgsForCommand,
+  defaultConfig,
+  normalizeConfig,
+} from "../src/config.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const PACKAGE_JSON = resolve(ROOT, "editors/vscode-prototype/package.json");
+
+const REQUIRED_SETTINGS = new Map([
+  ["pccxSystemVerilog.mode", { default: "example" }],
+  ["pccxSystemVerilog.pythonPath", { default: "python3" }],
+  ["pccxSystemVerilog.defaultSource", { default: "fixtures/missing_endmodule.sv" }],
+  ["pccxSystemVerilog.defaultLog", { default: "fixtures/xsim/mixed.log" }],
+  ["pccxSystemVerilog.defaultModule", { default: "simple_mod" }],
+  ["pccxSystemVerilog.defaultDeclarationKind", { default: "module" }],
+]);
+
+async function readPackageJson() {
+  return JSON.parse(await readFile(PACKAGE_JSON, "utf8"));
+}
+
+async function testPackageConfigurationSchema() {
+  const manifest = await readPackageJson();
+  const configuration = manifest.contributes?.configuration;
+  assert.ok(configuration);
+  assert.equal(configuration.title, "PCCX SystemVerilog IDE Prototype");
+
+  for (const [setting, expected] of REQUIRED_SETTINGS) {
+    const property = configuration.properties?.[setting];
+    assert.ok(property, `${setting} missing`);
+    assert.equal(property.type, "string");
+    assert.equal(property.default, expected.default);
+    assert.match(property.description, /experimental local prototype/i);
+    assert.match(property.description, /not a stable API/i);
+  }
+
+  assert.deepEqual(configuration.properties["pccxSystemVerilog.mode"].enum, MODES);
+  assert.deepEqual(
+    configuration.properties["pccxSystemVerilog.defaultDeclarationKind"].enum,
+    DECLARATION_KINDS,
+  );
+}
+
+function testDefaultConfig() {
+  assert.deepEqual(defaultConfig(), {
+    mode: "example",
+    pythonPath: "python3",
+    defaultSource: "fixtures/missing_endmodule.sv",
+    defaultLog: "fixtures/xsim/mixed.log",
+    defaultModule: "simple_mod",
+    defaultDeclarationKind: "module",
+  });
+}
+
+function testNormalizeConfigRejectsInvalidSettings() {
+  assert.throws(
+    () => normalizeConfig({ mode: "automatic" }),
+    /pccxSystemVerilog\.mode must be one of: example, live/,
+  );
+  assert.throws(
+    () => normalizeConfig({ defaultDeclarationKind: "class" }),
+    /pccxSystemVerilog\.defaultDeclarationKind must be one of: module, package, interface, any/,
+  );
+  assert.throws(
+    () => normalizeConfig({ pythonPath: "" }),
+    /pccxSystemVerilog\.pythonPath must be a non-empty string/,
+  );
+  assert.throws(
+    () => normalizeConfig({ defaultSource: "fixtures/ok_module.sv; rm -rf /" }),
+    /pccxSystemVerilog\.defaultSource must not contain shell control syntax/,
+  );
+}
+
+function testFacadeArgsForKnownCommands() {
+  assert.deepEqual(
+    buildFacadeArgsForCommand("pccxSystemVerilog.showDiagnosticsExample"),
+    ["diagnostics", "--mode", "example", "--source", "check-missing-endmodule"],
+  );
+  assert.deepEqual(
+    buildFacadeArgsForCommand("pccxSystemVerilog.showNavigationExample"),
+    ["navigation", "--mode", "example", "--source", "declarations"],
+  );
+  assert.deepEqual(
+    buildFacadeArgsForCommand("pccxSystemVerilog.runDiagnosticsLive"),
+    ["diagnostics", "--mode", "live", "--from-check", "fixtures/missing_endmodule.sv"],
+  );
+  assert.deepEqual(
+    buildFacadeArgsForCommand("pccxSystemVerilog.runNavigationLive"),
+    ["navigation", "--mode", "live", "--locate", "fixtures/modules", "simple_mod", "--kind", "module"],
+  );
+}
+
+function testFacadeArgsUseNormalizedLiveConfig() {
+  assert.deepEqual(
+    buildFacadeArgsForCommand("pccxSystemVerilog.runDiagnosticsLive", {
+      mode: "live",
+      defaultSource: "rtl/top.sv",
+      defaultLog: "logs/xsim.log",
+      pythonPath: "python-custom",
+    }),
+    ["diagnostics", "--mode", "live", "--from-check", "rtl/top.sv"],
+  );
+
+  assert.deepEqual(
+    buildFacadeArgsForCommand("pccxSystemVerilog.runNavigationLive", {
+      defaultModule: "pkg_defs",
+      defaultDeclarationKind: "any",
+    }),
+    ["navigation", "--mode", "live", "--locate", "fixtures/modules", "pkg_defs", "--kind", "any"],
+  );
+}
+
+function testUnknownCommandAndShellShape() {
+  assert.throws(
+    () => buildFacadeArgsForCommand("pccxSystemVerilog.runArbitraryCommand"),
+    /unknown PCCX SystemVerilog command/,
+  );
+
+  for (const commandId of [
+    "pccxSystemVerilog.showDiagnosticsExample",
+    "pccxSystemVerilog.showNavigationExample",
+    "pccxSystemVerilog.runDiagnosticsLive",
+    "pccxSystemVerilog.runNavigationLive",
+  ]) {
+    const args = buildFacadeArgsForCommand(commandId);
+    assert.ok(Array.isArray(args));
+    assert.ok(args.every((arg) => typeof arg === "string"));
+    assert.doesNotMatch(args.join("\n"), /(?:&&|\|\||;|`|\$\()/);
+  }
+}
+
+await testPackageConfigurationSchema();
+testDefaultConfig();
+testNormalizeConfigRejectsInvalidSettings();
+testFacadeArgsForKnownCommands();
+testFacadeArgsUseNormalizedLiveConfig();
+testUnknownCommandAndShellShape();
+
+console.log("vscode extension config tests ok");

--- a/editors/vscode-prototype/test/extension-entrypoint.test.mjs
+++ b/editors/vscode-prototype/test/extension-entrypoint.test.mjs
@@ -7,6 +7,7 @@ import {
   buildFacadeInvocationForCommand,
   createCommandHandler,
   deactivate,
+  readExtensionConfig,
   resolveCommandRequest,
 } from "../src/extension.mjs";
 
@@ -25,16 +26,16 @@ const EXPECTED_ARGS = new Map([
   ],
   [
     "pccxSystemVerilog.runNavigationLive",
-    ["navigation", "--mode", "live", "--declarations", "fixtures/modules"],
+    ["navigation", "--mode", "live", "--locate", "fixtures/modules", "simple_mod", "--kind", "module"],
   ],
 ]);
 
-function optionsFor(commandId) {
+function configFor(commandId) {
   if (commandId === "pccxSystemVerilog.runDiagnosticsLive") {
-    return { targetFile: "fixtures/missing_endmodule.sv" };
+    return { defaultSource: "fixtures/missing_endmodule.sv" };
   }
   if (commandId === "pccxSystemVerilog.runNavigationLive") {
-    return { targetPath: "fixtures/modules" };
+    return { defaultModule: "simple_mod", defaultDeclarationKind: "module" };
   }
   return {};
 }
@@ -42,7 +43,7 @@ function optionsFor(commandId) {
 function testKnownFacadeArgs() {
   for (const commandId of COMMAND_IDS) {
     assert.deepEqual(
-      buildFacadeArgsForCommand(commandId, optionsFor(commandId)),
+      buildFacadeArgsForCommand(commandId, configFor(commandId)),
       EXPECTED_ARGS.get(commandId),
     );
   }
@@ -55,54 +56,83 @@ function testUnknownCommandsRejected() {
   );
 }
 
-function testLiveCommandsRequireExplicitPaths() {
-  assert.throws(
-    () => buildFacadeArgsForCommand("pccxSystemVerilog.runDiagnosticsLive"),
-    /targetFile is required/,
-  );
-  assert.throws(
-    () => buildFacadeArgsForCommand("pccxSystemVerilog.runNavigationLive"),
-    /targetPath is required/,
-  );
-}
-
 function testFacadeInvocationIsArgumentArray() {
   const invocation = buildFacadeInvocationForCommand(
     "pccxSystemVerilog.runDiagnosticsLive",
-    { targetFile: "fixtures/missing_endmodule.sv" },
+    { defaultSource: "fixtures/missing_endmodule.sv", pythonPath: "python3" },
     { nodeExecutable: "node", facadePath: "editors/vscode-prototype/bin/pccx-vscode-prototype.mjs" },
   );
 
   assert.equal(invocation.executable, "node");
   assert.equal(invocation.shell, false);
+  assert.deepEqual(invocation.env, { PCCX_IDE_PYTHON: "python3" });
   assert.ok(Array.isArray(invocation.args));
   assert.deepEqual(invocation.args.slice(1), EXPECTED_ARGS.get("pccxSystemVerilog.runDiagnosticsLive"));
   assert.doesNotMatch(invocation.args.join("\n"), /(?:&&|\|\||;|`|\$\()/);
 }
 
-function testResolveCommandRequestUsesVsCodeState() {
+function testResolveCommandRequestUsesVsCodeSettings() {
+  const settings = new Map([
+    ["mode", "live"],
+    ["pythonPath", "python-custom"],
+    ["defaultSource", "configured.sv"],
+    ["defaultLog", "configured.log"],
+    ["defaultModule", "pkg_defs"],
+    ["defaultDeclarationKind", "package"],
+  ]);
   const vscodeApi = {
-    window: {
-      activeTextEditor: {
-        document: { uri: { fsPath: "active.sv" } },
-      },
-    },
     workspace: {
-      workspaceFolders: [{ uri: { fsPath: "workspace-root" } }],
+      getConfiguration(section) {
+        assert.equal(section, "pccxSystemVerilog");
+        return {
+          get(key) {
+            return settings.get(key);
+          },
+        };
+      },
     },
   };
 
+  assert.deepEqual(readExtensionConfig(vscodeApi), {
+    mode: "live",
+    pythonPath: "python-custom",
+    defaultSource: "configured.sv",
+    defaultLog: "configured.log",
+    defaultModule: "pkg_defs",
+    defaultDeclarationKind: "package",
+  });
   assert.deepEqual(
     resolveCommandRequest("pccxSystemVerilog.runDiagnosticsLive", undefined, vscodeApi),
-    { targetFile: "active.sv" },
+    {
+      mode: "live",
+      pythonPath: "python-custom",
+      defaultSource: "configured.sv",
+      defaultLog: "configured.log",
+      defaultModule: "pkg_defs",
+      defaultDeclarationKind: "package",
+    },
   );
   assert.deepEqual(
     resolveCommandRequest("pccxSystemVerilog.runNavigationLive", undefined, vscodeApi),
-    { targetPath: "workspace-root" },
+    {
+      mode: "live",
+      pythonPath: "python-custom",
+      defaultSource: "configured.sv",
+      defaultLog: "configured.log",
+      defaultModule: "pkg_defs",
+      defaultDeclarationKind: "package",
+    },
   );
   assert.deepEqual(
     resolveCommandRequest("pccxSystemVerilog.runDiagnosticsLive", { fsPath: "explicit.sv" }, vscodeApi),
-    { targetFile: "explicit.sv" },
+    {
+      mode: "live",
+      pythonPath: "python-custom",
+      defaultSource: "explicit.sv",
+      defaultLog: "configured.log",
+      defaultModule: "pkg_defs",
+      defaultDeclarationKind: "package",
+    },
   );
 }
 
@@ -190,9 +220,8 @@ async function testCommandHandlerCanBeUsedWithoutRealVsCode() {
 
 testKnownFacadeArgs();
 testUnknownCommandsRejected();
-testLiveCommandsRequireExplicitPaths();
 testFacadeInvocationIsArgumentArray();
-testResolveCommandRequestUsesVsCodeState();
+testResolveCommandRequestUsesVsCodeSettings();
 await testEntrypointExportsAndActivation();
 await testNoVsCodeRuntimeIsANoop();
 await testCommandHandlerCanBeUsedWithoutRealVsCode();

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -13,6 +13,7 @@ node editors/vscode-prototype/test/adapter.test.mjs
 node editors/vscode-prototype/test/cli-runner.test.mjs
 node editors/vscode-prototype/test/facade.test.mjs
 node editors/vscode-prototype/test/extension-manifest.test.mjs
+node editors/vscode-prototype/test/extension-config.test.mjs
 node editors/vscode-prototype/test/extension-entrypoint.test.mjs
 node editors/vscode-prototype/src/adapter.mjs diagnostics \
   docs/examples/editor-bridge/problems-xsim-mixed.example.json \


### PR DESCRIPTION
## Summary
- Model used: GPT-5.5 xhigh requested for extension settings, command wiring safety, facade boundary, and merge readiness decisions.
- Spark usage: none.
- Configuration scope: added prototype-only `pccxSystemVerilog.*` settings for mode, Python executable, default source/log, default module, and declaration kind.
- Command wiring behavior: pure config helpers normalize settings, reject invalid mode/kind, reject shell-control syntax in setting strings, and build only known facade argument arrays.
- Facade boundary usage: extension commands still call `bin/pccx-vscode-prototype.mjs`; no direct `pccx_ide_cli` call from the extension entry point, no shell interpolation, and no arbitrary command string execution.
- Tests/smoke added: new extension config test plus updated entrypoint test and VS Code adapter smoke coverage.
- Non-goals held: no LSP, no published extension, no marketplace packaging/readiness, no VS Code GUI tests, and no stable ABI/API claim.
- FPGA repo untouched: no reads, writes, git commands, PRs, issues, tags, or releases under `/home/hwkim/Desktop/github/pccxai/pccx-FPGA-NPU-LLM-kv260`.
- Token-saving / compact handoff note: used targeted reads, focused Node checks during iteration, full validation before PR, and will include COMPACT_HANDOFF in the final report.

## Validation
- `python3 -m pytest -q` -> 164 passed
- `bash scripts/editor-bridge-smoke.sh` -> passed
- `bash scripts/check-editor-bridge-examples.sh` -> passed
- `node editors/vscode-prototype/test/adapter.test.mjs` -> passed
- `node editors/vscode-prototype/test/cli-runner.test.mjs` -> passed
- `node editors/vscode-prototype/test/facade.test.mjs` -> passed
- `node editors/vscode-prototype/test/extension-manifest.test.mjs` -> passed
- `node editors/vscode-prototype/test/extension-entrypoint.test.mjs` -> passed
- `node editors/vscode-prototype/test/extension-config.test.mjs` -> passed
- `bash scripts/vscode-adapter-smoke.sh` -> passed
- `git diff --check` -> passed