### PR TITLE
feat: add VS Code prototype command handler scaffold

### DIFF
--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -83,6 +83,9 @@ scaffold.  Its command handlers are thin wrappers around the local facade:
 VS Code command -> prototype settings -> extension wrapper -> facade ->
 JSON -> diagnostics/navigation records.  The prototype settings are
 validated before command wiring and route only into known facade flows.
+The command-handler scaffold converts facade JSON into testable UI action
+models for diagnostics and navigation behind injected VS Code-like
+dependencies.
 The scaffold is not published, is not marketplace-ready, has no LSP, and
 is not a stable ABI/API.  Current coverage is static/smoke tests, not VS
 Code GUI integration tests.
@@ -104,6 +107,7 @@ VS Code command
   -> experimental extension wrapper
   -> local pccx-vscode-prototype facade
   -> JSON output
+  -> testable diagnostics/navigation UI action
   -> diagnostics/navigation records
 ```
 

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -105,6 +105,16 @@ strings, and do not accept arbitrary command execution.  Live mode calls
 only known facade flows.  Live paths are still prototype-only and are
 passed to known facade flows as argument-array entries.
 
+`src/command-handlers.mjs` is the experimental local command-handler
+scaffold.  It maps command ID -> normalized prototype settings -> known
+facade argument array -> facade JSON result -> testable UI action model.
+Diagnostics facade payloads become `{ kind: "diagnostics", diagnostics,
+summary }` actions, and navigation facade payloads become
+`{ kind: "navigation", items, summary }` actions.  Tests use injected and
+mocked VS Code-like dependencies such as `runFacade`, `updateDiagnostics`,
+and `showNavigationItems`; they do not use a real `DiagnosticCollection`,
+quick pick, or VS Code GUI integration test.
+
 This scaffold is not LSP, not a full IDE replacement, not a stable
 ABI/API, and not a marketplace-ready or published extension.
 There are no VS Code GUI/integration tests yet.
@@ -118,6 +128,7 @@ node editors/vscode-prototype/test/facade.test.mjs
 node editors/vscode-prototype/test/extension-manifest.test.mjs
 node editors/vscode-prototype/test/extension-config.test.mjs
 node editors/vscode-prototype/test/extension-entrypoint.test.mjs
+node editors/vscode-prototype/test/command-handlers.test.mjs
 bash scripts/vscode-adapter-smoke.sh
 ```
 

--- a/editors/vscode-prototype/src/command-handlers.mjs
+++ b/editors/vscode-prototype/src/command-handlers.mjs
@@ -1,0 +1,137 @@
+import {
+  COMMAND_IDS,
+  buildFacadeArgsForCommand,
+  isLiveFacadeArgs,
+  normalizeConfig,
+} from "./config.mjs";
+
+export { COMMAND_IDS };
+
+function countSummary(count, label) {
+  return `${count} ${label}(s)`;
+}
+
+function assertStringArray(value, label) {
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
+    throw new Error(`${label} must be an argument array`);
+  }
+}
+
+export function createCommandExecutionPlan(commandId, rawConfig = {}) {
+  const config = normalizeConfig(rawConfig);
+  const facadeArgs = buildFacadeArgsForCommand(commandId, config);
+  assertStringArray(facadeArgs, "facade args");
+
+  const plan = {
+    commandId,
+    config,
+    facadeArgs,
+    env: {},
+  };
+
+  if (isLiveFacadeArgs(facadeArgs)) {
+    plan.env.PCCX_IDE_PYTHON = config.pythonPath;
+  }
+
+  return plan;
+}
+
+export function toDiagnosticsUiAction(facadePayload) {
+  if (facadePayload?.kind !== "vscode-diagnostics") {
+    throw new Error("expected vscode-diagnostics facade payload");
+  }
+
+  const diagnostics = Array.isArray(facadePayload.diagnostics)
+    ? facadePayload.diagnostics
+    : [];
+  return {
+    kind: "diagnostics",
+    diagnostics,
+    summary: countSummary(diagnostics.length, "diagnostic"),
+  };
+}
+
+export function toNavigationUiAction(facadePayload) {
+  if (facadePayload?.kind !== "vscode-navigation") {
+    throw new Error("expected vscode-navigation facade payload");
+  }
+
+  const items = Array.isArray(facadePayload.items) ? facadePayload.items : [];
+  return {
+    kind: "navigation",
+    items,
+    summary: countSummary(items.length, "navigation item"),
+  };
+}
+
+function payloadFromFacadeResult(result) {
+  if (!result?.ok) {
+    throw new Error(result?.error || result?.stderr || "facade command failed");
+  }
+
+  if (result.json) {
+    return result.json;
+  }
+  if (result.kind) {
+    return result;
+  }
+
+  throw new Error("facade command did not return JSON payload");
+}
+
+function toUiAction(facadePayload) {
+  if (facadePayload?.kind === "vscode-diagnostics") {
+    return toDiagnosticsUiAction(facadePayload);
+  }
+  if (facadePayload?.kind === "vscode-navigation") {
+    return toNavigationUiAction(facadePayload);
+  }
+  throw new Error(`unsupported facade payload kind: ${facadePayload?.kind ?? "missing"}`);
+}
+
+async function applyUiAction(action, deps) {
+  if (action.kind === "diagnostics") {
+    await deps.updateDiagnostics?.(action.diagnostics, action);
+  } else if (action.kind === "navigation") {
+    await deps.showNavigationItems?.(action.items, action);
+  }
+
+  if (action.kind === "diagnostics" && action.diagnostics.length > 0) {
+    await deps.showWarningMessage?.(action.summary, action);
+  } else {
+    await deps.showInformationMessage?.(action.summary, action);
+  }
+}
+
+export async function runPrototypeCommand(commandId, rawConfig = {}, deps = {}) {
+  let plan;
+  try {
+    plan = createCommandExecutionPlan(commandId, rawConfig);
+    if (typeof deps.runFacade !== "function") {
+      throw new Error("runFacade dependency is required");
+    }
+
+    const facadeResult = await deps.runFacade(plan.facadeArgs, plan.env, plan);
+    const facadePayload = payloadFromFacadeResult(facadeResult);
+    const action = toUiAction(facadePayload);
+    await applyUiAction(action, deps);
+
+    return {
+      ok: true,
+      commandId,
+      plan,
+      action,
+    };
+  } catch (error) {
+    const result = {
+      ok: false,
+      commandId,
+      error: error.message,
+    };
+    if (plan) {
+      result.plan = plan;
+    }
+    await deps.showWarningMessage?.(result.error, result);
+    return result;
+  }
+}

--- a/editors/vscode-prototype/src/extension.mjs
+++ b/editors/vscode-prototype/src/extension.mjs
@@ -11,6 +11,10 @@ import {
   isLiveFacadeArgs,
   normalizeConfig,
 } from "./config.mjs";
+import {
+  createCommandExecutionPlan,
+  runPrototypeCommand,
+} from "./command-handlers.mjs";
 
 const EXTENSION_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_FACADE_PATH = resolve(EXTENSION_ROOT, "bin/pccx-vscode-prototype.mjs");
@@ -19,8 +23,10 @@ const OUTPUT_CHANNEL_NAME = "PCCX SystemVerilog IDE Prototype";
 export {
   COMMAND_IDS,
   buildFacadeArgsForCommand,
+  createCommandExecutionPlan,
   defaultConfig,
   normalizeConfig,
+  runPrototypeCommand,
 };
 
 function pathFromCommandInput(input) {
@@ -109,14 +115,18 @@ export async function runFacadeInvocation(invocation, runtime = {}) {
 }
 
 export function readExtensionConfig(vscodeApi) {
+  return normalizeConfig(readRawExtensionConfig(vscodeApi));
+}
+
+function readRawExtensionConfig(vscodeApi) {
   const settings = vscodeApi?.workspace?.getConfiguration?.(CONFIG_SECTION);
   if (!settings?.get) {
     return defaultConfig();
   }
 
-  return normalizeConfig(Object.fromEntries(
+  return Object.fromEntries(
     CONFIG_KEYS.map((key) => [key, settings.get(key)]),
-  ));
+  );
 }
 
 export function resolveCommandRequest(commandId, input, vscodeApi, rawConfig = readExtensionConfig(vscodeApi)) {
@@ -135,31 +145,17 @@ export async function runFacadeForCommand(commandId, options = {}, runtime = {})
   return runFacadeInvocation(invocation, runtime);
 }
 
-export function summarizeFacadeResult(commandId, result) {
-  if (!result.ok) {
-    return `PCCX facade command failed for ${commandId}`;
-  }
-
-  if (Array.isArray(result.json?.diagnostics)) {
-    return `PCCX facade returned ${result.json.diagnostics.length} diagnostics`;
-  }
-  if (Array.isArray(result.json?.items)) {
-    return `PCCX facade returned ${result.json.items.length} navigation items`;
-  }
-  return "PCCX facade command completed";
-}
-
-function appendFacadeOutput(outputChannel, commandId, result) {
+function appendCommandOutput(outputChannel, commandId, result) {
   if (!outputChannel?.appendLine) {
     return;
   }
 
   outputChannel.appendLine(`[${commandId}]`);
-  if (result.stdout) {
-    outputChannel.appendLine(result.stdout.trimEnd());
+  if (result.action?.summary) {
+    outputChannel.appendLine(result.action.summary);
   }
-  if (result.stderr) {
-    outputChannel.appendLine(result.stderr.trimEnd());
+  if (result.action) {
+    outputChannel.appendLine(JSON.stringify(result.action, null, 2));
   }
   if (result.error) {
     outputChannel.appendLine(result.error);
@@ -167,31 +163,40 @@ function appendFacadeOutput(outputChannel, commandId, result) {
   outputChannel.show?.(true);
 }
 
-export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
-  buildFacadeArgsForCommand(commandId, defaultConfig());
-  return async (input) => {
-    let result;
-    try {
-      const request = resolveCommandRequest(commandId, input, vscodeApi);
-      const run = runtime.runFacadeForCommand ?? runFacadeForCommand;
-      result = await run(commandId, request, runtime);
-    } catch (error) {
-      result = {
-        ok: false,
-        exitCode: null,
-        stdout: "",
-        stderr: "",
-        error: error.message,
-      };
-    }
-    appendFacadeOutput(runtime.outputChannel, commandId, result);
+function facadeRunnerFromRuntime(runtime = {}) {
+  return async (facadeArgs, env = {}) => {
+    const invocation = {
+      executable: runtime.nodeExecutable ?? process.execPath,
+      args: [
+        runtime.facadePath ?? DEFAULT_FACADE_PATH,
+        ...facadeArgs,
+      ],
+      shell: false,
+      env,
+    };
+    return runFacadeInvocation(invocation, runtime);
+  };
+}
 
-    const message = summarizeFacadeResult(commandId, result);
-    if (result.ok) {
-      vscodeApi?.window?.showInformationMessage?.(message);
-    } else {
-      vscodeApi?.window?.showErrorMessage?.(message);
-    }
+export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
+  createCommandExecutionPlan(commandId, defaultConfig());
+  return async (input) => {
+    const rawConfig = readRawExtensionConfig(vscodeApi);
+    const explicitPath = pathFromCommandInput(input);
+    const request = commandId === "pccxSystemVerilog.runDiagnosticsLive" && explicitPath
+      ? { ...rawConfig, defaultSource: explicitPath }
+      : rawConfig;
+    const deps = {
+      runFacade: runtime.runFacade ?? facadeRunnerFromRuntime(runtime),
+      showInformationMessage: vscodeApi?.window?.showInformationMessage?.bind(vscodeApi.window),
+      showWarningMessage: (
+        vscodeApi?.window?.showWarningMessage ?? vscodeApi?.window?.showErrorMessage
+      )?.bind(vscodeApi.window),
+      updateDiagnostics: runtime.updateDiagnostics,
+      showNavigationItems: runtime.showNavigationItems,
+    };
+    const result = await runPrototypeCommand(commandId, request, deps);
+    appendCommandOutput(runtime.outputChannel, commandId, result);
     return result;
   };
 }

--- a/editors/vscode-prototype/test/command-handlers.test.mjs
+++ b/editors/vscode-prototype/test/command-handlers.test.mjs
@@ -1,0 +1,306 @@
+import assert from "node:assert/strict";
+
+import {
+  COMMAND_IDS,
+  createCommandExecutionPlan,
+  runPrototypeCommand,
+  toDiagnosticsUiAction,
+  toNavigationUiAction,
+} from "../src/command-handlers.mjs";
+import {
+  activate,
+  deactivate,
+} from "../src/extension.mjs";
+
+function mockDeps(payloadOrResult) {
+  const calls = {
+    runFacade: [],
+    info: [],
+    warning: [],
+    diagnostics: [],
+    navigation: [],
+  };
+
+  return {
+    calls,
+    deps: {
+      async runFacade(args, env, plan) {
+        calls.runFacade.push({ args, env, plan });
+        if (payloadOrResult && Object.hasOwn(payloadOrResult, "ok")) {
+          return payloadOrResult;
+        }
+        return { ok: true, json: payloadOrResult };
+      },
+      async showInformationMessage(message, action) {
+        calls.info.push({ message, action });
+      },
+      async showWarningMessage(message, action) {
+        calls.warning.push({ message, action });
+      },
+      async updateDiagnostics(diagnostics, action) {
+        calls.diagnostics.push({ diagnostics, action });
+      },
+      async showNavigationItems(items, action) {
+        calls.navigation.push({ items, action });
+      },
+    },
+  };
+}
+
+function testPlansForKnownCommands() {
+  for (const commandId of COMMAND_IDS) {
+    const plan = createCommandExecutionPlan(commandId);
+    assert.equal(plan.commandId, commandId);
+    assert.ok(Array.isArray(plan.facadeArgs));
+    assert.ok(plan.facadeArgs.every((arg) => typeof arg === "string"));
+  }
+}
+
+function testUnknownCommandRejected() {
+  assert.throws(
+    () => createCommandExecutionPlan("pccxSystemVerilog.runArbitraryCommand"),
+    /unknown PCCX SystemVerilog command/,
+  );
+}
+
+async function testDiagnosticsExampleAction() {
+  const diagnostic = { file: "a.sv", message: "bad", severity: "Error" };
+  const { calls, deps } = mockDeps({
+    kind: "vscode-diagnostics",
+    diagnostics: [diagnostic],
+  });
+
+  const result = await runPrototypeCommand(
+    "pccxSystemVerilog.showDiagnosticsExample",
+    {},
+    deps,
+  );
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.action, {
+    kind: "diagnostics",
+    diagnostics: [diagnostic],
+    summary: "1 diagnostic(s)",
+  });
+  assert.deepEqual(calls.runFacade[0].args, [
+    "diagnostics",
+    "--mode",
+    "example",
+    "--source",
+    "check-missing-endmodule",
+  ]);
+  assert.deepEqual(calls.diagnostics[0].diagnostics, [diagnostic]);
+  assert.equal(calls.warning[0].message, "1 diagnostic(s)");
+}
+
+async function testDiagnosticsLiveAction() {
+  const { calls, deps } = mockDeps({
+    kind: "vscode-diagnostics",
+    diagnostics: [],
+  });
+
+  const result = await runPrototypeCommand(
+    "pccxSystemVerilog.runDiagnosticsLive",
+    {
+      defaultSource: "rtl/top.sv",
+      pythonPath: "python-custom",
+    },
+    deps,
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(result.action.summary, "0 diagnostic(s)");
+  assert.deepEqual(calls.runFacade[0].args, [
+    "diagnostics",
+    "--mode",
+    "live",
+    "--from-check",
+    "rtl/top.sv",
+  ]);
+  assert.deepEqual(calls.runFacade[0].env, { PCCX_IDE_PYTHON: "python-custom" });
+  assert.equal(calls.info[0].message, "0 diagnostic(s)");
+}
+
+async function testNavigationExampleAction() {
+  const item = { name: "simple_mod", kind: "module", file: "simple.sv" };
+  const { calls, deps } = mockDeps({
+    kind: "vscode-navigation",
+    items: [item],
+  });
+
+  const result = await runPrototypeCommand(
+    "pccxSystemVerilog.showNavigationExample",
+    {},
+    deps,
+  );
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.action, {
+    kind: "navigation",
+    items: [item],
+    summary: "1 navigation item(s)",
+  });
+  assert.deepEqual(calls.runFacade[0].args, [
+    "navigation",
+    "--mode",
+    "example",
+    "--source",
+    "declarations",
+  ]);
+  assert.deepEqual(calls.navigation[0].items, [item]);
+}
+
+async function testNavigationLiveAction() {
+  const { calls, deps } = mockDeps({
+    kind: "vscode-navigation",
+    items: [],
+  });
+
+  const result = await runPrototypeCommand(
+    "pccxSystemVerilog.runNavigationLive",
+    {
+      defaultModule: "pkg_defs",
+      defaultDeclarationKind: "package",
+      pythonPath: "python-custom",
+    },
+    deps,
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(result.action.summary, "0 navigation item(s)");
+  assert.deepEqual(calls.runFacade[0].args, [
+    "navigation",
+    "--mode",
+    "live",
+    "--locate",
+    "fixtures/modules",
+    "pkg_defs",
+    "--kind",
+    "package",
+  ]);
+  assert.deepEqual(calls.runFacade[0].env, { PCCX_IDE_PYTHON: "python-custom" });
+}
+
+async function testRunFacadeUsesArgumentArray() {
+  const { calls, deps } = mockDeps({
+    kind: "vscode-navigation",
+    items: [],
+  });
+
+  await runPrototypeCommand("pccxSystemVerilog.showNavigationExample", {}, deps);
+
+  assert.ok(Array.isArray(calls.runFacade[0].args));
+  assert.ok(calls.runFacade[0].args.every((arg) => typeof arg === "string"));
+  assert.doesNotMatch(calls.runFacade[0].args.join("\n"), /(?:&&|\|\||;|`|\$\()/);
+}
+
+async function testInvalidConfigControlledFailure() {
+  const { calls, deps } = mockDeps({
+    kind: "vscode-diagnostics",
+    diagnostics: [],
+  });
+
+  const result = await runPrototypeCommand(
+    "pccxSystemVerilog.runDiagnosticsLive",
+    { mode: "automatic" },
+    deps,
+  );
+
+  assert.equal(result.ok, false);
+  assert.match(result.error, /pccxSystemVerilog\.mode must be one of/);
+  assert.equal(calls.runFacade.length, 0);
+  assert.match(calls.warning[0].message, /pccxSystemVerilog\.mode/);
+}
+
+async function testFacadeFailureControlledFailure() {
+  const { calls, deps } = mockDeps({
+    ok: false,
+    error: "facade failed",
+  });
+
+  const result = await runPrototypeCommand(
+    "pccxSystemVerilog.showDiagnosticsExample",
+    {},
+    deps,
+  );
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "facade failed");
+  assert.equal(calls.runFacade.length, 1);
+  assert.equal(calls.warning[0].message, "facade failed");
+}
+
+async function testInvalidFacadeKindControlledFailure() {
+  const { calls, deps } = mockDeps({
+    kind: "vscode-symbols",
+    items: [],
+  });
+
+  const result = await runPrototypeCommand(
+    "pccxSystemVerilog.showNavigationExample",
+    {},
+    deps,
+  );
+
+  assert.equal(result.ok, false);
+  assert.match(result.error, /unsupported facade payload kind: vscode-symbols/);
+  assert.equal(calls.navigation.length, 0);
+  assert.match(calls.warning[0].message, /unsupported facade payload kind/);
+}
+
+function testActionSummaries() {
+  assert.equal(
+    toDiagnosticsUiAction({ kind: "vscode-diagnostics", diagnostics: [{}, {}] }).summary,
+    "2 diagnostic(s)",
+  );
+  assert.equal(
+    toNavigationUiAction({ kind: "vscode-navigation", items: [{}, {}, {}] }).summary,
+    "3 navigation item(s)",
+  );
+}
+
+async function testExtensionExportsAndRegistration() {
+  assert.equal(typeof activate, "function");
+  assert.equal(typeof deactivate, "function");
+
+  const registered = [];
+  const activation = await activate(
+    { subscriptions: [] },
+    {
+      commands: {
+        registerCommand(commandId) {
+          registered.push(commandId);
+          return { dispose() {} };
+        },
+      },
+      window: {
+        createOutputChannel() {
+          return { appendLine() {}, show() {}, dispose() {} };
+        },
+      },
+    },
+    {
+      async runFacade() {
+        return { ok: true, json: { kind: "vscode-diagnostics", diagnostics: [] } };
+      },
+    },
+  );
+
+  assert.deepEqual(activation.registered, COMMAND_IDS);
+  assert.deepEqual(registered, COMMAND_IDS);
+}
+
+testPlansForKnownCommands();
+testUnknownCommandRejected();
+await testDiagnosticsExampleAction();
+await testDiagnosticsLiveAction();
+await testNavigationExampleAction();
+await testNavigationLiveAction();
+await testRunFacadeUsesArgumentArray();
+await testInvalidConfigControlledFailure();
+await testFacadeFailureControlledFailure();
+await testInvalidFacadeKindControlledFailure();
+testActionSummaries();
+await testExtensionExportsAndRegistration();
+
+console.log("vscode command handler tests ok");

--- a/editors/vscode-prototype/test/extension-entrypoint.test.mjs
+++ b/editors/vscode-prototype/test/extension-entrypoint.test.mjs
@@ -169,14 +169,10 @@ async function testEntrypointExportsAndActivation() {
     { subscriptions },
     vscodeApi,
     {
-      async runFacadeForCommand(commandId) {
+      async runFacade() {
         return {
           ok: true,
-          exitCode: 0,
-          stdout: JSON.stringify({ kind: "vscode-diagnostics", diagnostics: [] }),
-          stderr: "",
           json: { kind: "vscode-diagnostics", diagnostics: [] },
-          commandId,
         };
       },
     },
@@ -201,14 +197,10 @@ async function testCommandHandlerCanBeUsedWithoutRealVsCode() {
     "pccxSystemVerilog.showNavigationExample",
     null,
     {
-      async runFacadeForCommand(commandId) {
+      async runFacade() {
         return {
           ok: true,
-          exitCode: 0,
-          stdout: JSON.stringify({ kind: "vscode-navigation", items: [] }),
-          stderr: "",
           json: { kind: "vscode-navigation", items: [] },
-          commandId,
         };
       },
     },

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -15,6 +15,7 @@ node editors/vscode-prototype/test/facade.test.mjs
 node editors/vscode-prototype/test/extension-manifest.test.mjs
 node editors/vscode-prototype/test/extension-config.test.mjs
 node editors/vscode-prototype/test/extension-entrypoint.test.mjs
+node editors/vscode-prototype/test/command-handlers.test.mjs
 node editors/vscode-prototype/src/adapter.mjs diagnostics \
   docs/examples/editor-bridge/problems-xsim-mixed.example.json \
   | node -e "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{const d=JSON.parse(s);if(!Array.isArray(d)||d.length===0)process.exit(1);})"


### PR DESCRIPTION
## Summary
- Model used: GPT-5.5 xhigh requested for command-handler execution boundary, UI action model behavior, facade boundary, and merge readiness decisions.
- Spark usage: none.
- Command handler scope: added `src/command-handlers.mjs` with testable execution plans, injected facade dependency, controlled failure results, and no VS Code runtime requirement.
- UI action model behavior: diagnostics facade payloads become `{ kind: "diagnostics", diagnostics, summary }`; navigation facade payloads become `{ kind: "navigation", items, summary }`.
- Facade boundary usage: command handlers build known facade argument arrays through the config helper and call only an injected `runFacade(args, env)` dependency; extension activation still invokes `bin/pccx-vscode-prototype.mjs`; no direct `pccx_ide_cli` call from the extension entry point and no shell strings.
- Tests/smoke added: new `command-handlers.test.mjs`, updated entrypoint mocks, and updated `scripts/vscode-adapter-smoke.sh`.
- Non-goals held: no VS Code GUI tests, no LSP, no published extension, no marketplace readiness, and no stable ABI/API claim.
- FPGA repo untouched: no reads, writes, git commands, PRs, issues, tags, or releases under `/home/hwkim/Desktop/github/pccxai/pccx-FPGA-NPU-LLM-kv260`.
- Token-saving / compact handoff note: used targeted reads, focused Node checks during iteration, full validation before PR, and will include COMPACT_HANDOFF in the final report.

## Validation
- `python3 -m pytest -q` -> 164 passed
- `bash scripts/editor-bridge-smoke.sh` -> passed
- `bash scripts/check-editor-bridge-examples.sh` -> passed
- `node editors/vscode-prototype/test/adapter.test.mjs` -> passed
- `node editors/vscode-prototype/test/cli-runner.test.mjs` -> passed
- `node editors/vscode-prototype/test/facade.test.mjs` -> passed
- `node editors/vscode-prototype/test/extension-manifest.test.mjs` -> passed
- `node editors/vscode-prototype/test/extension-entrypoint.test.mjs` -> passed
- `node editors/vscode-prototype/test/extension-config.test.mjs` -> passed
- `node editors/vscode-prototype/test/command-handlers.test.mjs` -> passed
- `bash scripts/vscode-adapter-smoke.sh` -> passed
- `git diff --check` -> passed