### PR TITLE
feat: add VS Code presenter and readiness scaffold

### DIFF
--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -86,6 +86,9 @@ validated before command wiring and route only into known facade flows.
 The command-handler scaffold converts facade JSON into testable UI action
 models for diagnostics and navigation behind injected VS Code-like
 dependencies.
+The presenter scaffold maps those UI action models to mockable
+DiagnosticCollection-like and QuickPick-like APIs without requiring real
+VS Code GUI tests.
 The scaffold is not published, is not marketplace-ready, has no LSP, and
 is not a stable ABI/API.  Current coverage is static/smoke tests, not VS
 Code GUI integration tests.
@@ -108,6 +111,7 @@ VS Code command
   -> local pccx-vscode-prototype facade
   -> JSON output
   -> testable diagnostics/navigation UI action
+  -> mockable VS Code-like presenter
   -> diagnostics/navigation records
 ```
 

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -115,6 +115,15 @@ mocked VS Code-like dependencies such as `runFacade`, `updateDiagnostics`,
 and `showNavigationItems`; they do not use a real `DiagnosticCollection`,
 quick pick, or VS Code GUI integration test.
 
+`src/presenter.mjs` is the experimental local presenter scaffold.  It
+consumes command-handler UI actions and maps diagnostics/navigation
+actions to mocked VS Code-like APIs.  Diagnostics presentation groups
+records by file for a `DiagnosticCollection`-like dependency, and
+navigation presentation creates deterministic QuickPick-like items.
+These behaviors are tested through mocks only; there are still no real
+VS Code GUI or Extension Host integration tests.  Extension Host gates are
+tracked in [`docs/EXTENSION_HOST_READINESS.md`](./docs/EXTENSION_HOST_READINESS.md).
+
 This scaffold is not LSP, not a full IDE replacement, not a stable
 ABI/API, and not a marketplace-ready or published extension.
 There are no VS Code GUI/integration tests yet.
@@ -129,6 +138,7 @@ node editors/vscode-prototype/test/extension-manifest.test.mjs
 node editors/vscode-prototype/test/extension-config.test.mjs
 node editors/vscode-prototype/test/extension-entrypoint.test.mjs
 node editors/vscode-prototype/test/command-handlers.test.mjs
+node editors/vscode-prototype/test/presenter.test.mjs
 bash scripts/vscode-adapter-smoke.sh
 ```
 

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -1,0 +1,32 @@
+# Extension Host Readiness
+
+## Current Status
+
+This is a local experimental VS Code extension scaffold.  It is not
+published, not marketplace-ready, not LSP, and not a stable ABI/API.
+
+## Tested Today
+
+- Configuration helper defaults and validation.
+- Known facade argument arrays.
+- Command handlers and UI action models.
+- Presenter behavior with mocked VS Code-like dependencies.
+- Checked editor bridge examples.
+- Live CLI runner for known local JSON flows.
+
+## Not Tested Today
+
+- Real VS Code Extension Host.
+- Real `DiagnosticCollection`.
+- Real QuickPick.
+- Packaging.
+- `vsce`.
+- Marketplace install.
+
+## Next Gates
+
+1. Add a `vscode` dev dependency only if an Extension Host smoke needs it.
+2. Add an isolated Extension Host smoke only if it stays cheap and local.
+3. Keep the facade boundary.
+4. Do not call `pccx_ide_cli` directly from activation.
+5. Do not make a marketplace or stable API claim.

--- a/editors/vscode-prototype/src/extension.mjs
+++ b/editors/vscode-prototype/src/extension.mjs
@@ -15,6 +15,9 @@ import {
   createCommandExecutionPlan,
   runPrototypeCommand,
 } from "./command-handlers.mjs";
+import {
+  presentAction,
+} from "./presenter.mjs";
 
 const EXTENSION_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_FACADE_PATH = resolve(EXTENSION_ROOT, "bin/pccx-vscode-prototype.mjs");
@@ -26,6 +29,7 @@ export {
   createCommandExecutionPlan,
   defaultConfig,
   normalizeConfig,
+  presentAction,
   runPrototypeCommand,
 };
 
@@ -178,6 +182,40 @@ function facadeRunnerFromRuntime(runtime = {}) {
   };
 }
 
+export function createPresenterDeps(vscodeApi, runtime = {}) {
+  const diagnosticSeverity = {
+    Error: vscodeApi?.DiagnosticSeverity?.Error ?? "Error",
+    Warning: vscodeApi?.DiagnosticSeverity?.Warning ?? "Warning",
+    Information: vscodeApi?.DiagnosticSeverity?.Information ?? "Information",
+  };
+
+  return {
+    createUri(file) {
+      return vscodeApi?.Uri?.file ? vscodeApi.Uri.file(file) : { fsPath: file };
+    },
+    createRange(startLine, startCharacter, endLine, endCharacter) {
+      return typeof vscodeApi?.Range === "function"
+        ? new vscodeApi.Range(startLine, startCharacter, endLine, endCharacter)
+        : {
+            start: { line: startLine, character: startCharacter },
+            end: { line: endLine, character: endCharacter },
+          };
+    },
+    createDiagnostic(range, message, severity) {
+      return typeof vscodeApi?.Diagnostic === "function"
+        ? new vscodeApi.Diagnostic(range, message, severity)
+        : { range, message, severity };
+    },
+    diagnosticSeverity,
+    diagnosticsCollection: runtime.diagnosticsCollection,
+    showInformationMessage: vscodeApi?.window?.showInformationMessage?.bind(vscodeApi.window),
+    showWarningMessage: (
+      vscodeApi?.window?.showWarningMessage ?? vscodeApi?.window?.showErrorMessage
+    )?.bind(vscodeApi.window),
+    showQuickPick: vscodeApi?.window?.showQuickPick?.bind(vscodeApi.window),
+  };
+}
+
 export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
   createCommandExecutionPlan(commandId, defaultConfig());
   return async (input) => {
@@ -186,16 +224,19 @@ export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
     const request = commandId === "pccxSystemVerilog.runDiagnosticsLive" && explicitPath
       ? { ...rawConfig, defaultSource: explicitPath }
       : rawConfig;
+    const presenterDeps = {
+      ...createPresenterDeps(vscodeApi, runtime),
+      ...(runtime.presenterDeps ?? {}),
+    };
     const deps = {
       runFacade: runtime.runFacade ?? facadeRunnerFromRuntime(runtime),
-      showInformationMessage: vscodeApi?.window?.showInformationMessage?.bind(vscodeApi.window),
-      showWarningMessage: (
-        vscodeApi?.window?.showWarningMessage ?? vscodeApi?.window?.showErrorMessage
-      )?.bind(vscodeApi.window),
-      updateDiagnostics: runtime.updateDiagnostics,
-      showNavigationItems: runtime.showNavigationItems,
+      updateDiagnostics: (_diagnostics, action) => presentAction(action, presenterDeps),
+      showNavigationItems: (_items, action) => presentAction(action, presenterDeps),
     };
     const result = await runPrototypeCommand(commandId, request, deps);
+    if (!result.ok) {
+      presenterDeps.showWarningMessage?.(result.error, result);
+    }
     appendCommandOutput(runtime.outputChannel, commandId, result);
     return result;
   };
@@ -216,7 +257,9 @@ export async function activate(context, injectedVscodeApi = null, runtime = {}) 
   }
 
   const outputChannel = vscodeApi.window?.createOutputChannel?.(OUTPUT_CHANNEL_NAME);
-  const commandRuntime = { ...runtime, outputChannel };
+  const diagnosticsCollection = runtime.diagnosticsCollection
+    ?? vscodeApi.languages?.createDiagnosticCollection?.(OUTPUT_CHANNEL_NAME);
+  const commandRuntime = { ...runtime, diagnosticsCollection, outputChannel };
   const registered = [];
 
   for (const commandId of COMMAND_IDS) {
@@ -230,6 +273,9 @@ export async function activate(context, injectedVscodeApi = null, runtime = {}) 
 
   if (outputChannel) {
     context?.subscriptions?.push?.(outputChannel);
+  }
+  if (diagnosticsCollection && diagnosticsCollection !== runtime.diagnosticsCollection) {
+    context?.subscriptions?.push?.(diagnosticsCollection);
   }
   return { registered };
 }

--- a/editors/vscode-prototype/src/presenter.mjs
+++ b/editors/vscode-prototype/src/presenter.mjs
@@ -1,0 +1,191 @@
+const DEFAULT_FILE = "";
+const DEFAULT_POSITION = Object.freeze({ line: 0, character: 0 });
+
+function requireAction(action, expectedKind) {
+  if (action?.kind !== expectedKind) {
+    throw new Error(`expected ${expectedKind} UI action`);
+  }
+}
+
+function safePosition(position) {
+  return {
+    line: Number.isInteger(position?.line) && position.line >= 0 ? position.line : 0,
+    character: Number.isInteger(position?.character) && position.character >= 0
+      ? position.character
+      : 0,
+  };
+}
+
+function safeRange(diagnostic) {
+  const start = safePosition(diagnostic?.range?.start ?? DEFAULT_POSITION);
+  const end = safePosition(diagnostic?.range?.end ?? {
+    line: start.line,
+    character: start.character + 1,
+  });
+  return { start, end };
+}
+
+function severityName(severity) {
+  const normalized = String(severity ?? "").toLowerCase();
+  if (normalized === "error") {
+    return "Error";
+  }
+  if (normalized === "warning") {
+    return "Warning";
+  }
+  return "Information";
+}
+
+export function mapDiagnosticSeverity(severity, diagnosticSeverity = {}) {
+  const name = severityName(severity);
+  return diagnosticSeverity[name] ?? name;
+}
+
+function groupDiagnostics(diagnostics) {
+  const groups = new Map();
+  for (const diagnostic of diagnostics) {
+    const file = diagnostic?.file == null ? DEFAULT_FILE : String(diagnostic.file);
+    if (!groups.has(file)) {
+      groups.set(file, []);
+    }
+    groups.get(file).push(diagnostic);
+  }
+  return groups;
+}
+
+export function createDiagnosticsPresentation(action) {
+  requireAction(action, "diagnostics");
+  const diagnostics = Array.isArray(action.diagnostics) ? action.diagnostics : [];
+  const files = Array.from(groupDiagnostics(diagnostics), ([file, fileDiagnostics]) => ({
+    file,
+    diagnostics: fileDiagnostics,
+  }));
+
+  return {
+    kind: "diagnostics-presentation",
+    files,
+    summary: String(action.summary ?? `${diagnostics.length} diagnostic(s)`),
+  };
+}
+
+function fallbackUri(file) {
+  return { fsPath: file };
+}
+
+function fallbackRange(startLine, startCharacter, endLine, endCharacter) {
+  return {
+    start: { line: startLine, character: startCharacter },
+    end: { line: endLine, character: endCharacter },
+  };
+}
+
+function fallbackDiagnostic(range, message, severity) {
+  return { range, message, severity };
+}
+
+function toVsCodeLikeDiagnostic(diagnostic, deps) {
+  const range = safeRange(diagnostic);
+  const vsCodeRange = (deps.createRange ?? fallbackRange)(
+    range.start.line,
+    range.start.character,
+    range.end.line,
+    range.end.character,
+  );
+  const severity = mapDiagnosticSeverity(diagnostic?.severity, deps.diagnosticSeverity);
+  return (deps.createDiagnostic ?? fallbackDiagnostic)(
+    vsCodeRange,
+    String(diagnostic?.message ?? ""),
+    severity,
+    diagnostic,
+  );
+}
+
+export function presentDiagnostics(action, deps = {}) {
+  const presentation = createDiagnosticsPresentation(action);
+  const collection = deps.diagnosticsCollection;
+
+  if (presentation.files.length === 0) {
+    collection?.clear?.();
+    deps.showInformationMessage?.(presentation.summary, presentation);
+    return presentation;
+  }
+
+  for (const fileGroup of presentation.files) {
+    const uri = (deps.createUri ?? fallbackUri)(fileGroup.file);
+    const diagnostics = fileGroup.diagnostics.map((diagnostic) => (
+      toVsCodeLikeDiagnostic(diagnostic, deps)
+    ));
+    collection?.set?.(uri, diagnostics);
+  }
+
+  if (action.diagnostics?.length > 0) {
+    deps.showWarningMessage?.(presentation.summary, presentation);
+  } else {
+    deps.showInformationMessage?.(presentation.summary, presentation);
+  }
+  return presentation;
+}
+
+function oneBased(value) {
+  return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function navigationLabel(item) {
+  const kind = item?.kind ? `${String(item.kind)} ` : "";
+  const name = item?.name ? String(item.name) : "(unnamed)";
+  return `${kind}${name}`.trim();
+}
+
+function navigationDescription(item) {
+  const file = item?.file == null ? "" : String(item.file);
+  const line = oneBased(item?.line);
+  const column = oneBased(item?.column);
+  if (line && column) {
+    return `${file}:${line}:${column}`;
+  }
+  if (line) {
+    return `${file}:${line}`;
+  }
+  return file;
+}
+
+export function createNavigationPresentation(action) {
+  requireAction(action, "navigation");
+  const items = Array.isArray(action.items) ? action.items : [];
+  return {
+    kind: "navigation-presentation",
+    items: items.map((item) => ({
+      label: navigationLabel(item),
+      description: navigationDescription(item),
+      detail: item?.kind ? String(item.kind) : "",
+      file: item?.file == null ? "" : String(item.file),
+      line: oneBased(item?.line),
+      column: oneBased(item?.column),
+    })),
+    summary: String(action.summary ?? `${items.length} navigation item(s)`),
+  };
+}
+
+export async function presentNavigation(action, deps = {}) {
+  const presentation = createNavigationPresentation(action);
+  if (presentation.items.length === 0) {
+    await deps.showInformationMessage?.(presentation.summary, presentation);
+    return presentation;
+  }
+
+  await deps.showQuickPick?.(presentation.items, {
+    title: "PCCX SystemVerilog Navigation",
+    placeHolder: presentation.summary,
+  });
+  return presentation;
+}
+
+export function presentAction(action, deps = {}) {
+  if (action?.kind === "diagnostics") {
+    return presentDiagnostics(action, deps);
+  }
+  if (action?.kind === "navigation") {
+    return presentNavigation(action, deps);
+  }
+  throw new Error(`unsupported UI action kind: ${action?.kind ?? "missing"}`);
+}

--- a/editors/vscode-prototype/test/presenter.test.mjs
+++ b/editors/vscode-prototype/test/presenter.test.mjs
@@ -1,0 +1,326 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  createDiagnosticsPresentation,
+  createNavigationPresentation,
+  mapDiagnosticSeverity,
+  presentAction,
+  presentDiagnostics,
+  presentNavigation,
+} from "../src/presenter.mjs";
+import {
+  activate,
+  deactivate,
+} from "../src/extension.mjs";
+import { COMMAND_IDS } from "../src/config.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+function diagnosticsAction(diagnostics) {
+  return {
+    kind: "diagnostics",
+    diagnostics,
+    summary: `${diagnostics.length} diagnostic(s)`,
+  };
+}
+
+function navigationAction(items) {
+  return {
+    kind: "navigation",
+    items,
+    summary: `${items.length} navigation item(s)`,
+  };
+}
+
+function mockPresenterDeps() {
+  const calls = {
+    clear: 0,
+    set: [],
+    info: [],
+    warning: [],
+    quickPick: [],
+  };
+
+  return {
+    calls,
+    deps: {
+      createUri(file) {
+        return { uri: file };
+      },
+      createRange(startLine, startCharacter, endLine, endCharacter) {
+        return { startLine, startCharacter, endLine, endCharacter };
+      },
+      createDiagnostic(range, message, severity, raw) {
+        return { range, message, severity, raw };
+      },
+      diagnosticSeverity: {
+        Error: 1,
+        Warning: 2,
+        Information: 3,
+      },
+      diagnosticsCollection: {
+        clear() {
+          calls.clear += 1;
+        },
+        set(uri, diagnostics) {
+          calls.set.push({ uri, diagnostics });
+        },
+      },
+      async showInformationMessage(message, payload) {
+        calls.info.push({ message, payload });
+      },
+      async showWarningMessage(message, payload) {
+        calls.warning.push({ message, payload });
+      },
+      async showQuickPick(items, options) {
+        calls.quickPick.push({ items, options });
+        return items[0];
+      },
+    },
+  };
+}
+
+function testDiagnosticsPresentationGroupsByFile() {
+  const action = diagnosticsAction([
+    { file: "a.sv", message: "a1" },
+    { file: "b.sv", message: "b1" },
+    { file: "a.sv", message: "a2" },
+  ]);
+  const presentation = createDiagnosticsPresentation(action);
+
+  assert.equal(presentation.kind, "diagnostics-presentation");
+  assert.equal(presentation.summary, "3 diagnostic(s)");
+  assert.deepEqual(
+    presentation.files.map((group) => [group.file, group.diagnostics.length]),
+    [["a.sv", 2], ["b.sv", 1]],
+  );
+}
+
+function testDiagnosticsPresenterCallsCollectionSet() {
+  const { calls, deps } = mockPresenterDeps();
+  const action = diagnosticsAction([
+    {
+      file: "a.sv",
+      message: "bad",
+      severity: "Error",
+      range: { start: { line: 2, character: 4 }, end: { line: 2, character: 5 } },
+    },
+  ]);
+
+  const presentation = presentDiagnostics(action, deps);
+
+  assert.equal(presentation.files.length, 1);
+  assert.equal(calls.set.length, 1);
+  assert.deepEqual(calls.set[0].uri, { uri: "a.sv" });
+  assert.deepEqual(calls.set[0].diagnostics[0].range, {
+    startLine: 2,
+    startCharacter: 4,
+    endLine: 2,
+    endCharacter: 5,
+  });
+  assert.equal(calls.set[0].diagnostics[0].severity, 1);
+  assert.equal(calls.warning[0].message, "1 diagnostic(s)");
+}
+
+function testDiagnosticsZeroCaseClearsCollection() {
+  const { calls, deps } = mockPresenterDeps();
+  const presentation = presentDiagnostics(diagnosticsAction([]), deps);
+
+  assert.equal(presentation.files.length, 0);
+  assert.equal(calls.clear, 1);
+  assert.equal(calls.set.length, 0);
+  assert.equal(calls.info[0].message, "0 diagnostic(s)");
+}
+
+function testDiagnosticsSeverityMapping() {
+  const severity = { Error: "E", Warning: "W", Information: "I" };
+  assert.equal(mapDiagnosticSeverity("Error", severity), "E");
+  assert.equal(mapDiagnosticSeverity("Warning", severity), "W");
+  assert.equal(mapDiagnosticSeverity("Information", severity), "I");
+  assert.equal(mapDiagnosticSeverity("notice", severity), "I");
+}
+
+function testDiagnosticsMissingFileAndLocation() {
+  const { calls, deps } = mockPresenterDeps();
+  const action = diagnosticsAction([{ message: "missing location", severity: "notice" }]);
+  const presentation = presentDiagnostics(action, deps);
+
+  assert.equal(presentation.files[0].file, "");
+  assert.deepEqual(calls.set[0].uri, { uri: "" });
+  assert.deepEqual(calls.set[0].diagnostics[0].range, {
+    startLine: 0,
+    startCharacter: 0,
+    endLine: 0,
+    endCharacter: 1,
+  });
+  assert.equal(calls.set[0].diagnostics[0].severity, 3);
+}
+
+function testNavigationPresentationCreatesQuickPickItems() {
+  const action = navigationAction([
+    {
+      name: "simple_mod",
+      kind: "module",
+      file: "fixtures/modules/simple_module.sv",
+      line: 1,
+      column: 1,
+    },
+  ]);
+  const presentation = createNavigationPresentation(action);
+
+  assert.equal(presentation.kind, "navigation-presentation");
+  assert.deepEqual(presentation.items[0], {
+    label: "module simple_mod",
+    description: "fixtures/modules/simple_module.sv:1:1",
+    detail: "module",
+    file: "fixtures/modules/simple_module.sv",
+    line: 1,
+    column: 1,
+  });
+}
+
+async function testNavigationPresenterCallsQuickPick() {
+  const { calls, deps } = mockPresenterDeps();
+  const action = navigationAction([
+    { name: "pkg_defs", kind: "package", file: "pkg.sv", line: 1, column: 1 },
+  ]);
+
+  const presentation = await presentNavigation(action, deps);
+
+  assert.equal(presentation.items.length, 1);
+  assert.equal(calls.quickPick.length, 1);
+  assert.equal(calls.quickPick[0].items[0].label, "package pkg_defs");
+  assert.equal(calls.quickPick[0].options.placeHolder, "1 navigation item(s)");
+}
+
+async function testNavigationZeroCaseShowsInformation() {
+  const { calls, deps } = mockPresenterDeps();
+  const presentation = await presentNavigation(navigationAction([]), deps);
+
+  assert.equal(presentation.items.length, 0);
+  assert.equal(calls.quickPick.length, 0);
+  assert.equal(calls.info[0].message, "0 navigation item(s)");
+}
+
+function testInvalidActionsRejected() {
+  assert.throws(
+    () => createDiagnosticsPresentation({ kind: "navigation", items: [] }),
+    /expected diagnostics UI action/,
+  );
+  assert.throws(
+    () => createNavigationPresentation({ kind: "diagnostics", diagnostics: [] }),
+    /expected navigation UI action/,
+  );
+}
+
+async function testPresentActionDispatches() {
+  const diagnosticsDeps = mockPresenterDeps();
+  const diagnosticPresentation = await presentAction(
+    diagnosticsAction([{ file: "a.sv", message: "bad" }]),
+    diagnosticsDeps.deps,
+  );
+  assert.equal(diagnosticPresentation.kind, "diagnostics-presentation");
+  assert.equal(diagnosticsDeps.calls.set.length, 1);
+
+  const navigationDeps = mockPresenterDeps();
+  const navigationPresentation = await presentAction(
+    navigationAction([{ name: "simple_mod", kind: "module", file: "a.sv" }]),
+    navigationDeps.deps,
+  );
+  assert.equal(navigationPresentation.kind, "navigation-presentation");
+  assert.equal(navigationDeps.calls.quickPick.length, 1);
+}
+
+async function testExtensionEntrypointCanWirePresenter() {
+  assert.equal(typeof activate, "function");
+  assert.equal(typeof deactivate, "function");
+
+  const registered = new Map();
+  const calls = {
+    set: [],
+    warning: [],
+  };
+  const vscodeApi = {
+    commands: {
+      registerCommand(commandId, handler) {
+        registered.set(commandId, handler);
+        return { dispose() {} };
+      },
+    },
+    window: {
+      createOutputChannel() {
+        return { appendLine() {}, show() {}, dispose() {} };
+      },
+      showWarningMessage(message) {
+        calls.warning.push(message);
+      },
+    },
+  };
+
+  const activation = await activate(
+    { subscriptions: [] },
+    vscodeApi,
+    {
+      async runFacade() {
+        return {
+          ok: true,
+          json: {
+            kind: "vscode-diagnostics",
+            diagnostics: [{ file: "a.sv", message: "bad", severity: "Error" }],
+          },
+        };
+      },
+      presenterDeps: {
+        createUri(file) {
+          return { uri: file };
+        },
+        diagnosticsCollection: {
+          set(uri, diagnostics) {
+            calls.set.push({ uri, diagnostics });
+          },
+          clear() {},
+        },
+      },
+    },
+  );
+
+  assert.deepEqual(activation.registered, COMMAND_IDS);
+  const result = await registered.get("pccxSystemVerilog.showDiagnosticsExample")();
+  assert.equal(result.ok, true);
+  assert.equal(calls.set.length, 1);
+  assert.deepEqual(calls.set[0].uri, { uri: "a.sv" });
+}
+
+async function testPresenterDoesNotImportVscode() {
+  const source = await readFile(resolve(ROOT, "editors/vscode-prototype/src/presenter.mjs"), "utf8");
+  const testSource = await readFile(resolve(ROOT, "editors/vscode-prototype/test/presenter.test.mjs"), "utf8");
+
+  assert.doesNotMatch(source, /from ["']vscode["']|import\(["']vscode["']\)/);
+  assert.doesNotMatch(testSource, /from ["']vscode["']|import\(["']vscode["']\)/);
+}
+
+function testPresenterDoesNotReturnShellStrings() {
+  const diagnostics = createDiagnosticsPresentation(diagnosticsAction([]));
+  const navigation = createNavigationPresentation(navigationAction([]));
+  assert.doesNotMatch(JSON.stringify(diagnostics), /(?:&&|\|\||;|`|\$\()/);
+  assert.doesNotMatch(JSON.stringify(navigation), /(?:&&|\|\||;|`|\$\()/);
+}
+
+testDiagnosticsPresentationGroupsByFile();
+testDiagnosticsPresenterCallsCollectionSet();
+testDiagnosticsZeroCaseClearsCollection();
+testDiagnosticsSeverityMapping();
+testDiagnosticsMissingFileAndLocation();
+testNavigationPresentationCreatesQuickPickItems();
+await testNavigationPresenterCallsQuickPick();
+await testNavigationZeroCaseShowsInformation();
+testInvalidActionsRejected();
+await testPresentActionDispatches();
+await testExtensionEntrypointCanWirePresenter();
+await testPresenterDoesNotImportVscode();
+testPresenterDoesNotReturnShellStrings();
+
+console.log("vscode presenter tests ok");

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -16,6 +16,7 @@ node editors/vscode-prototype/test/extension-manifest.test.mjs
 node editors/vscode-prototype/test/extension-config.test.mjs
 node editors/vscode-prototype/test/extension-entrypoint.test.mjs
 node editors/vscode-prototype/test/command-handlers.test.mjs
+node editors/vscode-prototype/test/presenter.test.mjs
 node editors/vscode-prototype/src/adapter.mjs diagnostics \
   docs/examples/editor-bridge/problems-xsim-mixed.example.json \
   | node -e "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{const d=JSON.parse(s);if(!Array.isArray(d)||d.length===0)process.exit(1);})"


### PR DESCRIPTION
## Summary
- Model used: GPT-5.5 xhigh requested for VS Code-facing presenter boundaries, activation wiring, extension-host readiness, and merge readiness decisions.
- Spark usage: none.
- Presenter scope: added `src/presenter.mjs` with mockable diagnostics/navigation presentation helpers and `presentAction` dispatch.
- Diagnostics/navigation presentation behavior: diagnostics group by file and call a DiagnosticCollection-like dependency; navigation creates deterministic QuickPick-like items and handles zero-result information messages.
- Extension-host readiness scope: added `docs/EXTENSION_HOST_READINESS.md` covering tested surfaces, untested real Extension Host surfaces, and next gates.
- Facade/action boundary usage: command path remains facade JSON -> command-handler UI action -> presenter; activation still routes through `bin/pccx-vscode-prototype.mjs` and does not call `pccx_ide_cli` directly.
- Tests/smoke added: new `presenter.test.mjs`, updated entrypoint presenter wiring, and updated `scripts/vscode-adapter-smoke.sh`.
- Non-goals held: no VS Code GUI tests, no LSP, no published extension, no marketplace readiness, and no stable ABI/API claim.
- FPGA repo untouched: no reads, writes, git commands, PRs, issues, tags, or releases under `/home/hwkim/Desktop/github/pccxai/pccx-FPGA-NPU-LLM-kv260`.
- Token-saving / compact handoff note: used targeted reads, focused Node checks during iteration, full validation before PR, and will include COMPACT_HANDOFF in the final report.

## Validation
- `python3 -m pytest -q` -> 164 passed
- `bash scripts/editor-bridge-smoke.sh` -> passed
- `bash scripts/check-editor-bridge-examples.sh` -> passed
- `node editors/vscode-prototype/test/adapter.test.mjs` -> passed
- `node editors/vscode-prototype/test/cli-runner.test.mjs` -> passed
- `node editors/vscode-prototype/test/facade.test.mjs` -> passed
- `node editors/vscode-prototype/test/extension-manifest.test.mjs` -> passed
- `node editors/vscode-prototype/test/extension-entrypoint.test.mjs` -> passed
- `node editors/vscode-prototype/test/extension-config.test.mjs` -> passed
- `node editors/vscode-prototype/test/command-handlers.test.mjs` -> passed
- `node editors/vscode-prototype/test/presenter.test.mjs` -> passed
- `bash scripts/vscode-adapter-smoke.sh` -> passed
- `git diff --check` -> passed
- `node --test editors/vscode-prototype/test/*.test.mjs` -> passed