### PR TITLE
test: add VS Code extension host smoke readiness scaffold

### DIFF
--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -88,10 +88,12 @@ models for diagnostics and navigation behind injected VS Code-like
 dependencies.
 The presenter scaffold maps those UI action models to mockable
 DiagnosticCollection-like and QuickPick-like APIs without requiring real
-VS Code GUI tests.
+VS Code GUI tests.  A guarded local-only Extension Host smoke scaffold
+exists, but it is disabled by default and no real VS Code Extension Host
+coverage is claimed yet.
 The scaffold is not published, is not marketplace-ready, has no LSP, and
-is not a stable ABI/API.  Current coverage is static/smoke tests, not VS
-Code GUI integration tests.
+is not a stable ABI/API.  Current coverage is mostly static/mock tests
+and smoke tests, not VS Code GUI integration tests.
 The prototype documents the 1-based CLI position to 0-based editor
 position conversion expected by editor adapters.
 

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -1,6 +1,6 @@
 # VS Code Prototype Adapter
 
-This directory is an experimental local prototype for translating
+This directory is an experimental local VS Code prototype for translating
 pre-stable editor bridge JSON into VS Code-style data records and for
 hosting a minimal local VS Code extension package scaffold.
 
@@ -8,8 +8,9 @@ The extension scaffold is not published, is not marketplace-ready, has no
 LSP, and does not define a stable ABI/API.  It can consume the checked
 examples under `docs/examples/editor-bridge` and can also run limited
 live JSON flows from this source tree through the local command facade.
-The current tests are static/smoke tests, not VS Code GUI integration
-tests, and they run without npm install, Vivado, xsim, or hardware.
+The current tests are mostly static/mock tests, not VS Code GUI
+integration tests, and they run without npm install, Vivado, xsim, or
+hardware.
 
 ## Data Mapping
 
@@ -120,13 +121,16 @@ consumes command-handler UI actions and maps diagnostics/navigation
 actions to mocked VS Code-like APIs.  Diagnostics presentation groups
 records by file for a `DiagnosticCollection`-like dependency, and
 navigation presentation creates deterministic QuickPick-like items.
-These behaviors are tested through mocks only; there are still no real
-VS Code GUI or Extension Host integration tests.  Extension Host gates are
-tracked in [`docs/EXTENSION_HOST_READINESS.md`](./docs/EXTENSION_HOST_READINESS.md).
+These behaviors are tested through mocks only.  A guarded local-only
+Extension Host smoke scaffold now exists at
+`scripts/vscode-extension-host-smoke.sh`, but it exits as not enabled by
+default and no real VS Code Extension Host coverage is claimed yet.
+Extension Host gates are tracked in
+[`docs/EXTENSION_HOST_READINESS.md`](./docs/EXTENSION_HOST_READINESS.md).
 
 This scaffold is not LSP, not a full IDE replacement, not a stable
 ABI/API, and not a marketplace-ready or published extension.
-There are no VS Code GUI/integration tests yet.
+There are no enabled VS Code GUI or Extension Host integration tests yet.
 
 ## Local Smoke
 
@@ -139,7 +143,19 @@ node editors/vscode-prototype/test/extension-config.test.mjs
 node editors/vscode-prototype/test/extension-entrypoint.test.mjs
 node editors/vscode-prototype/test/command-handlers.test.mjs
 node editors/vscode-prototype/test/presenter.test.mjs
+node editors/vscode-prototype/test/extension-host-readiness.test.mjs
 bash scripts/vscode-adapter-smoke.sh
+```
+
+`scripts/vscode-extension-host-smoke.sh` is intentionally guarded.  By
+default it exits with a clear not-enabled message and does not download
+VS Code, Electron, or npm dependencies.  `PCCX_RUN_EXTENSION_HOST_SMOKE=1`
+is reserved for a future pinned `@vscode/test-electron` runner after the
+dependency and CI policy are explicitly reviewed.
+
+```bash
+# Expected exit 2 until a real Extension Host runner is explicitly enabled.
+bash scripts/vscode-extension-host-smoke.sh
 ```
 
 The adapter can also print translated examples:

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -5,6 +5,11 @@
 This is a local experimental VS Code extension scaffold.  It is not
 published, not marketplace-ready, not LSP, and not a stable ABI/API.
 
+Feasibility decision for this phase: Option B.  Real Extension Host smoke
+is not enabled yet because the repository currently has no npm install
+path, no lockfile, no VS Code test dependency, and CI is intentionally
+limited to deterministic static/mock smoke coverage.
+
 ## Tested Today
 
 - Configuration helper defaults and validation.
@@ -13,6 +18,7 @@ published, not marketplace-ready, not LSP, and not a stable ABI/API.
 - Presenter behavior with mocked VS Code-like dependencies.
 - Checked editor bridge examples.
 - Live CLI runner for known local JSON flows.
+- Guard behavior for the local-only Extension Host smoke scaffold.
 
 ## Not Tested Today
 
@@ -23,10 +29,26 @@ published, not marketplace-ready, not LSP, and not a stable ABI/API.
 - `vsce`.
 - Marketplace install.
 
+No real VS Code Extension Host coverage is claimed by this scaffold.
+
+## Guarded Local Scaffold
+
+`scripts/vscode-extension-host-smoke.sh` is a guarded local-only scaffold.
+By default it exits with a not-enabled message, prints the exact next
+gate, and does not download VS Code, Electron, or npm dependencies.
+
+`PCCX_RUN_EXTENSION_HOST_SMOKE=1` is reserved for a future isolated runner
+under `editors/vscode-prototype/test/extension-host/` after a pinned
+`@vscode/test-electron` dependency, lockfile impact, and CI policy are
+explicitly reviewed.  The guarded script is not run by CI today.
+
 ## Next Gates
 
-1. Add a `vscode` dev dependency only if an Extension Host smoke needs it.
-2. Add an isolated Extension Host smoke only if it stays cheap and local.
+1. Add a pinned VS Code test dependency only if an Extension Host smoke is
+   approved.
+2. Add an isolated Extension Host runner only if it stays cheap and local.
 3. Keep the facade boundary.
 4. Do not call `pccx_ide_cli` directly from activation.
-5. Do not make a marketplace or stable API claim.
+5. Do not add `vsce`, publisher metadata, packaging scripts, LSP, or
+   marketplace flow.
+6. Do not make a marketplace, published-extension, or stable API claim.

--- a/editors/vscode-prototype/package.json
+++ b/editors/vscode-prototype/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pccx-systemverilog-ide-prototype",
   "displayName": "PCCX SystemVerilog IDE Prototype",
-  "description": "Experimental local VS Code extension scaffold for the PCCX SystemVerilog IDE prototype; not published and not marketplace-ready.",
+  "description": "Experimental local VS Code extension scaffold for the PCCX SystemVerilog IDE prototype; not published.",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/editors/vscode-prototype/test/extension-config.test.mjs
+++ b/editors/vscode-prototype/test/extension-config.test.mjs
@@ -32,8 +32,13 @@ async function testPackageConfigurationSchema() {
   const configuration = manifest.contributes?.configuration;
   assert.ok(configuration);
   assert.equal(configuration.title, "PCCX SystemVerilog IDE Prototype");
+  assert.deepEqual(
+    Object.keys(configuration.properties ?? {}).sort(),
+    Array.from(REQUIRED_SETTINGS.keys()).sort(),
+  );
 
   for (const [setting, expected] of REQUIRED_SETTINGS) {
+    assert.ok(setting.startsWith("pccxSystemVerilog."), `${setting} is not prototype-scoped`);
     const property = configuration.properties?.[setting];
     assert.ok(property, `${setting} missing`);
     assert.equal(property.type, "string");

--- a/editors/vscode-prototype/test/extension-host-readiness.test.mjs
+++ b/editors/vscode-prototype/test/extension-host-readiness.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { constants } from "node:fs";
+import { access, readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const EXTENSION_ROOT = resolve(ROOT, "editors/vscode-prototype");
+const SCRIPT = resolve(ROOT, "scripts/vscode-extension-host-smoke.sh");
+
+async function readText(path) {
+  return readFile(path, "utf8");
+}
+
+async function pathExists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function testNoRuntimeDependencyChurn() {
+  const manifest = JSON.parse(await readText(resolve(EXTENSION_ROOT, "package.json")));
+  const deps = {
+    ...(manifest.dependencies ?? {}),
+    ...(manifest.devDependencies ?? {}),
+  };
+
+  assert.equal(deps["@vscode/test-electron"], undefined);
+  assert.equal(deps.vscode, undefined);
+  assert.equal(await pathExists(resolve(ROOT, "package-lock.json")), false);
+  assert.equal(await pathExists(resolve(EXTENSION_ROOT, "package-lock.json")), false);
+}
+
+function testGuardedScriptDefault() {
+  const result = spawnSync("bash", [SCRIPT], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PCCX_RUN_EXTENSION_HOST_SMOKE: "",
+    },
+  });
+  const output = `${result.stdout}\n${result.stderr}`;
+
+  assert.equal(result.status, 2);
+  assert.match(output, /Extension Host smoke is not enabled yet/);
+  assert.match(output, /static\/mock-only/);
+  assert.match(output, /no real VS Code Extension Host coverage is claimed/);
+  assert.match(output, /PCCX_RUN_EXTENSION_HOST_SMOKE=1/);
+  assert.match(output, /@vscode\/test-electron/);
+  assert.match(output, /do not add vsce/);
+}
+
+async function testReadinessDocsAndCiPolicy() {
+  const readme = await readText(resolve(EXTENSION_ROOT, "README.md"));
+  const readiness = await readText(resolve(EXTENSION_ROOT, "docs/EXTENSION_HOST_READINESS.md"));
+  const bridgeContract = await readText(resolve(ROOT, "docs/EDITOR_BRIDGE_CONTRACT.md"));
+  const ci = await readText(resolve(ROOT, ".github/workflows/ci.yml"));
+
+  assert.match(readme, /experimental local VS Code prototype/i);
+  assert.match(readme, /mostly static\/mock tests/i);
+  assert.match(readme, /guarded local-only\s+Extension Host smoke/i);
+  assert.match(readiness, /Option B/i);
+  assert.match(readiness, /guarded local-only scaffold/i);
+  assert.match(readiness, /PCCX_RUN_EXTENSION_HOST_SMOKE=1/);
+  assert.match(readiness, /No real VS Code Extension Host coverage is claimed/i);
+  assert.match(bridgeContract, /guarded local-only\s+Extension Host smoke scaffold/i);
+  assert.doesNotMatch(ci, /vscode-extension-host-smoke\.sh/);
+}
+
+async function testGuardScriptNamesFutureRunnerButDoesNotProvideIt() {
+  const script = await readText(SCRIPT);
+
+  assert.match(script, /PCCX_RUN_EXTENSION_HOST_SMOKE/);
+  assert.match(script, /run-extension-host-smoke\.mjs/);
+  assert.equal(
+    await pathExists(resolve(EXTENSION_ROOT, "test/extension-host/run-extension-host-smoke.mjs")),
+    false,
+  );
+}
+
+await testNoRuntimeDependencyChurn();
+testGuardedScriptDefault();
+await testReadinessDocsAndCiPolicy();
+await testGuardScriptNamesFutureRunnerButDoesNotProvideIt();
+
+console.log("vscode extension host readiness tests ok");

--- a/editors/vscode-prototype/test/extension-manifest.test.mjs
+++ b/editors/vscode-prototype/test/extension-manifest.test.mjs
@@ -43,6 +43,7 @@ async function testPackageManifestShape() {
   assert.equal(manifest.displayName, "PCCX SystemVerilog IDE Prototype");
   assert.match(manifest.description, /experimental local VS Code extension scaffold/i);
   assert.match(manifest.description, /not published/i);
+  assert.doesNotMatch(manifest.description, /marketplace/i);
   assert.ok(manifest.engines?.vscode);
   assert.equal(manifest.main, "./src/extension.mjs");
 }
@@ -54,6 +55,7 @@ async function testNoMarketplacePublishingShape() {
   assert.equal(Object.hasOwn(manifest, "publisher"), false);
   assert.equal(Object.hasOwn(manifest, "galleryBanner"), false);
   assert.doesNotMatch(manifestStrings, /\bvsce\b/i);
+  assert.equal(manifest.scripts, undefined);
   assert.equal(manifest.scripts?.publish, undefined);
   assert.equal(manifest.scripts?.package, undefined);
   assert.equal(manifest.dependencies, undefined);
@@ -66,7 +68,13 @@ async function testCommandContributions() {
     manifest.contributes?.commands?.map((command) => command.command),
   );
   const activationEvents = new Set(manifest.activationEvents);
+  const commandIds = manifest.contributes?.commands?.map((command) => command.command);
 
+  assert.deepEqual(commandIds, COMMAND_IDS);
+  assert.deepEqual(
+    manifest.activationEvents,
+    COMMAND_IDS.map((commandId) => `onCommand:${commandId}`),
+  );
   for (const commandId of COMMAND_IDS) {
     assert.ok(contributedCommands.has(commandId), `${commandId} missing from contributes.commands`);
     assert.ok(
@@ -87,7 +95,8 @@ async function testDocsKeepExperimentalScope() {
   assert.match(combined, /not marketplace-ready/i);
   assert.match(combined, /no LSP/i);
   assert.match(combined, /not a stable ABI\/API/i);
-  assert.match(combined, /static\/smoke tests/i);
+  assert.match(combined, /static\/mock tests/i);
+  assert.match(combined, /no real VS Code Extension Host coverage is claimed/i);
 }
 
 await testPackageManifestShape();

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -17,6 +17,7 @@ node editors/vscode-prototype/test/extension-config.test.mjs
 node editors/vscode-prototype/test/extension-entrypoint.test.mjs
 node editors/vscode-prototype/test/command-handlers.test.mjs
 node editors/vscode-prototype/test/presenter.test.mjs
+node editors/vscode-prototype/test/extension-host-readiness.test.mjs
 node editors/vscode-prototype/src/adapter.mjs diagnostics \
   docs/examples/editor-bridge/problems-xsim-mixed.example.json \
   | node -e "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{const d=JSON.parse(s);if(!Array.isArray(d)||d.length===0)process.exit(1);})"

--- a/scripts/vscode-extension-host-smoke.sh
+++ b/scripts/vscode-extension-host-smoke.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUNNER="$ROOT/editors/vscode-prototype/test/extension-host/run-extension-host-smoke.mjs"
+
+cat_guard_message() {
+  cat >&2 <<'EOF'
+VS Code Extension Host smoke is not enabled yet.
+
+Current coverage remains static/mock-only; no real VS Code Extension Host coverage is claimed.
+
+Next gate, when explicitly approved:
+- add a pinned @vscode/test-electron dev dependency
+- add an isolated runner at editors/vscode-prototype/test/extension-host/run-extension-host-smoke.mjs
+- keep the smoke local-only until CI stability is reviewed
+- do not add vsce, packaging, publisher metadata, LSP, or marketplace flow
+
+Set PCCX_RUN_EXTENSION_HOST_SMOKE=1 only after that runner and dependency policy are in place.
+EOF
+}
+
+if [[ "${PCCX_RUN_EXTENSION_HOST_SMOKE:-}" != "1" ]]; then
+  cat_guard_message
+  exit 2
+fi
+
+if [[ ! -f "$RUNNER" ]]; then
+  cat_guard_message
+  echo "error: enabled by environment, but runner is missing: $RUNNER" >&2
+  exit 2
+fi
+
+exec node "$RUNNER"


### PR DESCRIPTION
## Model

Used GPT-5.5 xhigh per repo routing because this phase makes the Extension Host readiness and CI-policy decision.

## Extension Host Smoke Decision

Decision: Option B, guarded local-only scaffold. Real isolated Extension Host smoke is not enabled yet.

Rationale: the prototype currently has no npm install path, no package-lock, no VS Code test dependency, and CI is intentionally deterministic/static. Adding `@vscode/test-electron` now would introduce Electron/VS Code download behavior and lockfile churn before the runtime gate is ready.

## Behavior

- Adds `scripts/vscode-extension-host-smoke.sh`.
- By default it exits with a clear not-enabled message and code 2.
- It does not download VS Code, Electron, or npm dependencies.
- `PCCX_RUN_EXTENSION_HOST_SMOKE=1` is reserved for a future pinned runner under `editors/vscode-prototype/test/extension-host/`.
- CI does not run real Extension Host smoke in this PR.

## Dependencies

No dependencies added. No npm lockfile added. No `vsce`, publisher metadata, packaging script, marketplace flow, LSP server, or stable ABI/API claim added.

## Tests / Smoke Added

- Added `editors/vscode-prototype/test/extension-host-readiness.test.mjs`.
- Strengthened manifest/config static guards for private package shape, no publisher, no scripts/dependencies, minimal activation events, expected command IDs, prototype-scoped settings, and guarded readiness docs.
- Added the readiness guard test to `scripts/vscode-adapter-smoke.sh`.

## Validation Run

- `node editors/vscode-prototype/test/adapter.test.mjs`
- `node editors/vscode-prototype/test/cli-runner.test.mjs`
- `node editors/vscode-prototype/test/facade.test.mjs`
- `node editors/vscode-prototype/test/extension-manifest.test.mjs`
- `node editors/vscode-prototype/test/extension-config.test.mjs`
- `node editors/vscode-prototype/test/extension-entrypoint.test.mjs`
- `node editors/vscode-prototype/test/command-handlers.test.mjs`
- `node editors/vscode-prototype/test/presenter.test.mjs`
- `node editors/vscode-prototype/test/extension-host-readiness.test.mjs`
- `python3 -m pytest -q` -> 164 passed
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `bash scripts/vscode-extension-host-smoke.sh` -> expected guarded exit 2
- `git diff --check`

## Safety Notes

- No VS Code marketplace or published-extension claim.
- No LSP claim.
- No stable ABI/API claim.
- Facade boundary remains the backend boundary.
- FPGA repo untouched: `/home/hwkim/Desktop/github/pccxai/pccx-FPGA-NPU-LLM-kv260` was not accessed, read, edited, or used.
- No release or tag created.

## Compact Handoff Note

This PR intentionally stops at a guarded readiness scaffold. The next real runtime gate should only add pinned `@vscode/test-electron` and a minimal `activate`/command registration Extension Host runner after dependency and CI policy review.
