### PR TITLE
feat: add VS Code DiagnosticCollection command smoke

### DIFF
--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -83,6 +83,7 @@ VS Code manifest wrapper; the implementation stays in `src/extension.mjs`.
 
 The contributed commands are:
 
+- `pccxSystemVerilog.publishCheckedExampleDiagnostics`
 - `pccxSystemVerilog.showDiagnosticsExample`
 - `pccxSystemVerilog.showNavigationExample`
 - `pccxSystemVerilog.runDiagnosticsLive`
@@ -97,11 +98,16 @@ The prototype-only settings are:
 - `pccxSystemVerilog.defaultModule`, default `simple_mod`
 - `pccxSystemVerilog.defaultDeclarationKind`, default `module`
 
-The default mode is checked-example mode.  The explicit example commands
-always build checked-example facade arguments, and the explicit live
-commands always build known live facade arguments.  Live diagnostics uses
+The default diagnostics publishing command is
+`pccxSystemVerilog.publishCheckedExampleDiagnostics`.  It is experimental
+and always uses the checked `check-missing-endmodule` example through the
+facade boundary.  The explicit example commands always build
+checked-example facade arguments, and the explicit live commands always
+build known live facade arguments.  Live diagnostics uses
 `--from-check <defaultSource>`.  Live navigation uses
 `--locate fixtures/modules <defaultModule> --kind <defaultDeclarationKind>`.
+Live mode remains separate and explicit; the extension does not silently
+fall back between live and checked-example modes.
 
 The command handlers are thin wrappers around the local facade.  They
 normalize the prototype-only settings, build known facade argument arrays,
@@ -118,23 +124,39 @@ Diagnostics facade payloads become `{ kind: "diagnostics", diagnostics,
 summary }` actions, and navigation facade payloads become
 `{ kind: "navigation", items, summary }` actions.  Tests use injected and
 mocked VS Code-like dependencies such as `runFacade`, `updateDiagnostics`,
-and `showNavigationItems`; they do not use a real `DiagnosticCollection`,
-quick pick, or VS Code GUI integration test.
+and `showNavigationItems` for static coverage.
 
 `src/presenter.mjs` is the experimental local presenter scaffold.  It
 consumes command-handler UI actions and maps diagnostics/navigation
 actions to mocked VS Code-like APIs.  Diagnostics presentation groups
 records by file for a `DiagnosticCollection`-like dependency, and
 navigation presentation creates deterministic QuickPick-like items.
-These behaviors are tested through mocks only.  A guarded local-only
-Extension Host runtime smoke now exists at
+The opt-in Extension Host runtime smoke additionally verifies that the
+checked-example diagnostics command publishes at least one real VS Code
+diagnostic with URI, range, severity, message, and source fields through
+a `DiagnosticCollection`.  A guarded local-only Extension Host runtime
+smoke now exists at
 `scripts/vscode-extension-host-smoke.sh`, but it exits 2 by default and
 only runs when `PCCX_RUN_EXTENSION_HOST_SMOKE=1` is set.  The runtime
 smoke loads the local extension package, verifies activation/command
-registration, and executes one checked-example command.  It does not run
-the live CLI path, package the extension, or install from the
-marketplace.  Extension Host gates are tracked in
+registration, and executes the checked-example diagnostics publishing
+command.  It does not run the live CLI path, package the extension, or
+install from the marketplace.  Extension Host gates are tracked in
 [`docs/EXTENSION_HOST_READINESS.md`](./docs/EXTENSION_HOST_READINESS.md).
+
+## Theme-Neutral Presentation Boundary
+
+`src/presentation-boundary.mjs` defines the first theme-neutral
+presentation boundary for editor-facing records.  Diagnostics and command
+output carry semantic fields such as file, range, severity, message, and
+source; they do not carry editor colors or style constants.  The VS Code
+path uses native `DiagnosticSeverity` and `DiagnosticCollection` APIs.
+
+The current policy is host theme first.  Future UI or webview surfaces
+should use host theme tokens or explicit user-provided theme tokens.
+VS Code, Xcode, and JetBrains are future presentation preset families,
+not implemented skins and not completion claims.  This is not a completed
+custom theme system.
 
 This scaffold is not LSP, not a full IDE replacement, not a stable
 ABI/API, and not a marketplace-ready or published extension.
@@ -151,6 +173,7 @@ node editors/vscode-prototype/test/extension-config.test.mjs
 node editors/vscode-prototype/test/extension-entrypoint.test.mjs
 node editors/vscode-prototype/test/command-handlers.test.mjs
 node editors/vscode-prototype/test/presenter.test.mjs
+node editors/vscode-prototype/test/presentation-boundary.test.mjs
 node editors/vscode-prototype/test/extension-host-readiness.test.mjs
 bash scripts/vscode-adapter-smoke.sh
 ```

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -19,6 +19,8 @@ should earn CI promotion separately.
 - Known facade argument arrays.
 - Command handlers and UI action models.
 - Presenter behavior with mocked VS Code-like dependencies.
+- Real VS Code `DiagnosticCollection` population for the checked-example
+  diagnostics command when the local runtime smoke is explicitly enabled.
 - Checked editor bridge examples.
 - Live CLI runner for known local JSON flows.
 - Guard behavior for the local-only Extension Host runtime smoke.
@@ -27,7 +29,6 @@ should earn CI promotion separately.
 
 ## Not Tested Today
 
-- Real `DiagnosticCollection`.
 - Real QuickPick.
 - Packaging.
 - `vsce`.
@@ -54,10 +55,27 @@ PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh
 The runner lives under `editors/vscode-prototype/test/extension-host/`.
 It uses `@vscode/test-electron@2.5.2`, pins VS Code to `1.90.2`, creates
 a temporary workspace, loads the local extension package, verifies the
-expected command IDs, and executes only the checked-example diagnostics
-command.  It does not execute live CLI commands by default.
+expected command IDs, and executes only
+`pccxSystemVerilog.publishCheckedExampleDiagnostics`.  That command uses
+checked example diagnostics by default, goes through the facade boundary,
+and verifies that VS Code receives at least one diagnostic with URI,
+range, severity, message, and source fields.  It does not execute live
+CLI commands by default.
 
 The guarded script is not run by CI today.
+
+## Theme Boundary
+
+The current presentation boundary is intentionally small and
+theme-neutral.  Diagnostic records and command output do not carry
+hardcoded editor colors or styles; VS Code diagnostics use native
+severity and `DiagnosticCollection` APIs.  Future UI or webview surfaces
+should use host theme tokens first, with explicit user-provided theme
+tokens as the customization path.
+
+VS Code, Xcode, and JetBrains are future presentation preset families.
+They are not implemented skins and do not imply a completed custom theme
+system.
 
 ## Dependency and CI Policy
 

--- a/editors/vscode-prototype/package.json
+++ b/editors/vscode-prototype/package.json
@@ -13,6 +13,7 @@
     "Other"
   ],
   "activationEvents": [
+    "onCommand:pccxSystemVerilog.publishCheckedExampleDiagnostics",
     "onCommand:pccxSystemVerilog.showDiagnosticsExample",
     "onCommand:pccxSystemVerilog.showNavigationExample",
     "onCommand:pccxSystemVerilog.runDiagnosticsLive",
@@ -20,6 +21,10 @@
   ],
   "contributes": {
     "commands": [
+      {
+        "command": "pccxSystemVerilog.publishCheckedExampleDiagnostics",
+        "title": "PCCX SystemVerilog: Publish Checked Example Diagnostics (Experimental)"
+      },
       {
         "command": "pccxSystemVerilog.showDiagnosticsExample",
         "title": "PCCX SystemVerilog: Show Diagnostics Example"

--- a/editors/vscode-prototype/src/config.mjs
+++ b/editors/vscode-prototype/src/config.mjs
@@ -10,6 +10,7 @@ export const CONFIG_KEYS = Object.freeze([
 ]);
 
 export const COMMAND_IDS = Object.freeze([
+  "pccxSystemVerilog.publishCheckedExampleDiagnostics",
   "pccxSystemVerilog.showDiagnosticsExample",
   "pccxSystemVerilog.showNavigationExample",
   "pccxSystemVerilog.runDiagnosticsLive",
@@ -88,7 +89,10 @@ export function normalizeConfig(rawConfig = {}) {
 export function buildFacadeArgsForCommand(commandId, rawConfig = {}) {
   const config = normalizeConfig(rawConfig);
 
-  if (commandId === "pccxSystemVerilog.showDiagnosticsExample") {
+  if (
+    commandId === "pccxSystemVerilog.publishCheckedExampleDiagnostics" ||
+    commandId === "pccxSystemVerilog.showDiagnosticsExample"
+  ) {
     return ["diagnostics", "--mode", "example", "--source", "check-missing-endmodule"];
   }
 

--- a/editors/vscode-prototype/src/extension.mjs
+++ b/editors/vscode-prototype/src/extension.mjs
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { dirname, resolve } from "node:path";
+import { dirname, isAbsolute, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
@@ -20,6 +20,7 @@ import {
 } from "./presenter.mjs";
 
 const EXTENSION_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const DEFAULT_DIAGNOSTIC_FILE_ROOT = resolve(EXTENSION_ROOT, "../..");
 const DEFAULT_FACADE_PATH = resolve(EXTENSION_ROOT, "bin/pccx-vscode-prototype.mjs");
 const OUTPUT_CHANNEL_NAME = "PCCX SystemVerilog IDE Prototype";
 
@@ -182,6 +183,14 @@ function facadeRunnerFromRuntime(runtime = {}) {
   };
 }
 
+function diagnosticFileForUri(file, root = DEFAULT_DIAGNOSTIC_FILE_ROOT) {
+  const filePath = file == null ? "" : String(file);
+  if (filePath.length === 0 || isAbsolute(filePath)) {
+    return filePath;
+  }
+  return resolve(root, filePath);
+}
+
 export function createPresenterDeps(vscodeApi, runtime = {}) {
   const diagnosticSeverity = {
     Error: vscodeApi?.DiagnosticSeverity?.Error ?? "Error",
@@ -191,7 +200,8 @@ export function createPresenterDeps(vscodeApi, runtime = {}) {
 
   return {
     createUri(file) {
-      return vscodeApi?.Uri?.file ? vscodeApi.Uri.file(file) : { fsPath: file };
+      const filePath = diagnosticFileForUri(file, runtime.diagnosticFileRoot);
+      return vscodeApi?.Uri?.file ? vscodeApi.Uri.file(filePath) : { fsPath: filePath };
     },
     createRange(startLine, startCharacter, endLine, endCharacter) {
       return typeof vscodeApi?.Range === "function"

--- a/editors/vscode-prototype/src/presentation-boundary.mjs
+++ b/editors/vscode-prototype/src/presentation-boundary.mjs
@@ -1,0 +1,56 @@
+export const THEME_TOKEN_CONTRACT = Object.freeze({
+  kind: "theme-token-contract",
+  currentPolicy: "host-theme-first",
+  tokenSources: Object.freeze([
+    "host-theme-token",
+    "user-override-token",
+  ]),
+  futurePresentationPresets: Object.freeze([
+    "VS Code",
+    "Xcode",
+    "JetBrains",
+  ]),
+  completedCustomThemeSystem: false,
+});
+
+const FORBIDDEN_PRESENTATION_KEYS = new Set([
+  "background",
+  "backgroundColor",
+  "border",
+  "borderColor",
+  "className",
+  "color",
+  "css",
+  "font",
+  "foreground",
+  "foregroundColor",
+  "style",
+  "styles",
+  "theme",
+  "themePreset",
+  "themeToken",
+  "themeTokens",
+]);
+
+function assertThemeNeutralRecord(value, path) {
+  if (!value || typeof value !== "object") {
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertThemeNeutralRecord(item, `${path}[${index}]`));
+    return;
+  }
+
+  for (const [key, child] of Object.entries(value)) {
+    if (FORBIDDEN_PRESENTATION_KEYS.has(key)) {
+      throw new Error(`theme-neutral presentation record must not define ${path}.${key}`);
+    }
+    assertThemeNeutralRecord(child, `${path}.${key}`);
+  }
+}
+
+export function assertThemeNeutralPresentation(presentation) {
+  assertThemeNeutralRecord(presentation, "$");
+  return presentation;
+}

--- a/editors/vscode-prototype/src/presenter.mjs
+++ b/editors/vscode-prototype/src/presenter.mjs
@@ -1,3 +1,7 @@
+import {
+  assertThemeNeutralPresentation,
+} from "./presentation-boundary.mjs";
+
 const DEFAULT_FILE = "";
 const DEFAULT_POSITION = Object.freeze({ line: 0, character: 0 });
 
@@ -83,6 +87,19 @@ function fallbackDiagnostic(range, message, severity) {
   return { range, message, severity };
 }
 
+function applyDiagnosticMetadata(vsCodeDiagnostic, diagnostic) {
+  if (!vsCodeDiagnostic || typeof vsCodeDiagnostic !== "object") {
+    return vsCodeDiagnostic;
+  }
+  if (diagnostic?.source != null && String(diagnostic.source).length > 0) {
+    vsCodeDiagnostic.source = String(diagnostic.source);
+  }
+  if (diagnostic?.code != null && String(diagnostic.code).length > 0) {
+    vsCodeDiagnostic.code = String(diagnostic.code);
+  }
+  return vsCodeDiagnostic;
+}
+
 function toVsCodeLikeDiagnostic(diagnostic, deps) {
   const range = safeRange(diagnostic);
   const vsCodeRange = (deps.createRange ?? fallbackRange)(
@@ -92,16 +109,18 @@ function toVsCodeLikeDiagnostic(diagnostic, deps) {
     range.end.character,
   );
   const severity = mapDiagnosticSeverity(diagnostic?.severity, deps.diagnosticSeverity);
-  return (deps.createDiagnostic ?? fallbackDiagnostic)(
+  const vsCodeDiagnostic = (deps.createDiagnostic ?? fallbackDiagnostic)(
     vsCodeRange,
     String(diagnostic?.message ?? ""),
     severity,
     diagnostic,
   );
+  return applyDiagnosticMetadata(vsCodeDiagnostic, diagnostic);
 }
 
 export function presentDiagnostics(action, deps = {}) {
   const presentation = createDiagnosticsPresentation(action);
+  assertThemeNeutralPresentation(presentation);
   const collection = deps.diagnosticsCollection;
 
   if (presentation.files.length === 0) {
@@ -168,6 +187,7 @@ export function createNavigationPresentation(action) {
 
 export async function presentNavigation(action, deps = {}) {
   const presentation = createNavigationPresentation(action);
+  assertThemeNeutralPresentation(presentation);
   if (presentation.items.length === 0) {
     await deps.showInformationMessage?.(presentation.summary, presentation);
     return presentation;

--- a/editors/vscode-prototype/test/command-handlers.test.mjs
+++ b/editors/vscode-prototype/test/command-handlers.test.mjs
@@ -93,6 +93,32 @@ async function testDiagnosticsExampleAction() {
   assert.equal(calls.warning[0].message, "1 diagnostic(s)");
 }
 
+async function testPublishCheckedExampleDiagnosticsAction() {
+  const diagnostic = { file: "a.sv", message: "bad", severity: "Error" };
+  const { calls, deps } = mockDeps({
+    kind: "vscode-diagnostics",
+    diagnostics: [diagnostic],
+  });
+
+  const result = await runPrototypeCommand(
+    "pccxSystemVerilog.publishCheckedExampleDiagnostics",
+    { mode: "live", defaultSource: "live.sv", pythonPath: "python-custom" },
+    deps,
+  );
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(calls.runFacade[0].args, [
+    "diagnostics",
+    "--mode",
+    "example",
+    "--source",
+    "check-missing-endmodule",
+  ]);
+  assert.deepEqual(calls.runFacade[0].env, {});
+  assert.equal(result.action.kind, "diagnostics");
+  assert.equal(result.action.diagnostics.length, 1);
+}
+
 async function testDiagnosticsLiveAction() {
   const { calls, deps } = mockDeps({
     kind: "vscode-diagnostics",
@@ -293,6 +319,7 @@ async function testExtensionExportsAndRegistration() {
 testPlansForKnownCommands();
 testUnknownCommandRejected();
 await testDiagnosticsExampleAction();
+await testPublishCheckedExampleDiagnosticsAction();
 await testDiagnosticsLiveAction();
 await testNavigationExampleAction();
 await testNavigationLiveAction();

--- a/editors/vscode-prototype/test/extension-entrypoint.test.mjs
+++ b/editors/vscode-prototype/test/extension-entrypoint.test.mjs
@@ -5,6 +5,7 @@ import {
   activate,
   buildFacadeArgsForCommand,
   buildFacadeInvocationForCommand,
+  createPresenterDeps,
   createCommandHandler,
   deactivate,
   readExtensionConfig,
@@ -12,6 +13,10 @@ import {
 } from "../src/extension.mjs";
 
 const EXPECTED_ARGS = new Map([
+  [
+    "pccxSystemVerilog.publishCheckedExampleDiagnostics",
+    ["diagnostics", "--mode", "example", "--source", "check-missing-endmodule"],
+  ],
   [
     "pccxSystemVerilog.showDiagnosticsExample",
     ["diagnostics", "--mode", "example", "--source", "check-missing-endmodule"],
@@ -56,6 +61,16 @@ function testUnknownCommandsRejected() {
   );
 }
 
+function testCheckedExampleDiagnosticsCommandStaysExampleMode() {
+  assert.deepEqual(
+    buildFacadeArgsForCommand(
+      "pccxSystemVerilog.publishCheckedExampleDiagnostics",
+      { mode: "live", defaultSource: "configured.sv", pythonPath: "python-custom" },
+    ),
+    ["diagnostics", "--mode", "example", "--source", "check-missing-endmodule"],
+  );
+}
+
 function testFacadeInvocationIsArgumentArray() {
   const invocation = buildFacadeInvocationForCommand(
     "pccxSystemVerilog.runDiagnosticsLive",
@@ -69,6 +84,30 @@ function testFacadeInvocationIsArgumentArray() {
   assert.ok(Array.isArray(invocation.args));
   assert.deepEqual(invocation.args.slice(1), EXPECTED_ARGS.get("pccxSystemVerilog.runDiagnosticsLive"));
   assert.doesNotMatch(invocation.args.join("\n"), /(?:&&|\|\||;|`|\$\()/);
+}
+
+function testPresenterDepsResolveRelativeDiagnosticFiles() {
+  const created = [];
+  const deps = createPresenterDeps(
+    {
+      Uri: {
+        file(file) {
+          created.push(file);
+          return { fsPath: file };
+        },
+      },
+    },
+    { diagnosticFileRoot: "/repo/root" },
+  );
+
+  assert.deepEqual(deps.createUri("fixtures/missing_endmodule.sv"), {
+    fsPath: "/repo/root/fixtures/missing_endmodule.sv",
+  });
+  assert.deepEqual(deps.createUri("/tmp/file.sv"), { fsPath: "/tmp/file.sv" });
+  assert.deepEqual(created, [
+    "/repo/root/fixtures/missing_endmodule.sv",
+    "/tmp/file.sv",
+  ]);
 }
 
 function testResolveCommandRequestUsesVsCodeSettings() {
@@ -212,7 +251,9 @@ async function testCommandHandlerCanBeUsedWithoutRealVsCode() {
 
 testKnownFacadeArgs();
 testUnknownCommandsRejected();
+testCheckedExampleDiagnosticsCommandStaysExampleMode();
 testFacadeInvocationIsArgumentArray();
+testPresenterDepsResolveRelativeDiagnosticFiles();
 testResolveCommandRequestUsesVsCodeSettings();
 await testEntrypointExportsAndActivation();
 await testNoVsCodeRuntimeIsANoop();

--- a/editors/vscode-prototype/test/extension-host-readiness.test.mjs
+++ b/editors/vscode-prototype/test/extension-host-readiness.test.mjs
@@ -92,6 +92,9 @@ async function testReadinessDocsAndCiPolicy() {
   assert.match(readiness, /(?:not LSP|LSP support|LSP server)/i);
   assert.match(readiness, /(?:not a stable ABI\/API|stable ABI\/API claim)/i);
   assert.match(readiness, /facade boundary/i);
+  assert.match(`${readme}\n${readiness}`, /DiagnosticCollection/);
+  assert.match(`${readme}\n${readiness}`, /host theme first/i);
+  assert.match(`${readme}\n${readiness}`, /not a completed\s+custom theme system/i);
   assert.doesNotMatch(ci, /vscode-extension-host-smoke\.sh/);
   assert.doesNotMatch(ci, /PCCX_RUN_EXTENSION_HOST_SMOKE/);
   assert.doesNotMatch(extensionEntrypoint, /pccx_ide_cli/);
@@ -117,7 +120,9 @@ async function testRuntimeRunnerIsPinnedAndBounded() {
   assert.match(runner, /--extensions-dir=/);
   assert.match(runner, /--user-data-dir=/);
   assert.match(suite, /getCommands/);
-  assert.match(suite, /showDiagnosticsExample/);
+  assert.match(suite, /publishCheckedExampleDiagnostics/);
+  assert.match(suite, /getDiagnostics/);
+  assert.match(suite, /DiagnosticSeverity\.Error/);
   assert.doesNotMatch(suite, /executeCommand\(\s*"pccxSystemVerilog\.runDiagnosticsLive"/);
   assert.doesNotMatch(suite, /executeCommand\(\s*"pccxSystemVerilog\.runNavigationLive"/);
 }

--- a/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
+++ b/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
@@ -28,7 +28,9 @@ async function importExtensionEntrypoint() {
 
 async function run() {
   assert.ok(extensionRoot, "PCCX_EXTENSION_ROOT must be set");
+  assert.ok(process.env.PCCX_REPO_ROOT, "PCCX_REPO_ROOT must be set");
   assert.deepEqual(expectedCommandIds, [
+    "pccxSystemVerilog.publishCheckedExampleDiagnostics",
     "pccxSystemVerilog.showDiagnosticsExample",
     "pccxSystemVerilog.showNavigationExample",
     "pccxSystemVerilog.runDiagnosticsLive",
@@ -56,12 +58,39 @@ async function run() {
   }
 
   const result = await vscode.commands.executeCommand(
-    "pccxSystemVerilog.showDiagnosticsExample",
+    "pccxSystemVerilog.publishCheckedExampleDiagnostics",
   );
   assert.equal(result.ok, true);
-  assert.equal(result.commandId, "pccxSystemVerilog.showDiagnosticsExample");
+  assert.equal(result.commandId, "pccxSystemVerilog.publishCheckedExampleDiagnostics");
   assert.equal(result.action.kind, "diagnostics");
   assert.ok(result.action.diagnostics.length > 0);
+
+  const expectedDiagnostic = result.action.diagnostics[0];
+  const expectedUri = vscode.Uri.file(path.resolve(
+    process.env.PCCX_REPO_ROOT,
+    expectedDiagnostic.file,
+  ));
+  const publishedDiagnostics = vscode.languages.getDiagnostics(expectedUri);
+  assert.ok(
+    publishedDiagnostics.length > 0,
+    `no diagnostics were published for ${expectedUri.toString()}`,
+  );
+  const publishedDiagnostic = publishedDiagnostics.find(
+    (diagnostic) => diagnostic.message === expectedDiagnostic.message,
+  );
+  assert.ok(publishedDiagnostic, "published diagnostic message was not found");
+  assert.equal(publishedDiagnostic.source, expectedDiagnostic.source);
+  assert.equal(publishedDiagnostic.severity, vscode.DiagnosticSeverity.Error);
+  assert.equal(publishedDiagnostic.range.start.line, expectedDiagnostic.range.start.line);
+  assert.equal(
+    publishedDiagnostic.range.start.character,
+    expectedDiagnostic.range.start.character,
+  );
+  assert.equal(publishedDiagnostic.range.end.line, expectedDiagnostic.range.end.line);
+  assert.equal(
+    publishedDiagnostic.range.end.character,
+    expectedDiagnostic.range.end.character,
+  );
 
   const extensionModule = await importExtensionEntrypoint();
   assert.equal(typeof extensionModule.deactivate, "function");

--- a/editors/vscode-prototype/test/extension-manifest.test.mjs
+++ b/editors/vscode-prototype/test/extension-manifest.test.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 const EXTENSION_ROOT = resolve(ROOT, "editors/vscode-prototype");
 const COMMAND_IDS = [
+  "pccxSystemVerilog.publishCheckedExampleDiagnostics",
   "pccxSystemVerilog.showDiagnosticsExample",
   "pccxSystemVerilog.showNavigationExample",
   "pccxSystemVerilog.runDiagnosticsLive",

--- a/editors/vscode-prototype/test/presentation-boundary.test.mjs
+++ b/editors/vscode-prototype/test/presentation-boundary.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  assertThemeNeutralPresentation,
+  THEME_TOKEN_CONTRACT,
+} from "../src/presentation-boundary.mjs";
+import {
+  createDiagnosticsPresentation,
+  createNavigationPresentation,
+} from "../src/presenter.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const PRESENTATION_FILES = [
+  "editors/vscode-prototype/src/presentation-boundary.mjs",
+  "editors/vscode-prototype/src/presenter.mjs",
+  "editors/vscode-prototype/src/command-handlers.mjs",
+];
+const HARDCODED_COLOR_LITERAL = /#[0-9a-fA-F]{3,8}\b|\brgba?\s*\(|\bhsla?\s*\(/;
+
+function diagnosticsAction(diagnostics) {
+  return {
+    kind: "diagnostics",
+    diagnostics,
+    summary: `${diagnostics.length} diagnostic(s)`,
+  };
+}
+
+function navigationAction(items) {
+  return {
+    kind: "navigation",
+    items,
+    summary: `${items.length} navigation item(s)`,
+  };
+}
+
+function testThemeTokenContractScope() {
+  assert.equal(THEME_TOKEN_CONTRACT.currentPolicy, "host-theme-first");
+  assert.deepEqual(THEME_TOKEN_CONTRACT.tokenSources, [
+    "host-theme-token",
+    "user-override-token",
+  ]);
+  assert.deepEqual(THEME_TOKEN_CONTRACT.futurePresentationPresets, [
+    "VS Code",
+    "Xcode",
+    "JetBrains",
+  ]);
+  assert.equal(THEME_TOKEN_CONTRACT.completedCustomThemeSystem, false);
+}
+
+function testDiagnosticsPresentationIsThemeNeutral() {
+  const presentation = createDiagnosticsPresentation(diagnosticsAction([
+    {
+      file: "fixtures/missing_endmodule.sv",
+      message: "`module` declared but no matching `endmodule` found",
+      severity: "Error",
+      source: "check",
+    },
+  ]));
+
+  assert.equal(assertThemeNeutralPresentation(presentation), presentation);
+}
+
+function testNavigationPresentationIsThemeNeutral() {
+  const presentation = createNavigationPresentation(navigationAction([
+    {
+      name: "simple_mod",
+      kind: "module",
+      file: "fixtures/modules/simple_module.sv",
+      line: 1,
+      column: 1,
+    },
+  ]));
+
+  assert.equal(assertThemeNeutralPresentation(presentation), presentation);
+}
+
+function testStyleFieldsRejected() {
+  assert.throws(
+    () => assertThemeNeutralPresentation({
+      kind: "diagnostics-presentation",
+      files: [{ file: "a.sv", diagnostics: [{ message: "bad", color: "red" }] }],
+      summary: "1 diagnostic(s)",
+    }),
+    /theme-neutral presentation record must not define/,
+  );
+}
+
+async function testPresentationFilesDoNotHardcodeColorLiterals() {
+  for (const relativePath of PRESENTATION_FILES) {
+    const source = await readFile(resolve(ROOT, relativePath), "utf8");
+    assert.doesNotMatch(source, HARDCODED_COLOR_LITERAL, relativePath);
+  }
+}
+
+testThemeTokenContractScope();
+testDiagnosticsPresentationIsThemeNeutral();
+testNavigationPresentationIsThemeNeutral();
+testStyleFieldsRejected();
+await testPresentationFilesDoNotHardcodeColorLiterals();
+
+console.log("vscode presentation boundary tests ok");

--- a/editors/vscode-prototype/test/presenter.test.mjs
+++ b/editors/vscode-prototype/test/presenter.test.mjs
@@ -122,7 +122,26 @@ function testDiagnosticsPresenterCallsCollectionSet() {
     endCharacter: 5,
   });
   assert.equal(calls.set[0].diagnostics[0].severity, 1);
+  assert.equal(calls.set[0].diagnostics[0].source, undefined);
   assert.equal(calls.warning[0].message, "1 diagnostic(s)");
+}
+
+function testDiagnosticsPresenterMapsSourceAndCode() {
+  const { calls, deps } = mockPresenterDeps();
+  const action = diagnosticsAction([
+    {
+      file: "a.sv",
+      message: "bad",
+      severity: "Error",
+      source: "check",
+      code: "PCCX-SCAFFOLD-003",
+    },
+  ]);
+
+  presentDiagnostics(action, deps);
+
+  assert.equal(calls.set[0].diagnostics[0].source, "check");
+  assert.equal(calls.set[0].diagnostics[0].code, "PCCX-SCAFFOLD-003");
 }
 
 function testDiagnosticsZeroCaseClearsCollection() {
@@ -311,6 +330,7 @@ function testPresenterDoesNotReturnShellStrings() {
 
 testDiagnosticsPresentationGroupsByFile();
 testDiagnosticsPresenterCallsCollectionSet();
+testDiagnosticsPresenterMapsSourceAndCode();
 testDiagnosticsZeroCaseClearsCollection();
 testDiagnosticsSeverityMapping();
 testDiagnosticsMissingFileAndLocation();

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -17,6 +17,7 @@ node editors/vscode-prototype/test/extension-config.test.mjs
 node editors/vscode-prototype/test/extension-entrypoint.test.mjs
 node editors/vscode-prototype/test/command-handlers.test.mjs
 node editors/vscode-prototype/test/presenter.test.mjs
+node editors/vscode-prototype/test/presentation-boundary.test.mjs
 node editors/vscode-prototype/test/extension-host-readiness.test.mjs
 node editors/vscode-prototype/src/adapter.mjs diagnostics \
   docs/examples/editor-bridge/problems-xsim-mixed.example.json \


### PR DESCRIPTION
## Summary
- add experimental checked-example diagnostics publishing command for the VS Code prototype
- map facade diagnostics into VS Code DiagnosticCollection entries with URI/range/severity/message/source coverage in the opt-in Extension Host smoke
- add a small theme-neutral presentation boundary and docs for host-theme-first behavior

## Validation
- npm ci --prefix editors/vscode-prototype
- bash scripts/vscode-adapter-smoke.sh
- PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh
- bash scripts/vscode-extension-host-smoke.sh exits 2 by default
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- python3 -m pytest -q
- git diff --check

## Scope Notes
- no vsce, publisher, marketplace flow, release, or tag
- live CLI mode remains explicit and is not used by the runtime smoke
- theme handling is a small boundary, not a completed custom theme system