### PR TITLE
feat: add VS Code navigation command smoke

### DIFF
--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -84,6 +84,7 @@ VS Code manifest wrapper; the implementation stays in `src/extension.mjs`.
 The contributed commands are:
 
 - `pccxSystemVerilog.publishCheckedExampleDiagnostics`
+- `pccxSystemVerilog.showCheckedExampleNavigation`
 - `pccxSystemVerilog.showDiagnosticsExample`
 - `pccxSystemVerilog.showNavigationExample`
 - `pccxSystemVerilog.runDiagnosticsLive`
@@ -101,7 +102,13 @@ The prototype-only settings are:
 The default diagnostics publishing command is
 `pccxSystemVerilog.publishCheckedExampleDiagnostics`.  It is experimental
 and always uses the checked `check-missing-endmodule` example through the
-facade boundary.  The explicit example commands always build
+facade boundary.  The checked-example navigation command is
+`pccxSystemVerilog.showCheckedExampleNavigation`.  It is experimental,
+command-first navigation, and always uses
+`navigation --mode example --source declarations` through the facade
+boundary.  It maps the checked declaration records into VS Code
+`Uri`/`Range`/`Location`-style records and returns them to callers; it
+has no LSP provider yet.  The explicit example commands always build
 checked-example facade arguments, and the explicit live commands always
 build known live facade arguments.  Live diagnostics uses
 `--from-check <defaultSource>`.  Live navigation uses
@@ -134,14 +141,17 @@ navigation presentation creates deterministic QuickPick-like items.
 The opt-in Extension Host runtime smoke additionally verifies that the
 checked-example diagnostics command publishes at least one real VS Code
 diagnostic with URI, range, severity, message, and source fields through
-a `DiagnosticCollection`.  A guarded local-only Extension Host runtime
-smoke now exists at
+a `DiagnosticCollection`, and that the checked-example navigation
+command returns at least one Location-style record with URI, range,
+symbol, target kind, and source fields.  A guarded local-only Extension
+Host runtime smoke now exists at
 `scripts/vscode-extension-host-smoke.sh`, but it exits 2 by default and
 only runs when `PCCX_RUN_EXTENSION_HOST_SMOKE=1` is set.  The runtime
 smoke loads the local extension package, verifies activation/command
 registration, and executes the checked-example diagnostics publishing
-command.  It does not run the live CLI path, package the extension, or
-install from the marketplace.  Extension Host gates are tracked in
+command plus the checked-example navigation command.  It does not run
+the live CLI path, package the extension, add an LSP provider, or install
+from the marketplace.  Extension Host gates are tracked in
 [`docs/EXTENSION_HOST_READINESS.md`](./docs/EXTENSION_HOST_READINESS.md).
 
 ## Theme-Neutral Presentation Boundary
@@ -156,7 +166,7 @@ The current policy is host theme first.  Future UI or webview surfaces
 should use host theme tokens or explicit user-provided theme tokens.
 VS Code, Xcode, and JetBrains are future presentation preset families,
 not implemented skins and not completion claims.  This is not a completed
-custom theme system.
+custom theme system, and the current work is not a custom theme engine.
 
 This scaffold is not LSP, not a full IDE replacement, not a stable
 ABI/API, and not a marketplace-ready or published extension.

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -21,6 +21,10 @@ should earn CI promotion separately.
 - Presenter behavior with mocked VS Code-like dependencies.
 - Real VS Code `DiagnosticCollection` population for the checked-example
   diagnostics command when the local runtime smoke is explicitly enabled.
+- Command-first navigation for
+  `pccxSystemVerilog.showCheckedExampleNavigation`, returning checked
+  example declaration records as VS Code `Uri`/`Range`/`Location`-style
+  data when the local runtime smoke is explicitly enabled.
 - Checked editor bridge examples.
 - Live CLI runner for known local JSON flows.
 - Guard behavior for the local-only Extension Host runtime smoke.
@@ -30,6 +34,7 @@ should earn CI promotion separately.
 ## Not Tested Today
 
 - Real QuickPick.
+- LSP provider registration.
 - Packaging.
 - `vsce`.
 - Marketplace install.
@@ -56,11 +61,17 @@ The runner lives under `editors/vscode-prototype/test/extension-host/`.
 It uses `@vscode/test-electron@2.5.2`, pins VS Code to `1.90.2`, creates
 a temporary workspace, loads the local extension package, verifies the
 expected command IDs, and executes only
-`pccxSystemVerilog.publishCheckedExampleDiagnostics`.  That command uses
-checked example diagnostics by default, goes through the facade boundary,
-and verifies that VS Code receives at least one diagnostic with URI,
-range, severity, message, and source fields.  It does not execute live
-CLI commands by default.
+`pccxSystemVerilog.publishCheckedExampleDiagnostics` and
+`pccxSystemVerilog.showCheckedExampleNavigation`.  The diagnostics
+command uses checked example diagnostics by default, goes through the
+facade boundary, and verifies that VS Code receives at least one
+diagnostic with URI, range, severity, message, and source fields.  The
+navigation command uses checked example mode by default through
+`navigation --mode example --source declarations`; it returns
+Location-style records with URI, range, symbol, target kind, and source
+fields.  Live mode remains explicit and separate, and the runtime smoke
+does not execute live CLI commands by default.  There is no LSP provider
+yet.
 
 The guarded script is not run by CI today.
 
@@ -88,6 +99,10 @@ system.
 - CI keeps running the static/mock VS Code adapter smoke only.
 - CI promotion for the runtime smoke requires a separate stability review
   because the first enabled run downloads VS Code/Electron.
+- Theme handling remains host theme first.  Future visual presets can be
+  added through host theme tokens or explicit user-provided theme tokens;
+  the current work is not a completed custom theme system or custom theme
+  engine.
 
 ## Next Gates
 

--- a/editors/vscode-prototype/package.json
+++ b/editors/vscode-prototype/package.json
@@ -14,6 +14,7 @@
   ],
   "activationEvents": [
     "onCommand:pccxSystemVerilog.publishCheckedExampleDiagnostics",
+    "onCommand:pccxSystemVerilog.showCheckedExampleNavigation",
     "onCommand:pccxSystemVerilog.showDiagnosticsExample",
     "onCommand:pccxSystemVerilog.showNavigationExample",
     "onCommand:pccxSystemVerilog.runDiagnosticsLive",
@@ -24,6 +25,10 @@
       {
         "command": "pccxSystemVerilog.publishCheckedExampleDiagnostics",
         "title": "PCCX SystemVerilog: Publish Checked Example Diagnostics (Experimental)"
+      },
+      {
+        "command": "pccxSystemVerilog.showCheckedExampleNavigation",
+        "title": "PCCX SystemVerilog: Show Checked Example Navigation (Experimental)"
       },
       {
         "command": "pccxSystemVerilog.showDiagnosticsExample",

--- a/editors/vscode-prototype/src/config.mjs
+++ b/editors/vscode-prototype/src/config.mjs
@@ -11,6 +11,7 @@ export const CONFIG_KEYS = Object.freeze([
 
 export const COMMAND_IDS = Object.freeze([
   "pccxSystemVerilog.publishCheckedExampleDiagnostics",
+  "pccxSystemVerilog.showCheckedExampleNavigation",
   "pccxSystemVerilog.showDiagnosticsExample",
   "pccxSystemVerilog.showNavigationExample",
   "pccxSystemVerilog.runDiagnosticsLive",
@@ -96,7 +97,10 @@ export function buildFacadeArgsForCommand(commandId, rawConfig = {}) {
     return ["diagnostics", "--mode", "example", "--source", "check-missing-endmodule"];
   }
 
-  if (commandId === "pccxSystemVerilog.showNavigationExample") {
+  if (
+    commandId === "pccxSystemVerilog.showCheckedExampleNavigation" ||
+    commandId === "pccxSystemVerilog.showNavigationExample"
+  ) {
     return ["navigation", "--mode", "example", "--source", "declarations"];
   }
 

--- a/editors/vscode-prototype/src/extension.mjs
+++ b/editors/vscode-prototype/src/extension.mjs
@@ -18,15 +18,21 @@ import {
 import {
   presentAction,
 } from "./presenter.mjs";
+import {
+  createNavigationLocationRecords,
+} from "./navigation-locations.mjs";
 
 const EXTENSION_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_DIAGNOSTIC_FILE_ROOT = resolve(EXTENSION_ROOT, "../..");
+const DEFAULT_NAVIGATION_FILE_ROOT = DEFAULT_DIAGNOSTIC_FILE_ROOT;
 const DEFAULT_FACADE_PATH = resolve(EXTENSION_ROOT, "bin/pccx-vscode-prototype.mjs");
 const OUTPUT_CHANNEL_NAME = "PCCX SystemVerilog IDE Prototype";
+const CHECKED_EXAMPLE_NAVIGATION_COMMAND = "pccxSystemVerilog.showCheckedExampleNavigation";
 
 export {
   COMMAND_IDS,
   buildFacadeArgsForCommand,
+  createNavigationLocationRecords,
   createCommandExecutionPlan,
   defaultConfig,
   normalizeConfig,
@@ -216,6 +222,11 @@ export function createPresenterDeps(vscodeApi, runtime = {}) {
         ? new vscodeApi.Diagnostic(range, message, severity)
         : { range, message, severity };
     },
+    createLocation(uri, range) {
+      return typeof vscodeApi?.Location === "function"
+        ? new vscodeApi.Location(uri, range)
+        : { uri, range };
+    },
     diagnosticSeverity,
     diagnosticsCollection: runtime.diagnosticsCollection,
     showInformationMessage: vscodeApi?.window?.showInformationMessage?.bind(vscodeApi.window),
@@ -229,6 +240,7 @@ export function createPresenterDeps(vscodeApi, runtime = {}) {
 export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
   createCommandExecutionPlan(commandId, defaultConfig());
   return async (input) => {
+    const returnsNavigationLocations = commandId === CHECKED_EXAMPLE_NAVIGATION_COMMAND;
     const rawConfig = readRawExtensionConfig(vscodeApi);
     const explicitPath = pathFromCommandInput(input);
     const request = commandId === "pccxSystemVerilog.runDiagnosticsLive" && explicitPath
@@ -241,9 +253,17 @@ export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
     const deps = {
       runFacade: runtime.runFacade ?? facadeRunnerFromRuntime(runtime),
       updateDiagnostics: (_diagnostics, action) => presentAction(action, presenterDeps),
-      showNavigationItems: (_items, action) => presentAction(action, presenterDeps),
+      showNavigationItems: returnsNavigationLocations
+        ? undefined
+        : (_items, action) => presentAction(action, presenterDeps),
     };
     const result = await runPrototypeCommand(commandId, request, deps);
+    if (result.ok && returnsNavigationLocations) {
+      result.locations = createNavigationLocationRecords(result.action?.items, {
+        ...presenterDeps,
+        fileRoot: runtime.navigationFileRoot ?? DEFAULT_NAVIGATION_FILE_ROOT,
+      });
+    }
     if (!result.ok) {
       presenterDeps.showWarningMessage?.(result.error, result);
     }

--- a/editors/vscode-prototype/src/navigation-locations.mjs
+++ b/editors/vscode-prototype/src/navigation-locations.mjs
@@ -1,0 +1,80 @@
+import { isAbsolute, resolve } from "node:path";
+
+const DEFAULT_SOURCE = "pccx-vscode-prototype";
+
+function stringOrEmpty(value) {
+  return value == null ? "" : String(value);
+}
+
+function fallbackUri(file) {
+  return { fsPath: file };
+}
+
+function fallbackRange(startLine, startCharacter, endLine, endCharacter) {
+  return {
+    start: { line: startLine, character: startCharacter },
+    end: { line: endLine, character: endCharacter },
+  };
+}
+
+function fallbackLocation(uri, range) {
+  return { uri, range };
+}
+
+function positiveOneBased(value) {
+  return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function nonNegativeZeroBased(value) {
+  return Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function zeroBasedPosition(item, zeroBasedKey, oneBasedKey) {
+  return nonNegativeZeroBased(item?.[zeroBasedKey])
+    ?? (positiveOneBased(item?.[oneBasedKey]) == null ? 0 : item[oneBasedKey] - 1);
+}
+
+function navigationFilePath(file, fileRoot) {
+  const filePath = stringOrEmpty(file);
+  if (filePath.length === 0 || isAbsolute(filePath) || !fileRoot) {
+    return filePath;
+  }
+  return resolve(fileRoot, filePath);
+}
+
+export function createNavigationLocationRecord(item, deps = {}) {
+  const file = stringOrEmpty(item?.file);
+  const filePath = navigationFilePath(file, deps.fileRoot);
+  const uri = (deps.createUri ?? fallbackUri)(filePath);
+  const startLine = zeroBasedPosition(item, "zero_based_line", "line");
+  const startCharacter = zeroBasedPosition(item, "zero_based_column", "column");
+  const range = (deps.createRange ?? fallbackRange)(
+    startLine,
+    startCharacter,
+    startLine,
+    startCharacter + 1,
+  );
+  const location = (deps.createLocation ?? fallbackLocation)(uri, range);
+  const name = stringOrEmpty(item?.name);
+  const kind = stringOrEmpty(item?.kind);
+
+  return {
+    uri,
+    range,
+    location,
+    targetKind: kind,
+    kind,
+    symbol: name,
+    name,
+    source: stringOrEmpty(item?.source) || stringOrEmpty(deps.source) || DEFAULT_SOURCE,
+    file,
+    line: positiveOneBased(item?.line) ?? startLine + 1,
+    column: positiveOneBased(item?.column) ?? startCharacter + 1,
+  };
+}
+
+export function createNavigationLocationRecords(items, deps = {}) {
+  return Array.isArray(items)
+    ? items.map((item) => createNavigationLocationRecord(item, deps))
+    : [];
+}

--- a/editors/vscode-prototype/test/command-handlers.test.mjs
+++ b/editors/vscode-prototype/test/command-handlers.test.mjs
@@ -176,6 +176,32 @@ async function testNavigationExampleAction() {
   assert.deepEqual(calls.navigation[0].items, [item]);
 }
 
+async function testCheckedExampleNavigationAction() {
+  const item = { name: "pkg_defs", kind: "package", file: "pkg.sv" };
+  const { calls, deps } = mockDeps({
+    kind: "vscode-navigation",
+    items: [item],
+  });
+
+  const result = await runPrototypeCommand(
+    "pccxSystemVerilog.showCheckedExampleNavigation",
+    { mode: "live", pythonPath: "python-custom" },
+    deps,
+  );
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(calls.runFacade[0].args, [
+    "navigation",
+    "--mode",
+    "example",
+    "--source",
+    "declarations",
+  ]);
+  assert.deepEqual(calls.runFacade[0].env, {});
+  assert.equal(result.action.kind, "navigation");
+  assert.deepEqual(result.action.items, [item]);
+}
+
 async function testNavigationLiveAction() {
   const { calls, deps } = mockDeps({
     kind: "vscode-navigation",
@@ -322,6 +348,7 @@ await testDiagnosticsExampleAction();
 await testPublishCheckedExampleDiagnosticsAction();
 await testDiagnosticsLiveAction();
 await testNavigationExampleAction();
+await testCheckedExampleNavigationAction();
 await testNavigationLiveAction();
 await testRunFacadeUsesArgumentArray();
 await testInvalidConfigControlledFailure();

--- a/editors/vscode-prototype/test/extension-config.test.mjs
+++ b/editors/vscode-prototype/test/extension-config.test.mjs
@@ -90,6 +90,10 @@ function testFacadeArgsForKnownCommands() {
     ["diagnostics", "--mode", "example", "--source", "check-missing-endmodule"],
   );
   assert.deepEqual(
+    buildFacadeArgsForCommand("pccxSystemVerilog.showCheckedExampleNavigation"),
+    ["navigation", "--mode", "example", "--source", "declarations"],
+  );
+  assert.deepEqual(
     buildFacadeArgsForCommand("pccxSystemVerilog.showNavigationExample"),
     ["navigation", "--mode", "example", "--source", "declarations"],
   );
@@ -131,6 +135,7 @@ function testUnknownCommandAndShellShape() {
 
   for (const commandId of [
     "pccxSystemVerilog.showDiagnosticsExample",
+    "pccxSystemVerilog.showCheckedExampleNavigation",
     "pccxSystemVerilog.showNavigationExample",
     "pccxSystemVerilog.runDiagnosticsLive",
     "pccxSystemVerilog.runNavigationLive",

--- a/editors/vscode-prototype/test/extension-entrypoint.test.mjs
+++ b/editors/vscode-prototype/test/extension-entrypoint.test.mjs
@@ -5,6 +5,7 @@ import {
   activate,
   buildFacadeArgsForCommand,
   buildFacadeInvocationForCommand,
+  createNavigationLocationRecords,
   createPresenterDeps,
   createCommandHandler,
   deactivate,
@@ -20,6 +21,10 @@ const EXPECTED_ARGS = new Map([
   [
     "pccxSystemVerilog.showDiagnosticsExample",
     ["diagnostics", "--mode", "example", "--source", "check-missing-endmodule"],
+  ],
+  [
+    "pccxSystemVerilog.showCheckedExampleNavigation",
+    ["navigation", "--mode", "example", "--source", "declarations"],
   ],
   [
     "pccxSystemVerilog.showNavigationExample",
@@ -71,6 +76,16 @@ function testCheckedExampleDiagnosticsCommandStaysExampleMode() {
   );
 }
 
+function testCheckedExampleNavigationCommandStaysExampleMode() {
+  assert.deepEqual(
+    buildFacadeArgsForCommand(
+      "pccxSystemVerilog.showCheckedExampleNavigation",
+      { mode: "live", defaultModule: "pkg_defs", pythonPath: "python-custom" },
+    ),
+    ["navigation", "--mode", "example", "--source", "declarations"],
+  );
+}
+
 function testFacadeInvocationIsArgumentArray() {
   const invocation = buildFacadeInvocationForCommand(
     "pccxSystemVerilog.runDiagnosticsLive",
@@ -108,6 +123,46 @@ function testPresenterDepsResolveRelativeDiagnosticFiles() {
     "/repo/root/fixtures/missing_endmodule.sv",
     "/tmp/file.sv",
   ]);
+}
+
+function testNavigationLocationMapping() {
+  const records = createNavigationLocationRecords(
+    [
+      {
+        name: "pkg_defs",
+        kind: "package",
+        file: "fixtures/modules/package_defs.sv",
+        line: 1,
+        column: 1,
+        zero_based_line: 0,
+        zero_based_column: 0,
+      },
+    ],
+    {
+      fileRoot: "/repo/root",
+      createUri(file) {
+        return { fsPath: file };
+      },
+      createRange(startLine, startCharacter, endLine, endCharacter) {
+        return {
+          start: { line: startLine, character: startCharacter },
+          end: { line: endLine, character: endCharacter },
+        };
+      },
+      createLocation(uri, range) {
+        return { uri, range };
+      },
+    },
+  );
+
+  assert.equal(records.length, 1);
+  assert.equal(records[0].uri.fsPath, "/repo/root/fixtures/modules/package_defs.sv");
+  assert.equal(records[0].range.start.line, 0);
+  assert.equal(records[0].range.start.character, 0);
+  assert.equal(records[0].range.end.character, 1);
+  assert.equal(records[0].targetKind, "package");
+  assert.equal(records[0].symbol, "pkg_defs");
+  assert.equal(records[0].source, "pccx-vscode-prototype");
 }
 
 function testResolveCommandRequestUsesVsCodeSettings() {
@@ -226,6 +281,86 @@ async function testEntrypointExportsAndActivation() {
   assert.ok(outputLines.some((line) => line.includes("pccxSystemVerilog.showDiagnosticsExample")));
 }
 
+async function testCheckedExampleNavigationCommandReturnsLocations() {
+  const registered = new Map();
+  const quickPickCalls = [];
+  const vscodeApi = {
+    Uri: {
+      file(file) {
+        return { fsPath: file };
+      },
+    },
+    Range: class Range {
+      constructor(startLine, startCharacter, endLine, endCharacter) {
+        this.start = { line: startLine, character: startCharacter };
+        this.end = { line: endLine, character: endCharacter };
+      }
+    },
+    Location: class Location {
+      constructor(uri, range) {
+        this.uri = uri;
+        this.range = range;
+      }
+    },
+    commands: {
+      registerCommand(commandId, handler) {
+        registered.set(commandId, handler);
+        return { dispose() {} };
+      },
+    },
+    window: {
+      createOutputChannel() {
+        return { appendLine() {}, show() {}, dispose() {} };
+      },
+      showInformationMessage() {},
+      showErrorMessage() {},
+      showQuickPick(...args) {
+        quickPickCalls.push(args);
+      },
+    },
+  };
+
+  await activate(
+    { subscriptions: [] },
+    vscodeApi,
+    {
+      async runFacade(args) {
+        assert.deepEqual(args, ["navigation", "--mode", "example", "--source", "declarations"]);
+        return {
+          ok: true,
+          json: {
+            kind: "vscode-navigation",
+            items: [
+              {
+                name: "simple_mod",
+                kind: "module",
+                file: "fixtures/modules/simple_module.sv",
+                line: 1,
+                column: 1,
+                zero_based_line: 0,
+                zero_based_column: 0,
+              },
+            ],
+          },
+        };
+      },
+    },
+  );
+
+  const result = await registered.get("pccxSystemVerilog.showCheckedExampleNavigation")();
+  assert.equal(result.ok, true);
+  assert.equal(result.commandId, "pccxSystemVerilog.showCheckedExampleNavigation");
+  assert.equal(result.action.kind, "navigation");
+  assert.equal(result.locations.length, 1);
+  assert.match(result.locations[0].uri.fsPath, /fixtures\/modules\/simple_module\.sv$/);
+  assert.equal(result.locations[0].range.start.line, 0);
+  assert.equal(result.locations[0].targetKind, "module");
+  assert.equal(result.locations[0].symbol, "simple_mod");
+  assert.equal(result.locations[0].source, "pccx-vscode-prototype");
+  assert.deepEqual(result.locations[0].location.uri, result.locations[0].uri);
+  assert.equal(quickPickCalls.length, 0);
+}
+
 async function testNoVsCodeRuntimeIsANoop() {
   const activation = await activate({ subscriptions: [] }, { commands: null });
   assert.deepEqual(activation.registered, []);
@@ -252,10 +387,13 @@ async function testCommandHandlerCanBeUsedWithoutRealVsCode() {
 testKnownFacadeArgs();
 testUnknownCommandsRejected();
 testCheckedExampleDiagnosticsCommandStaysExampleMode();
+testCheckedExampleNavigationCommandStaysExampleMode();
 testFacadeInvocationIsArgumentArray();
 testPresenterDepsResolveRelativeDiagnosticFiles();
+testNavigationLocationMapping();
 testResolveCommandRequestUsesVsCodeSettings();
 await testEntrypointExportsAndActivation();
+await testCheckedExampleNavigationCommandReturnsLocations();
 await testNoVsCodeRuntimeIsANoop();
 await testCommandHandlerCanBeUsedWithoutRealVsCode();
 

--- a/editors/vscode-prototype/test/extension-host-readiness.test.mjs
+++ b/editors/vscode-prototype/test/extension-host-readiness.test.mjs
@@ -93,6 +93,9 @@ async function testReadinessDocsAndCiPolicy() {
   assert.match(readiness, /(?:not a stable ABI\/API|stable ABI\/API claim)/i);
   assert.match(readiness, /facade boundary/i);
   assert.match(`${readme}\n${readiness}`, /DiagnosticCollection/);
+  assert.match(`${readme}\n${readiness}`, /showCheckedExampleNavigation/);
+  assert.match(`${readme}\n${readiness}`, /command-first navigation/i);
+  assert.match(`${readme}\n${readiness}`, /no LSP provider/i);
   assert.match(`${readme}\n${readiness}`, /host theme first/i);
   assert.match(`${readme}\n${readiness}`, /not a completed\s+custom theme system/i);
   assert.doesNotMatch(ci, /vscode-extension-host-smoke\.sh/);
@@ -121,8 +124,11 @@ async function testRuntimeRunnerIsPinnedAndBounded() {
   assert.match(runner, /--user-data-dir=/);
   assert.match(suite, /getCommands/);
   assert.match(suite, /publishCheckedExampleDiagnostics/);
+  assert.match(suite, /showCheckedExampleNavigation/);
   assert.match(suite, /getDiagnostics/);
   assert.match(suite, /DiagnosticSeverity\.Error/);
+  assert.match(suite, /navigationResult\.locations/);
+  assert.match(suite, /vscode\.Location/);
   assert.doesNotMatch(suite, /executeCommand\(\s*"pccxSystemVerilog\.runDiagnosticsLive"/);
   assert.doesNotMatch(suite, /executeCommand\(\s*"pccxSystemVerilog\.runNavigationLive"/);
 }

--- a/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
+++ b/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
@@ -31,6 +31,7 @@ async function run() {
   assert.ok(process.env.PCCX_REPO_ROOT, "PCCX_REPO_ROOT must be set");
   assert.deepEqual(expectedCommandIds, [
     "pccxSystemVerilog.publishCheckedExampleDiagnostics",
+    "pccxSystemVerilog.showCheckedExampleNavigation",
     "pccxSystemVerilog.showDiagnosticsExample",
     "pccxSystemVerilog.showNavigationExample",
     "pccxSystemVerilog.runDiagnosticsLive",
@@ -91,6 +92,40 @@ async function run() {
     publishedDiagnostic.range.end.character,
     expectedDiagnostic.range.end.character,
   );
+
+  const navigationResult = await vscode.commands.executeCommand(
+    "pccxSystemVerilog.showCheckedExampleNavigation",
+  );
+  assert.equal(navigationResult.ok, true);
+  assert.equal(navigationResult.commandId, "pccxSystemVerilog.showCheckedExampleNavigation");
+  assert.deepEqual(navigationResult.plan.facadeArgs, [
+    "navigation",
+    "--mode",
+    "example",
+    "--source",
+    "declarations",
+  ]);
+  assert.equal(navigationResult.action.kind, "navigation");
+  assert.ok(navigationResult.action.items.length > 0);
+  assert.ok(Array.isArray(navigationResult.locations));
+  assert.ok(navigationResult.locations.length > 0);
+
+  const firstLocation = navigationResult.locations[0];
+  assert.ok(firstLocation.uri instanceof vscode.Uri);
+  assert.ok(firstLocation.range instanceof vscode.Range);
+  assert.ok(firstLocation.location instanceof vscode.Location);
+  assert.ok(firstLocation.uri.fsPath.endsWith(firstLocation.file));
+  assert.ok(firstLocation.range.start.line >= 0);
+  assert.ok(firstLocation.range.start.character >= 0);
+  assert.equal(firstLocation.range.end.line, firstLocation.range.start.line);
+  assert.equal(firstLocation.range.end.character, firstLocation.range.start.character + 1);
+  assert.equal(typeof firstLocation.symbol, "string");
+  assert.ok(firstLocation.symbol.length > 0);
+  assert.equal(typeof firstLocation.targetKind, "string");
+  assert.ok(firstLocation.targetKind.length > 0);
+  assert.equal(firstLocation.source, "pccx-vscode-prototype");
+  assert.equal(firstLocation.location.uri.toString(), firstLocation.uri.toString());
+  assert.equal(firstLocation.location.range.start.line, firstLocation.range.start.line);
 
   const extensionModule = await importExtensionEntrypoint();
   assert.equal(typeof extensionModule.deactivate, "function");

--- a/editors/vscode-prototype/test/extension-manifest.test.mjs
+++ b/editors/vscode-prototype/test/extension-manifest.test.mjs
@@ -7,6 +7,7 @@ const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 const EXTENSION_ROOT = resolve(ROOT, "editors/vscode-prototype");
 const COMMAND_IDS = [
   "pccxSystemVerilog.publishCheckedExampleDiagnostics",
+  "pccxSystemVerilog.showCheckedExampleNavigation",
   "pccxSystemVerilog.showDiagnosticsExample",
   "pccxSystemVerilog.showNavigationExample",
   "pccxSystemVerilog.runDiagnosticsLive",


### PR DESCRIPTION
## Summary
- add experimental pccxSystemVerilog.showCheckedExampleNavigation command
- route checked-example navigation through the existing VS Code prototype facade
- map navigation items to VS Code Uri/Range/Location-style records for command-first smoke coverage
- extend static tests, opt-in Extension Host smoke, and prototype docs without adding LSP, vsce, publisher, or marketplace flow

## Validation
- npm ci --prefix editors/vscode-prototype
- bash scripts/vscode-adapter-smoke.sh
- PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh
- bash scripts/vscode-extension-host-smoke.sh (expected exit 2 guard)
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- python3 -m pytest -q
- git diff HEAD --check