### PR TITLE
feat: add VS Code definition provider smoke

### DIFF
--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -133,6 +133,19 @@ summary }` actions, and navigation facade payloads become
 mocked VS Code-like dependencies such as `runFacade`, `updateDiagnostics`,
 and `showNavigationItems` for static coverage.
 
+`src/definition-provider.mjs` is the first experimental VS Code-native
+provider smoke.  It registers a minimal `DefinitionProvider` for
+SystemVerilog-like file documents and reuses the same checked-example
+navigation facade boundary used by
+`pccxSystemVerilog.showCheckedExampleNavigation`.  The provider returns
+VS Code `Location` results mapped from
+`navigation --mode example --source declarations`; it does not implement
+LSP, does not scan the live workspace by default, and does not silently
+switch modes.  Semantic cursor and symbol resolution are not complete in
+this phase, so the provider may ignore the cursor position and return
+the checked-example declaration location.  Live navigation remains an
+explicit and separate command path.
+
 `src/presenter.mjs` is the experimental local presenter scaffold.  It
 consumes command-handler UI actions and maps diagnostics/navigation
 actions to mocked VS Code-like APIs.  Diagnostics presentation groups
@@ -143,15 +156,20 @@ checked-example diagnostics command publishes at least one real VS Code
 diagnostic with URI, range, severity, message, and source fields through
 a `DiagnosticCollection`, and that the checked-example navigation
 command returns at least one Location-style record with URI, range,
-symbol, target kind, and source fields.  A guarded local-only Extension
-Host runtime smoke now exists at
+symbol, target kind, and source fields.  The same opt-in smoke also
+opens a temporary SystemVerilog-like document and executes
+`vscode.executeDefinitionProvider` to verify that the experimental
+VS Code-native `DefinitionProvider` returns at least one `Location` with
+sane URI and range fields.  A guarded local-only Extension Host runtime
+smoke now exists at
 `scripts/vscode-extension-host-smoke.sh`, but it exits 2 by default and
 only runs when `PCCX_RUN_EXTENSION_HOST_SMOKE=1` is set.  The runtime
 smoke loads the local extension package, verifies activation/command
 registration, and executes the checked-example diagnostics publishing
-command plus the checked-example navigation command.  It does not run
-the live CLI path, package the extension, add an LSP provider, or install
-from the marketplace.  Extension Host gates are tracked in
+command plus the checked-example navigation command and provider smoke.
+It does not run the live CLI path, package the extension, add an LSP
+provider, or install from the marketplace.  Extension Host gates are
+tracked in
 [`docs/EXTENSION_HOST_READINESS.md`](./docs/EXTENSION_HOST_READINESS.md).
 
 ## Theme-Neutral Presentation Boundary

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -25,6 +25,10 @@ should earn CI promotion separately.
   `pccxSystemVerilog.showCheckedExampleNavigation`, returning checked
   example declaration records as VS Code `Uri`/`Range`/`Location`-style
   data when the local runtime smoke is explicitly enabled.
+- Minimal VS Code-native `DefinitionProvider` registration for
+  SystemVerilog-like file documents.  The provider uses checked-example
+  navigation by default through the existing facade boundary and returns
+  VS Code `Location` results in the opt-in runtime smoke.
 - Checked editor bridge examples.
 - Live CLI runner for known local JSON flows.
 - Guard behavior for the local-only Extension Host runtime smoke.
@@ -34,15 +38,16 @@ should earn CI promotion separately.
 ## Not Tested Today
 
 - Real QuickPick.
+- Complete semantic cursor/symbol resolution.
 - LSP provider registration.
 - Packaging.
 - `vsce`.
 - Marketplace install.
 
-The runtime smoke is limited coverage for the activation and command
-facade boundary only.  It is not a product claim and does not imply
-marketplace readiness, a published extension, LSP support, or a stable
-ABI/API.
+The runtime smoke is limited coverage for the activation, command facade,
+and VS Code-native provider boundary only.  It is not a product claim and
+does not imply marketplace readiness, a published extension, LSP support,
+complete semantic navigation, or a stable ABI/API.
 
 ## Guarded Local Scaffold
 
@@ -69,9 +74,14 @@ diagnostic with URI, range, severity, message, and source fields.  The
 navigation command uses checked example mode by default through
 `navigation --mode example --source declarations`; it returns
 Location-style records with URI, range, symbol, target kind, and source
-fields.  Live mode remains explicit and separate, and the runtime smoke
-does not execute live CLI commands by default.  There is no LSP provider
-yet.
+fields.  The same smoke opens a temporary SystemVerilog-like document
+and executes `vscode.executeDefinitionProvider` to verify that the
+experimental VS Code-native `DefinitionProvider` returns at least one
+`Location` with sane URI and range fields.  The provider currently
+reuses the checked-example declaration result and does not complete
+semantic cursor/symbol resolution.  Live mode remains explicit and
+separate, and the runtime smoke does not execute live CLI commands by
+default.  This is not LSP, and there is no LSP provider yet.
 
 The guarded script is not run by CI today.
 
@@ -109,7 +119,9 @@ system.
 1. Keep the facade boundary.
 2. Do not call `pccx_ide_cli` directly from activation.
 3. Do not run live CLI commands in the runtime smoke by default.
-4. Promote the runtime smoke to CI only after separate stability evidence.
-5. Do not add `vsce`, publisher metadata, packaging scripts, LSP, or
+4. Keep the VS Code-native `DefinitionProvider` separate from any LSP
+   implementation.
+5. Promote the runtime smoke to CI only after separate stability evidence.
+6. Do not add `vsce`, publisher metadata, packaging scripts, LSP, or
    marketplace flow.
-6. Do not make a marketplace, published-extension, or stable API claim.
+7. Do not make a marketplace, published-extension, or stable API claim.

--- a/editors/vscode-prototype/src/definition-provider.mjs
+++ b/editors/vscode-prototype/src/definition-provider.mjs
@@ -1,0 +1,67 @@
+export const CHECKED_EXAMPLE_DEFINITION_PROVIDER_ID =
+  "pccxSystemVerilog.definitionProvider.checkedExample";
+
+export const CHECKED_EXAMPLE_DEFINITION_SELECTOR = Object.freeze([
+  Object.freeze({ language: "systemverilog", scheme: "file" }),
+  Object.freeze({ language: "verilog", scheme: "file" }),
+  Object.freeze({ scheme: "file", pattern: "**/*.sv" }),
+  Object.freeze({ scheme: "file", pattern: "**/*.svh" }),
+  Object.freeze({ scheme: "file", pattern: "**/*.v" }),
+]);
+
+function locationFromRecord(record) {
+  if (record?.location) {
+    return record.location;
+  }
+  if (record?.uri && record?.range) {
+    return { uri: record.uri, range: record.range };
+  }
+  return null;
+}
+
+export function checkedExampleDefinitionProvider(options = {}) {
+  if (typeof options.runCheckedExampleNavigationLocations !== "function") {
+    throw new Error("runCheckedExampleNavigationLocations dependency is required");
+  }
+
+  return {
+    async provideDefinition(_document, _position, token) {
+      if (token?.isCancellationRequested) {
+        return [];
+      }
+
+      const result = await options.runCheckedExampleNavigationLocations();
+      if (!result?.ok || token?.isCancellationRequested) {
+        return [];
+      }
+
+      return (Array.isArray(result.locations) ? result.locations : [])
+        .map(locationFromRecord)
+        .filter(Boolean);
+    },
+  };
+}
+
+export function registerCheckedExampleDefinitionProvider(vscodeApi, context, options = {}) {
+  const registration = {
+    id: CHECKED_EXAMPLE_DEFINITION_PROVIDER_ID,
+    selector: CHECKED_EXAMPLE_DEFINITION_SELECTOR,
+    registered: false,
+  };
+
+  if (typeof vscodeApi?.languages?.registerDefinitionProvider !== "function") {
+    return registration;
+  }
+
+  const provider = checkedExampleDefinitionProvider(options);
+  const disposable = vscodeApi.languages.registerDefinitionProvider(
+    CHECKED_EXAMPLE_DEFINITION_SELECTOR,
+    provider,
+  );
+  context?.subscriptions?.push?.(disposable);
+
+  return {
+    ...registration,
+    registered: true,
+  };
+}

--- a/editors/vscode-prototype/src/extension.mjs
+++ b/editors/vscode-prototype/src/extension.mjs
@@ -21,13 +21,17 @@ import {
 import {
   createNavigationLocationRecords,
 } from "./navigation-locations.mjs";
+import {
+  registerCheckedExampleDefinitionProvider,
+} from "./definition-provider.mjs";
 
 const EXTENSION_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_DIAGNOSTIC_FILE_ROOT = resolve(EXTENSION_ROOT, "../..");
 const DEFAULT_NAVIGATION_FILE_ROOT = DEFAULT_DIAGNOSTIC_FILE_ROOT;
 const DEFAULT_FACADE_PATH = resolve(EXTENSION_ROOT, "bin/pccx-vscode-prototype.mjs");
 const OUTPUT_CHANNEL_NAME = "PCCX SystemVerilog IDE Prototype";
-const CHECKED_EXAMPLE_NAVIGATION_COMMAND = "pccxSystemVerilog.showCheckedExampleNavigation";
+export const CHECKED_EXAMPLE_NAVIGATION_COMMAND =
+  "pccxSystemVerilog.showCheckedExampleNavigation";
 
 export {
   COMMAND_IDS,
@@ -156,6 +160,16 @@ export async function runFacadeForCommand(commandId, options = {}, runtime = {})
   return runFacadeInvocation(invocation, runtime);
 }
 
+export async function runCheckedExampleNavigationLocations(rawConfig = {}, deps = {}) {
+  const result = await runPrototypeCommand(CHECKED_EXAMPLE_NAVIGATION_COMMAND, rawConfig, {
+    runFacade: deps.runFacade,
+  });
+  if (result.ok) {
+    result.locations = createNavigationLocationRecords(result.action?.items, deps);
+  }
+  return result;
+}
+
 function appendCommandOutput(outputChannel, commandId, result) {
   if (!outputChannel?.appendLine) {
     return;
@@ -257,13 +271,13 @@ export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
         ? undefined
         : (_items, action) => presentAction(action, presenterDeps),
     };
-    const result = await runPrototypeCommand(commandId, request, deps);
-    if (result.ok && returnsNavigationLocations) {
-      result.locations = createNavigationLocationRecords(result.action?.items, {
+    const result = returnsNavigationLocations
+      ? await runCheckedExampleNavigationLocations(request, {
         ...presenterDeps,
+        runFacade: deps.runFacade,
         fileRoot: runtime.navigationFileRoot ?? DEFAULT_NAVIGATION_FILE_ROOT,
-      });
-    }
+      })
+      : await runPrototypeCommand(commandId, request, deps);
     if (!result.ok) {
       presenterDeps.showWarningMessage?.(result.error, result);
     }
@@ -291,6 +305,7 @@ export async function activate(context, injectedVscodeApi = null, runtime = {}) 
     ?? vscodeApi.languages?.createDiagnosticCollection?.(OUTPUT_CHANNEL_NAME);
   const commandRuntime = { ...runtime, diagnosticsCollection, outputChannel };
   const registered = [];
+  const definitionProviders = [];
 
   for (const commandId of COMMAND_IDS) {
     const disposable = vscodeApi.commands.registerCommand(
@@ -301,13 +316,28 @@ export async function activate(context, injectedVscodeApi = null, runtime = {}) 
     registered.push(commandId);
   }
 
+  definitionProviders.push(registerCheckedExampleDefinitionProvider(vscodeApi, context, {
+    runCheckedExampleNavigationLocations() {
+      const rawConfig = readRawExtensionConfig(vscodeApi);
+      const presenterDeps = {
+        ...createPresenterDeps(vscodeApi, commandRuntime),
+        ...(commandRuntime.presenterDeps ?? {}),
+      };
+      return runCheckedExampleNavigationLocations(rawConfig, {
+        ...presenterDeps,
+        runFacade: commandRuntime.runFacade ?? facadeRunnerFromRuntime(commandRuntime),
+        fileRoot: commandRuntime.navigationFileRoot ?? DEFAULT_NAVIGATION_FILE_ROOT,
+      });
+    },
+  }));
+
   if (outputChannel) {
     context?.subscriptions?.push?.(outputChannel);
   }
   if (diagnosticsCollection && diagnosticsCollection !== runtime.diagnosticsCollection) {
     context?.subscriptions?.push?.(diagnosticsCollection);
   }
-  return { registered };
+  return { registered, definitionProviders };
 }
 
 export function deactivate() {}

--- a/editors/vscode-prototype/test/extension-entrypoint.test.mjs
+++ b/editors/vscode-prototype/test/extension-entrypoint.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 
 import {
   COMMAND_IDS,
+  CHECKED_EXAMPLE_NAVIGATION_COMMAND,
   activate,
   buildFacadeArgsForCommand,
   buildFacadeInvocationForCommand,
@@ -12,6 +13,11 @@ import {
   readExtensionConfig,
   resolveCommandRequest,
 } from "../src/extension.mjs";
+import {
+  CHECKED_EXAMPLE_DEFINITION_PROVIDER_ID,
+  CHECKED_EXAMPLE_DEFINITION_SELECTOR,
+  checkedExampleDefinitionProvider,
+} from "../src/definition-provider.mjs";
 
 const EXPECTED_ARGS = new Map([
   [
@@ -273,6 +279,9 @@ async function testEntrypointExportsAndActivation() {
   );
 
   assert.deepEqual(activation.registered, COMMAND_IDS);
+  assert.equal(activation.definitionProviders.length, 1);
+  assert.equal(activation.definitionProviders[0].id, CHECKED_EXAMPLE_DEFINITION_PROVIDER_ID);
+  assert.equal(activation.definitionProviders[0].registered, false);
   assert.equal(registered.size, COMMAND_IDS.length);
   assert.equal(subscriptions.length, COMMAND_IDS.length + 1);
 
@@ -361,6 +370,142 @@ async function testCheckedExampleNavigationCommandReturnsLocations() {
   assert.equal(quickPickCalls.length, 0);
 }
 
+async function testCheckedExampleDefinitionProviderReturnsLocations() {
+  const location = { uri: { fsPath: "/repo/root/pkg.sv" }, range: { start: { line: 0 } } };
+  const provider = checkedExampleDefinitionProvider({
+    async runCheckedExampleNavigationLocations() {
+      return {
+        ok: true,
+        locations: [
+          { location },
+          { uri: { fsPath: "/repo/root/simple.sv" }, range: { start: { line: 1 } } },
+        ],
+      };
+    },
+  });
+
+  const definitions = await provider.provideDefinition({}, {}, {});
+
+  assert.equal(definitions.length, 2);
+  assert.equal(definitions[0], location);
+  assert.deepEqual(definitions[1], {
+    uri: { fsPath: "/repo/root/simple.sv" },
+    range: { start: { line: 1 } },
+  });
+}
+
+async function testActivationRegistersCheckedExampleDefinitionProvider() {
+  const registered = new Map();
+  const subscriptions = [];
+  const definitionRegistrations = [];
+  const facadeCalls = [];
+  const vscodeApi = {
+    Uri: {
+      file(file) {
+        return { fsPath: file };
+      },
+    },
+    Range: class Range {
+      constructor(startLine, startCharacter, endLine, endCharacter) {
+        this.start = { line: startLine, character: startCharacter };
+        this.end = { line: endLine, character: endCharacter };
+      }
+    },
+    Location: class Location {
+      constructor(uri, range) {
+        this.uri = uri;
+        this.range = range;
+      }
+    },
+    commands: {
+      registerCommand(commandId, handler) {
+        registered.set(commandId, handler);
+        return { dispose() {} };
+      },
+    },
+    languages: {
+      registerDefinitionProvider(selector, provider) {
+        definitionRegistrations.push({ selector, provider });
+        return { dispose() {} };
+      },
+    },
+    window: {
+      createOutputChannel() {
+        return { appendLine() {}, show() {}, dispose() {} };
+      },
+      showInformationMessage() {},
+      showErrorMessage() {},
+    },
+  };
+
+  const activation = await activate(
+    { subscriptions },
+    vscodeApi,
+    {
+      async runFacade(args, env, plan) {
+        facadeCalls.push({ args, env, plan });
+        return {
+          ok: true,
+          json: {
+            kind: "vscode-navigation",
+            items: [
+              {
+                name: "pkg_defs",
+                kind: "package",
+                file: "fixtures/modules/package_defs.sv",
+                line: 1,
+                column: 1,
+                zero_based_line: 0,
+                zero_based_column: 0,
+              },
+            ],
+          },
+        };
+      },
+    },
+  );
+
+  assert.deepEqual(activation.registered, COMMAND_IDS);
+  assert.deepEqual(activation.definitionProviders, [
+    {
+      id: CHECKED_EXAMPLE_DEFINITION_PROVIDER_ID,
+      selector: CHECKED_EXAMPLE_DEFINITION_SELECTOR,
+      registered: true,
+    },
+  ]);
+  assert.equal(definitionRegistrations.length, 1);
+  assert.equal(definitionRegistrations[0].selector, CHECKED_EXAMPLE_DEFINITION_SELECTOR);
+  assert.ok(
+    CHECKED_EXAMPLE_DEFINITION_SELECTOR.some((selector) => selector.language === "systemverilog"),
+  );
+  assert.ok(
+    CHECKED_EXAMPLE_DEFINITION_SELECTOR.some((selector) => selector.pattern === "**/*.sv"),
+  );
+  assert.equal(subscriptions.length, COMMAND_IDS.length + 2);
+
+  const definitions = await definitionRegistrations[0].provider.provideDefinition(
+    { uri: { fsPath: "/workspace/smoke.sv" } },
+    { line: 0, character: 7 },
+    {},
+  );
+
+  assert.equal(facadeCalls.length, 1);
+  assert.equal(facadeCalls[0].plan.commandId, CHECKED_EXAMPLE_NAVIGATION_COMMAND);
+  assert.deepEqual(facadeCalls[0].args, [
+    "navigation",
+    "--mode",
+    "example",
+    "--source",
+    "declarations",
+  ]);
+  assert.deepEqual(facadeCalls[0].env, {});
+  assert.equal(definitions.length, 1);
+  assert.match(definitions[0].uri.fsPath, /fixtures\/modules\/package_defs\.sv$/);
+  assert.equal(definitions[0].range.start.line, 0);
+  assert.equal(definitions[0].range.start.character, 0);
+  assert.equal(definitions[0].range.end.character, 1);
+}
+
 async function testNoVsCodeRuntimeIsANoop() {
   const activation = await activate({ subscriptions: [] }, { commands: null });
   assert.deepEqual(activation.registered, []);
@@ -394,6 +539,8 @@ testNavigationLocationMapping();
 testResolveCommandRequestUsesVsCodeSettings();
 await testEntrypointExportsAndActivation();
 await testCheckedExampleNavigationCommandReturnsLocations();
+await testCheckedExampleDefinitionProviderReturnsLocations();
+await testActivationRegistersCheckedExampleDefinitionProvider();
 await testNoVsCodeRuntimeIsANoop();
 await testCommandHandlerCanBeUsedWithoutRealVsCode();
 

--- a/editors/vscode-prototype/test/extension-host-readiness.test.mjs
+++ b/editors/vscode-prototype/test/extension-host-readiness.test.mjs
@@ -80,6 +80,7 @@ async function testReadinessDocsAndCiPolicy() {
   const ci = await readText(resolve(ROOT, ".github/workflows/ci.yml"));
   const extensionEntrypoint = await readText(resolve(EXTENSION_ROOT, "src/extension.mjs"));
   const extensionWrapper = await readText(resolve(EXTENSION_ROOT, "src/extension.cjs"));
+  const definitionProvider = await readText(resolve(EXTENSION_ROOT, "src/definition-provider.mjs"));
 
   assert.match(readme, /experimental local VS Code prototype/i);
   assert.match(readme, /mostly static\/mock tests/i);
@@ -94,6 +95,8 @@ async function testReadinessDocsAndCiPolicy() {
   assert.match(readiness, /facade boundary/i);
   assert.match(`${readme}\n${readiness}`, /DiagnosticCollection/);
   assert.match(`${readme}\n${readiness}`, /showCheckedExampleNavigation/);
+  assert.match(`${readme}\n${readiness}`, /DefinitionProvider/);
+  assert.match(`${readme}\n${readiness}`, /VS Code-native\s+provider smoke/i);
   assert.match(`${readme}\n${readiness}`, /command-first navigation/i);
   assert.match(`${readme}\n${readiness}`, /no LSP provider/i);
   assert.match(`${readme}\n${readiness}`, /host theme first/i);
@@ -102,6 +105,10 @@ async function testReadinessDocsAndCiPolicy() {
   assert.doesNotMatch(ci, /PCCX_RUN_EXTENSION_HOST_SMOKE/);
   assert.doesNotMatch(extensionEntrypoint, /pccx_ide_cli/);
   assert.doesNotMatch(extensionWrapper, /pccx_ide_cli/);
+  assert.doesNotMatch(definitionProvider, /pccx_ide_cli/);
+  assert.doesNotMatch(`${extensionEntrypoint}\n${definitionProvider}`, /LanguageClient|vscode-languageclient/);
+  assert.match(definitionProvider, /checkedExampleDefinitionProvider/);
+  assert.match(extensionEntrypoint, /registerCheckedExampleDefinitionProvider/);
   assert.match(extensionWrapper, /require\("vscode"\)/);
   assert.match(extensionWrapper, /import\("\.\/extension\.mjs"\)/);
 }
@@ -129,6 +136,9 @@ async function testRuntimeRunnerIsPinnedAndBounded() {
   assert.match(suite, /DiagnosticSeverity\.Error/);
   assert.match(suite, /navigationResult\.locations/);
   assert.match(suite, /vscode\.Location/);
+  assert.match(suite, /vscode\.executeDefinitionProvider/);
+  assert.match(suite, /definitionProviders/);
+  assert.match(suite, /definitionProvider\.checkedExample/);
   assert.doesNotMatch(suite, /executeCommand\(\s*"pccxSystemVerilog\.runDiagnosticsLive"/);
   assert.doesNotMatch(suite, /executeCommand\(\s*"pccxSystemVerilog\.runNavigationLive"/);
 }

--- a/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
+++ b/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
@@ -52,6 +52,13 @@ async function run() {
   const activation = await developmentExtension.activate();
   assert.equal(developmentExtension.isActive, true);
   assert.deepEqual(activation.registered, expectedCommandIds);
+  assert.ok(
+    activation.definitionProviders.some((provider) => (
+      provider.id === "pccxSystemVerilog.definitionProvider.checkedExample" &&
+      provider.registered === true
+    )),
+    "checked-example DefinitionProvider was not registered",
+  );
 
   const commands = await vscode.commands.getCommands(true);
   for (const commandId of expectedCommandIds) {
@@ -126,6 +133,32 @@ async function run() {
   assert.equal(firstLocation.source, "pccx-vscode-prototype");
   assert.equal(firstLocation.location.uri.toString(), firstLocation.uri.toString());
   assert.equal(firstLocation.location.range.start.line, firstLocation.range.start.line);
+
+  const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  assert.ok(workspaceRoot, "runtime smoke workspace was not opened");
+  const definitionUri = vscode.Uri.file(path.join(workspaceRoot, "smoke.sv"));
+  const document = await vscode.workspace.openTextDocument(definitionUri);
+  assert.equal(document.uri.toString(), definitionUri.toString());
+  const definitionLocations = await vscode.commands.executeCommand(
+    "vscode.executeDefinitionProvider",
+    definitionUri,
+    new vscode.Position(0, 7),
+  );
+
+  assert.ok(Array.isArray(definitionLocations));
+  assert.ok(definitionLocations.length > 0);
+  const providerLocation = definitionLocations[0];
+  assert.ok(providerLocation instanceof vscode.Location);
+  assert.ok(providerLocation.uri instanceof vscode.Uri);
+  assert.ok(providerLocation.range instanceof vscode.Range);
+  assert.ok(providerLocation.uri.fsPath.endsWith(".sv"));
+  assert.ok(providerLocation.range.start.line >= 0);
+  assert.ok(providerLocation.range.start.character >= 0);
+  assert.equal(providerLocation.range.end.line, providerLocation.range.start.line);
+  assert.equal(
+    providerLocation.range.end.character,
+    providerLocation.range.start.character + 1,
+  );
 
   const extensionModule = await importExtensionEntrypoint();
   assert.equal(typeof extensionModule.deactivate, "function");


### PR DESCRIPTION
## Summary
- add an experimental checked-example VS Code-native DefinitionProvider registration
- reuse the existing facade-backed checked navigation mapping to return Location results
- extend static tests and opt-in Extension Host smoke for provider registration and vscode.executeDefinitionProvider
- document that this remains local-only, command/provider smoke, not LSP, not marketplace packaging, and not a stable API

## Validation
- git status --short --branch
- npm ci --prefix editors/vscode-prototype
- bash scripts/vscode-adapter-smoke.sh
- PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh
- bash scripts/vscode-extension-host-smoke.sh (expected exit 2 guard)
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- python3 -m pytest -q
- git diff --check