### PR TITLE
feat: add VS Code live workspace and AI boundary foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,26 @@ If a feature would need a side channel that bypasses the CLI / core
 contract, that is a signal the contract needs to grow first — not a
 signal to add a back door from the GUI.
 
+## Architecture roles
+
+- `systemverilog-ide` is the editor cockpit: VS Code commands,
+  presentation boundaries, opt-in live workspace command shape, and
+  future context bundle construction.
+- `pccx-lab` is the CLI-first verification/tooling backend. Reusable
+  analysis and validation behavior should flow through the facade and
+  CLI/core contract instead of being duplicated here.
+- `pccx-llm-launcher` is a future local LLM/chat backend candidate for
+  local coding-assistant mode. This repository currently contains only
+  boundary/stub work for AI-assisted SystemVerilog development workflow
+  experiments: no AI provider calls, no pccx-llm-launcher runtime calls
+  yet, and no MCP server implementation.
+
 ## Initial track (near-term)
 
-- SystemVerilog navigation backed by `pccx-lab` analysis.
+- SystemVerilog navigation through the CLI/editor bridge boundary.
 - Diagnostics surfaced from the same place the lab CLI surfaces them.
-- xsim run launching and log handoff via the CLI / core boundary.
+- Existing xsim log handoff through the CLI / core boundary; xsim run
+  launching remains a planned integration path.
 - Project-aware view of `pccx-lab` artifacts (traces, run reports,
   verification status).
 
@@ -156,11 +171,18 @@ The envelope shape is fixed in [`schema/diagnostics-v0.json`](./schema/diagnosti
 Handoff notes for the eventual `pccx-lab` and xsim integration paths
 live in [`docs/HANDOFF.md`](./docs/HANDOFF.md).
 
+The experimental VS Code prototype under
+[`editors/vscode-prototype`](./editors/vscode-prototype) keeps
+checked-example mode as the safe default. Live workspace commands are
+opt-in and require an explicit configuration gate; the current AI
+assistant work is only a proposal boundary and token-saving context
+bundle stub.
+
 ## Later track (deferred)
 
-- AI workers can interact with `pccx-lab` through a controlled MCP
-  interface; the IDE surfaces those flows but does not own the
-  contract.
+- Local coding-assistant mode can propose interactions with `pccx-lab`
+  through a controlled tool boundary; the IDE surfaces those flows but
+  does not own the reusable analysis contract.
 - Evolutionary generate / simulate / evaluate / refine loop, again
   driven through the lab boundary.
 - VS Code extension distribution.

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -78,6 +78,22 @@ navigation records.  Its local command facade requires explicit
 checked-example or live mode selection and emits VS Code-style JSON for
 known flows only.
 
+The VS Code prototype is the editor cockpit over this contract.  It owns
+command registration, presentation mapping, and the opt-in live workspace
+command boundary.  It is not a second analysis backend, does not
+duplicate pccx-lab internals, and does not implement LSP.  pccx-lab
+remains the CLI-first verification/tooling backend for reusable analysis
+and validation behavior.
+
+Checked-example remains the default.  Live workspace mode is explicit
+opt-in and requires both `pccxSystemVerilog.mode=liveWorkspace` and
+`pccxSystemVerilog.liveWorkspace.enabled=true`; disabled live workspace
+commands fail clearly instead of falling back to examples.  The current
+AI-assisted SystemVerilog development workflow work is boundary/stub
+only: a context bundle JSON contract and proposal model, with no AI
+provider calls, no pccx-llm-launcher runtime calls yet, and no MCP server
+implementation.
+
 The same directory now includes an experimental local VS Code extension
 scaffold.  Its command handlers are thin wrappers around the local facade:
 VS Code command -> prototype settings -> extension wrapper -> facade ->
@@ -118,6 +134,14 @@ VS Code command
   -> diagnostics/navigation records
 ```
 
+Future local coding-assistant mode should use the same controlled data
+path.  Context bundle records should carry selected file/range,
+diagnostics, declaration references, validation summaries, and bounded
+snippets by path/range instead of whole workspaces.  Any command proposal
+or validation proposal must route through the facade or pccx-lab
+CLI/core boundary and remain a proposal until an editor/user-controlled
+executor accepts it.
+
 `problems` converts local diagnostics and log records into editor-friendly
 problem records.  `index` provides scanner-based module/package/interface
 declaration records.  `declarations` exports those records directly, and
@@ -132,3 +156,8 @@ declaration records.  `declarations` exports those records directly, and
 - No stable schema yet.
 - No real xsim or Vivado execution.
 - No hardware access or hardware correctness claim.
+- No AI provider calls or local chat backend integration in this repo
+  today.
+- No MCP server implementation in this repo today.
+- No pccx-llm-launcher runtime call yet; future integration requires an
+  explicit reviewed contract.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -12,9 +12,10 @@ Two handoff paths are tracked:
 
 ## pccx-lab diagnostics handoff (active)
 
-`pccx-lab` now exposes `analyze <path> [--format json]` which emits an
-early diagnostics envelope.  The `pccx-ide check --backend pccx-lab`
-flag wires this path.
+This repository expects the pccx-lab CLI/core boundary to expose
+`analyze <path> [--format json]` with an early diagnostics envelope.  The
+`pccx-ide check --backend pccx-lab` flag wires this path when the
+pccx-lab binary is configured.
 
 ### Usage
 
@@ -332,6 +333,12 @@ python -m pccx_ide_cli problems from-xsim-log fixtures/xsim/mixed.log --format t
   the diagnostics envelope.
 - Whether the `additionalProperties: false` constraint on diagnostics
   should relax at v1 to allow forward-compatible extension fields.
+- How a future local coding-assistant mode should pass token-saving
+  context bundles to pccx-llm-launcher or an MCP-style controlled tool
+  boundary.  The current VS Code prototype only has boundary/stub types
+  and tests: no AI provider calls, no local chat backend runtime calls,
+  no MCP server implementation, and no direct execution of command or
+  validation proposals.
 
 These are intentionally unresolved while both sides mature.
 
@@ -340,4 +347,4 @@ These are intentionally unresolved while both sides mature.
 *See also*:
 [AI-assisted engineering discipline](https://github.com/pccxai/pccxai/blob/main/docs/AI_ASSISTED_ENGINEERING.md) —
 org-level rules covering interface-first work and gray-box delegation that govern
-how AI workers interact with the pccx-lab boundary from this IDE layer.
+how AI-assisted work interacts with the pccx-lab boundary from this IDE layer.

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -13,6 +13,23 @@ integration tests, and they run without npm install, Vivado, xsim, or
 hardware.  A limited opt-in Extension Host runtime smoke exists for local
 dependency-policy review; it is not a product claim.
 
+## Boundary Roles
+
+`systemverilog-ide` is the editor cockpit: it owns VS Code command
+registration, presentation mapping, opt-in workspace command shape, and
+future context construction for editor users.  It does not become a
+separate analysis backend.
+
+`pccx-lab` is the CLI-first verification/tooling backend.  Reusable
+analysis, diagnostics, declaration lookup, validation status, and log
+handoff should flow through the existing facade and CLI/core boundary
+rather than being duplicated inside this extension scaffold.
+
+`pccx-llm-launcher` is a future local LLM/chat/model backend candidate.
+This prototype only adds an AI assistant boundary/stub and context bundle
+contract.  There are no AI provider calls, no pccx-llm-launcher runtime
+calls, and no MCP server implementation in this scaffold.
+
 ## Data Mapping
 
 Problem payloads become diagnostic-like records:
@@ -45,6 +62,24 @@ strings.  It only exposes helpers for known `pccx_ide_cli` JSON flows:
 JSON payloads through the same adapter functions used by the checked
 example path.  Failures return structured `ok`, `exitCode`, `stdout`,
 `stderr`, and `error` fields for callers to surface.
+
+## Live Workspace Opt-In
+
+Checked-example remains the default.  Live workspace behavior requires
+both `pccxSystemVerilog.mode=liveWorkspace` and
+`pccxSystemVerilog.liveWorkspace.enabled=true`; setting only one of those
+values is not enough.  Live workspace commands do not silently fall back
+to checked examples, do not start background workspace scanning, do not
+add file watchers, do not check on save, and do not run arbitrary shell
+commands.
+
+The live workspace command shape is limited to known facade argument
+arrays.  `pccxSystemVerilog.publishLiveWorkspaceDiagnostics` maps to the
+known diagnostics facade flow for the configured default source, and
+`pccxSystemVerilog.showLiveWorkspaceNavigation` maps to the known locate
+flow for the configured default module/kind.  The older
+`runDiagnosticsLive` and `runNavigationLive` command IDs remain
+experimental opt-in aliases for now.
 
 ## Command Facade
 
@@ -85,6 +120,8 @@ The contributed commands are:
 
 - `pccxSystemVerilog.publishCheckedExampleDiagnostics`
 - `pccxSystemVerilog.showCheckedExampleNavigation`
+- `pccxSystemVerilog.publishLiveWorkspaceDiagnostics`
+- `pccxSystemVerilog.showLiveWorkspaceNavigation`
 - `pccxSystemVerilog.showDiagnosticsExample`
 - `pccxSystemVerilog.showNavigationExample`
 - `pccxSystemVerilog.runDiagnosticsLive`
@@ -92,7 +129,11 @@ The contributed commands are:
 
 The prototype-only settings are:
 
-- `pccxSystemVerilog.mode`, default `example`
+- `pccxSystemVerilog.mode`, default `checkedExample`
+- `pccxSystemVerilog.liveWorkspace.enabled`, default `false`
+- `pccxSystemVerilog.pccxLab.command`, default `pccx_ide_cli`
+- `pccxSystemVerilog.aiAssistant.enabled`, default `false`
+- `pccxSystemVerilog.aiAssistant.backend`, default `none`
 - `pccxSystemVerilog.pythonPath`, default `python3`
 - `pccxSystemVerilog.defaultSource`, default `fixtures/missing_endmodule.sv`
 - `pccxSystemVerilog.defaultLog`, default `fixtures/xsim/mixed.log`
@@ -141,8 +182,9 @@ navigation facade boundary used by
 VS Code `Location` results mapped from
 `navigation --mode example --source declarations`; it does not implement
 LSP, does not scan the live workspace by default, and does not silently
-switch modes.  Semantic cursor and symbol resolution are not complete in
-this phase, so the provider may ignore the cursor position and return
+switch modes.  It also does not call AI providers, pccx-llm-launcher, or
+chat services.  Semantic cursor and symbol resolution are not complete
+in this phase, so the provider may ignore the cursor position and return
 the checked-example declaration location.  Live navigation remains an
 explicit and separate command path.
 
@@ -165,12 +207,38 @@ smoke now exists at
 `scripts/vscode-extension-host-smoke.sh`, but it exits 2 by default and
 only runs when `PCCX_RUN_EXTENSION_HOST_SMOKE=1` is set.  The runtime
 smoke loads the local extension package, verifies activation/command
-registration, and executes the checked-example diagnostics publishing
-command plus the checked-example navigation command and provider smoke.
-It does not run the live CLI path, package the extension, add an LSP
+registration, confirms the live workspace diagnostics command fails
+clearly while disabled by default, and executes the checked-example
+diagnostics publishing command plus the checked-example navigation
+command and provider smoke.  It does not run an enabled live CLI path,
+package the extension, add an LSP
 provider, or install from the marketplace.  Extension Host gates are
 tracked in
 [`docs/EXTENSION_HOST_READINESS.md`](./docs/EXTENSION_HOST_READINESS.md).
+
+## AI Assistant Boundary and Context Bundle
+
+`src/ai-assistant-boundary.mjs` models a future local coding-assistant
+mode as proposals only.  Allowed proposal kinds include explaining
+diagnostics, proposing a patch, proposing a validation command,
+summarizing xsim/log output, asking for more context, opening a related
+symbol, and proposing a pccx-lab tool call through a controlled tool
+boundary.  Direct file writes, git commits, pushes, release/tag actions,
+ruleset/settings/secrets changes, staging/private repo access, and
+arbitrary shell commands are disallowed by default.
+
+`src/context-bundle.mjs` is a token-saving context bundle stub for future
+AI-assisted SystemVerilog development workflow experiments.  It prefers
+the current file, selected range/symbol, active diagnostics, declaration
+references, recent validation summaries, pccx-lab output summaries, and
+small bounded snippets.  It references files by path/range instead of
+including whole workspaces, excludes `node_modules`, `.vscode-test`,
+binary-like content, and private worker instruction paths, and redacts
+secret-like assignments.  This is a JSON contract/stub only: no AI
+provider calls, no pccx-llm-launcher runtime calls yet, no MCP server
+implementation, no direct file modification, and no stable API claim.
+The boundary notes are tracked in
+[`docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md`](./docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md).
 
 ## Theme-Neutral Presentation Boundary
 
@@ -198,6 +266,9 @@ node editors/vscode-prototype/test/cli-runner.test.mjs
 node editors/vscode-prototype/test/facade.test.mjs
 node editors/vscode-prototype/test/extension-manifest.test.mjs
 node editors/vscode-prototype/test/extension-config.test.mjs
+node editors/vscode-prototype/test/context-bundle.test.mjs
+node editors/vscode-prototype/test/ai-assistant-boundary.test.mjs
+node editors/vscode-prototype/test/static-boundary.test.mjs
 node editors/vscode-prototype/test/extension-entrypoint.test.mjs
 node editors/vscode-prototype/test/command-handlers.test.mjs
 node editors/vscode-prototype/test/presenter.test.mjs

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -16,8 +16,13 @@ should earn CI promotion separately.
 ## Tested Today
 
 - Configuration helper defaults and validation.
+- Explicit live workspace configuration guard:
+  `checkedExample` remains the default, and live workspace commands
+  require both `mode=liveWorkspace` and `liveWorkspace.enabled=true`.
 - Known facade argument arrays.
 - Command handlers and UI action models.
+- AI assistant boundary and token-saving context bundle unit tests.  The
+  current AI assistant work is boundary/stub only.
 - Presenter behavior with mocked VS Code-like dependencies.
 - Real VS Code `DiagnosticCollection` population for the checked-example
   diagnostics command when the local runtime smoke is explicitly enabled.
@@ -43,6 +48,10 @@ should earn CI promotion separately.
 - Packaging.
 - `vsce`.
 - Marketplace install.
+- Enabled live workspace scanning, watchers, check-on-save, or arbitrary
+  project indexing.
+- AI provider calls, pccx-llm-launcher runtime calls, chat backend
+  calls, or MCP server implementation.
 
 The runtime smoke is limited coverage for the activation, command facade,
 and VS Code-native provider boundary only.  It is not a product claim and
@@ -65,9 +74,10 @@ PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh
 The runner lives under `editors/vscode-prototype/test/extension-host/`.
 It uses `@vscode/test-electron@2.5.2`, pins VS Code to `1.90.2`, creates
 a temporary workspace, loads the local extension package, verifies the
-expected command IDs, and executes only
-`pccxSystemVerilog.publishCheckedExampleDiagnostics` and
-`pccxSystemVerilog.showCheckedExampleNavigation`.  The diagnostics
+expected command IDs, checks that
+`pccxSystemVerilog.publishLiveWorkspaceDiagnostics` fails clearly while
+live workspace is disabled by default, and executes only the
+checked-example diagnostics/navigation command paths.  The diagnostics
 command uses checked example diagnostics by default, goes through the
 facade boundary, and verifies that VS Code receives at least one
 diagnostic with URI, range, severity, message, and source fields.  The
@@ -80,8 +90,17 @@ experimental VS Code-native `DefinitionProvider` returns at least one
 `Location` with sane URI and range fields.  The provider currently
 reuses the checked-example declaration result and does not complete
 semantic cursor/symbol resolution.  Live mode remains explicit and
-separate, and the runtime smoke does not execute live CLI commands by
-default.  This is not LSP, and there is no LSP provider yet.
+separate, and the runtime smoke does not execute enabled live CLI
+commands by default.  This is not LSP, and there is no LSP provider yet.
+
+## AI Assistant Boundary
+
+The prototype has a future AI-assisted SystemVerilog development workflow
+boundary, not a model integration.  pccx-llm-launcher is a future local LLM/chat backend candidate, and any later integration must use a reviewed
+contract.  The current extension code makes no AI provider calls, no
+pccx-llm-launcher runtime calls, and implements no MCP server.  AI
+actions are modeled as proposals, including command proposal and
+validation proposal shapes, rather than direct execution.
 
 The guarded script is not run by CI today.
 
@@ -125,3 +144,6 @@ system.
 6. Do not add `vsce`, publisher metadata, packaging scripts, LSP, or
    marketplace flow.
 7. Do not make a marketplace, published-extension, or stable API claim.
+8. Do not make live workspace mode the default.
+9. Do not add AI provider calls, pccx-llm-launcher runtime calls, or MCP
+   server implementation without a separate contract review.

--- a/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
+++ b/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
@@ -1,0 +1,114 @@
+# Live Workspace and AI Boundary
+
+## Status
+
+This is experimental boundary documentation for the local VS Code
+prototype.  It is not production-ready, not a stable API/ABI, not LSP,
+not marketplace packaging, and not a complete AI integration.
+
+Checked-example remains the default.  Live workspace mode is opt-in and
+requires both:
+
+- `pccxSystemVerilog.mode=liveWorkspace`
+- `pccxSystemVerilog.liveWorkspace.enabled=true`
+
+AI assistant behavior is disabled by default:
+
+- `pccxSystemVerilog.aiAssistant.enabled=false`
+- `pccxSystemVerilog.aiAssistant.backend=none`
+
+## Roles
+
+```text
+VS Code editor cockpit
+  -> extension command/config boundary
+  -> local pccx-vscode-prototype facade
+  -> pccx_ide_cli JSON contract
+  -> pccx-lab CLI/core boundary where configured
+
+Future local coding-assistant mode
+  -> bounded context bundle
+  -> command proposal / validation proposal
+  -> controlled tool boundary
+  -> pccx-lab or future pccx-llm-launcher contract
+```
+
+`systemverilog-ide` owns editor presentation, command registration,
+context-bundle construction, and proposal display.  It should not copy
+reusable analysis or verification behavior from pccx-lab.
+
+`pccx-lab` is the CLI-first verification/tooling backend.  Analysis,
+diagnostics, declaration lookup, validation status, and log handoff
+should flow through the facade or CLI/core boundary.
+
+`pccx-llm-launcher` is a future local LLM/chat/model backend candidate.
+There are no pccx-llm-launcher runtime calls in this prototype.  A later
+integration needs an explicit contract for request shape, response shape,
+local process/session behavior, failure handling, and user approval
+boundaries.
+
+## Live Workspace Commands
+
+The current command shape is intentionally narrow:
+
+- `pccxSystemVerilog.publishLiveWorkspaceDiagnostics`
+- `pccxSystemVerilog.showLiveWorkspaceNavigation`
+
+The older `pccxSystemVerilog.runDiagnosticsLive` and
+`pccxSystemVerilog.runNavigationLive` command IDs remain experimental
+opt-in aliases.  Live commands build fixed facade argument arrays for
+known flows only.  They do not accept arbitrary shell commands, do not
+use shell interpolation, do not silently fall back to checked-example
+mode, and do not start background scanning.
+
+## AI Assistant Proposal Boundary
+
+The current AI assistant boundary is a proposal model only.  There are
+no AI provider calls, no external API keys, no pccx-llm-launcher runtime
+calls yet, and no MCP server implementation.
+
+Allowed proposal kinds:
+
+- explain diagnostics
+- propose patch
+- propose validation command
+- summarize xsim/log output
+- ask for more context
+- open related symbol
+- call pccx-lab tool through a controlled boundary
+
+Disallowed by default:
+
+- direct file write
+- direct git commit
+- direct push
+- direct release/tag
+- direct ruleset/settings/secrets change
+- staging/private repo access
+- arbitrary shell command
+
+## Context Bundle Contract
+
+The context bundle is a token-saving JSON contract stub.  It prefers:
+
+- selected file path and selected range
+- selected symbol and declaration references
+- active diagnostics around the selected range
+- recent validation status
+- pccx-lab command output summaries
+- bounded snippets with path/range references
+- summarized logs, not full logs
+
+Limits are enforced by `src/context-bundle.mjs`:
+
+- max files
+- max diagnostics
+- max declarations
+- max snippet lines
+- max log summary lines
+- max text characters
+
+The builder excludes binary-like content, `node_modules`, `.vscode-test`,
+`.git`, secret-like path names, and private worker instruction paths.  It
+redacts secret-like assignment lines and keeps deterministic ordering for
+reviewable tests.

--- a/editors/vscode-prototype/package.json
+++ b/editors/vscode-prototype/package.json
@@ -15,6 +15,8 @@
   "activationEvents": [
     "onCommand:pccxSystemVerilog.publishCheckedExampleDiagnostics",
     "onCommand:pccxSystemVerilog.showCheckedExampleNavigation",
+    "onCommand:pccxSystemVerilog.publishLiveWorkspaceDiagnostics",
+    "onCommand:pccxSystemVerilog.showLiveWorkspaceNavigation",
     "onCommand:pccxSystemVerilog.showDiagnosticsExample",
     "onCommand:pccxSystemVerilog.showNavigationExample",
     "onCommand:pccxSystemVerilog.runDiagnosticsLive",
@@ -31,6 +33,14 @@
         "title": "PCCX SystemVerilog: Show Checked Example Navigation (Experimental)"
       },
       {
+        "command": "pccxSystemVerilog.publishLiveWorkspaceDiagnostics",
+        "title": "PCCX SystemVerilog: Publish Live Workspace Diagnostics (Experimental, Opt-In)"
+      },
+      {
+        "command": "pccxSystemVerilog.showLiveWorkspaceNavigation",
+        "title": "PCCX SystemVerilog: Show Live Workspace Navigation (Experimental, Opt-In)"
+      },
+      {
         "command": "pccxSystemVerilog.showDiagnosticsExample",
         "title": "PCCX SystemVerilog: Show Diagnostics Example"
       },
@@ -40,11 +50,11 @@
       },
       {
         "command": "pccxSystemVerilog.runDiagnosticsLive",
-        "title": "PCCX SystemVerilog: Run Diagnostics Live"
+        "title": "PCCX SystemVerilog: Run Diagnostics Live (Experimental, Opt-In Alias)"
       },
       {
         "command": "pccxSystemVerilog.runNavigationLive",
-        "title": "PCCX SystemVerilog: Run Navigation Live"
+        "title": "PCCX SystemVerilog: Run Navigation Live (Experimental, Opt-In Alias)"
       }
     ],
     "configuration": {
@@ -53,11 +63,36 @@
         "pccxSystemVerilog.mode": {
           "type": "string",
           "enum": [
-            "example",
-            "live"
+            "checkedExample",
+            "liveWorkspace"
           ],
-          "default": "example",
-          "description": "Experimental local prototype setting selecting checked-example mode or live CLI mode for prototype commands; not a stable API."
+          "default": "checkedExample",
+          "description": "Experimental local prototype setting selecting checked-example mode or explicit live workspace mode for prototype commands; not a stable API."
+        },
+        "pccxSystemVerilog.liveWorkspace.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Experimental local prototype opt-in gate for live workspace commands; checked-example mode remains the default and this is not a stable API."
+        },
+        "pccxSystemVerilog.pccxLab.command": {
+          "type": "string",
+          "default": "pccx_ide_cli",
+          "description": "Experimental local prototype command-boundary name for the pccx-lab CLI-first backend; no arguments, no direct internals, and not a stable API."
+        },
+        "pccxSystemVerilog.aiAssistant.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Experimental local prototype opt-in flag reserved for future AI-assisted SystemVerilog development workflow boundaries; no provider calls and not a stable API."
+        },
+        "pccxSystemVerilog.aiAssistant.backend": {
+          "type": "string",
+          "enum": [
+            "none",
+            "pccx-llm-launcher",
+            "mcp"
+          ],
+          "default": "none",
+          "description": "Experimental local prototype AI assistant backend selector for future controlled tool boundaries; no runtime calls in this scaffold and not a stable API."
         },
         "pccxSystemVerilog.pythonPath": {
           "type": "string",

--- a/editors/vscode-prototype/src/ai-assistant-boundary.mjs
+++ b/editors/vscode-prototype/src/ai-assistant-boundary.mjs
@@ -1,0 +1,93 @@
+import { normalizeConfig } from "./config.mjs";
+import {
+  buildContextBundle,
+  summarizeContextBundle,
+} from "./context-bundle.mjs";
+
+export const AI_ASSISTANT_BOUNDARY_VERSION = "pccx.aiAssistantBoundary.v0";
+
+export const AI_ASSISTANT_STATUSES = Object.freeze({
+  DISABLED: "disabled",
+  NOT_CONFIGURED: "notConfigured",
+  PROPOSAL_BOUNDARY: "proposalBoundary",
+});
+
+export const AI_PROPOSAL_KINDS = Object.freeze([
+  "explainDiagnostics",
+  "proposePatch",
+  "proposeValidationCommand",
+  "summarizeXsimLogOutput",
+  "askForMoreContext",
+  "openRelatedSymbol",
+  "callPccxLabTool",
+]);
+
+export const DISALLOWED_AI_ACTIONS = Object.freeze([
+  "directFileWrite",
+  "directGitCommit",
+  "directGitPush",
+  "directReleaseOrTag",
+  "directRulesetSettingsOrSecretsChange",
+  "stagingOrPrivateRepoAccess",
+  "arbitraryShellCommand",
+]);
+
+function proposalAction(kind) {
+  return {
+    kind,
+    execution: "proposalOnly",
+  };
+}
+
+export function createAssistantBoundaryStatus(rawConfig = {}) {
+  const config = normalizeConfig(rawConfig);
+  if (!config.aiAssistant.enabled) {
+    return {
+      version: AI_ASSISTANT_BOUNDARY_VERSION,
+      status: AI_ASSISTANT_STATUSES.DISABLED,
+      backend: config.aiAssistant.backend,
+      providerCalls: false,
+      runtimeCalls: false,
+    };
+  }
+  if (config.aiAssistant.backend === "none") {
+    return {
+      version: AI_ASSISTANT_BOUNDARY_VERSION,
+      status: AI_ASSISTANT_STATUSES.NOT_CONFIGURED,
+      backend: config.aiAssistant.backend,
+      providerCalls: false,
+      runtimeCalls: false,
+    };
+  }
+  return {
+    version: AI_ASSISTANT_BOUNDARY_VERSION,
+    status: AI_ASSISTANT_STATUSES.PROPOSAL_BOUNDARY,
+    backend: config.aiAssistant.backend,
+    providerCalls: false,
+    runtimeCalls: false,
+  };
+}
+
+export function createAssistantRequest(rawConfig = {}, contextInput = {}, options = {}) {
+  const status = createAssistantBoundaryStatus(rawConfig);
+  const contextBundle = buildContextBundle(contextInput, options);
+
+  return {
+    ...status,
+    contextBundle,
+    contextSummary: summarizeContextBundle(contextBundle),
+    allowedActions: AI_PROPOSAL_KINDS.map(proposalAction),
+    disallowedActions: [...DISALLOWED_AI_ACTIONS],
+  };
+}
+
+export function createCommandProposal(kind, payload = {}) {
+  if (!AI_PROPOSAL_KINDS.includes(kind)) {
+    throw new Error(`unsupported AI assistant proposal kind: ${kind}`);
+  }
+  return {
+    kind,
+    execution: "proposalOnly",
+    payload: { ...payload },
+  };
+}

--- a/editors/vscode-prototype/src/config.mjs
+++ b/editors/vscode-prototype/src/config.mjs
@@ -2,6 +2,10 @@ export const CONFIG_SECTION = "pccxSystemVerilog";
 
 export const CONFIG_KEYS = Object.freeze([
   "mode",
+  "liveWorkspace.enabled",
+  "pccxLab.command",
+  "aiAssistant.enabled",
+  "aiAssistant.backend",
   "pythonPath",
   "defaultSource",
   "defaultLog",
@@ -12,17 +16,36 @@ export const CONFIG_KEYS = Object.freeze([
 export const COMMAND_IDS = Object.freeze([
   "pccxSystemVerilog.publishCheckedExampleDiagnostics",
   "pccxSystemVerilog.showCheckedExampleNavigation",
+  "pccxSystemVerilog.publishLiveWorkspaceDiagnostics",
+  "pccxSystemVerilog.showLiveWorkspaceNavigation",
   "pccxSystemVerilog.showDiagnosticsExample",
   "pccxSystemVerilog.showNavigationExample",
   "pccxSystemVerilog.runDiagnosticsLive",
   "pccxSystemVerilog.runNavigationLive",
 ]);
 
-export const MODES = Object.freeze(["example", "live"]);
+export const MODES = Object.freeze(["checkedExample", "liveWorkspace"]);
+export const AI_ASSISTANT_BACKENDS = Object.freeze(["none", "pccx-llm-launcher", "mcp"]);
 export const DECLARATION_KINDS = Object.freeze(["module", "package", "interface", "any"]);
+export const LIVE_WORKSPACE_COMMAND_IDS = Object.freeze([
+  "pccxSystemVerilog.publishLiveWorkspaceDiagnostics",
+  "pccxSystemVerilog.showLiveWorkspaceNavigation",
+  "pccxSystemVerilog.runDiagnosticsLive",
+  "pccxSystemVerilog.runNavigationLive",
+]);
 
 const DEFAULT_CONFIG = Object.freeze({
-  mode: "example",
+  mode: "checkedExample",
+  liveWorkspace: Object.freeze({
+    enabled: false,
+  }),
+  pccxLab: Object.freeze({
+    command: "pccx_ide_cli",
+  }),
+  aiAssistant: Object.freeze({
+    enabled: false,
+    backend: "none",
+  }),
   pythonPath: "python3",
   defaultSource: "fixtures/missing_endmodule.sv",
   defaultLog: "fixtures/xsim/mixed.log",
@@ -37,7 +60,19 @@ function rawConfigValue(rawConfig, key) {
   if (rawConfig && typeof rawConfig.get === "function") {
     return rawConfig.get(key);
   }
-  return rawConfig?.[key];
+  if (rawConfig && Object.hasOwn(rawConfig, key)) {
+    return rawConfig[key];
+  }
+
+  const parts = key.split(".");
+  let value = rawConfig;
+  for (const part of parts) {
+    if (value == null || typeof value !== "object" || !Object.hasOwn(value, part)) {
+      return undefined;
+    }
+    value = value[part];
+  }
+  return value;
 }
 
 function stringSetting(rawConfig, key, fallback) {
@@ -57,6 +92,25 @@ function stringSetting(rawConfig, key, fallback) {
   return value;
 }
 
+function commandSetting(rawConfig, key, fallback) {
+  const value = stringSetting(rawConfig, key, fallback);
+  if (/\s/.test(value)) {
+    throw new Error(`${CONFIG_SECTION}.${key} must be a command name or path without arguments`);
+  }
+  return value;
+}
+
+function booleanSetting(rawConfig, key, fallback) {
+  const value = rawConfigValue(rawConfig, key);
+  if (value == null) {
+    return fallback;
+  }
+  if (typeof value !== "boolean") {
+    throw new Error(`${CONFIG_SECTION}.${key} must be a boolean`);
+  }
+  return value;
+}
+
 function enumSetting(rawConfig, key, fallback, allowedValues) {
   const value = stringSetting(rawConfig, key, fallback);
   if (!allowedValues.includes(value)) {
@@ -68,12 +122,40 @@ function enumSetting(rawConfig, key, fallback, allowedValues) {
 }
 
 export function defaultConfig() {
-  return { ...DEFAULT_CONFIG };
+  return {
+    ...DEFAULT_CONFIG,
+    liveWorkspace: { ...DEFAULT_CONFIG.liveWorkspace },
+    pccxLab: { ...DEFAULT_CONFIG.pccxLab },
+    aiAssistant: { ...DEFAULT_CONFIG.aiAssistant },
+  };
 }
 
 export function normalizeConfig(rawConfig = {}) {
   return {
     mode: enumSetting(rawConfig, "mode", DEFAULT_CONFIG.mode, MODES),
+    liveWorkspace: {
+      enabled: booleanSetting(
+        rawConfig,
+        "liveWorkspace.enabled",
+        DEFAULT_CONFIG.liveWorkspace.enabled,
+      ),
+    },
+    pccxLab: {
+      command: commandSetting(rawConfig, "pccxLab.command", DEFAULT_CONFIG.pccxLab.command),
+    },
+    aiAssistant: {
+      enabled: booleanSetting(
+        rawConfig,
+        "aiAssistant.enabled",
+        DEFAULT_CONFIG.aiAssistant.enabled,
+      ),
+      backend: enumSetting(
+        rawConfig,
+        "aiAssistant.backend",
+        DEFAULT_CONFIG.aiAssistant.backend,
+        AI_ASSISTANT_BACKENDS,
+      ),
+    },
     pythonPath: stringSetting(rawConfig, "pythonPath", DEFAULT_CONFIG.pythonPath),
     defaultSource: stringSetting(rawConfig, "defaultSource", DEFAULT_CONFIG.defaultSource),
     defaultLog: stringSetting(rawConfig, "defaultLog", DEFAULT_CONFIG.defaultLog),
@@ -87,7 +169,35 @@ export function normalizeConfig(rawConfig = {}) {
   };
 }
 
+export function isKnownCommandId(commandId) {
+  return COMMAND_IDS.includes(commandId);
+}
+
+export function assertKnownCommandId(commandId) {
+  if (!isKnownCommandId(commandId)) {
+    throw new Error(`unknown PCCX SystemVerilog command: ${commandId}`);
+  }
+}
+
+export function isLiveWorkspaceCommand(commandId) {
+  return LIVE_WORKSPACE_COMMAND_IDS.includes(commandId);
+}
+
+export function isLiveWorkspaceEnabled(config) {
+  return config?.mode === "liveWorkspace" && config?.liveWorkspace?.enabled === true;
+}
+
+export function assertLiveWorkspaceEnabled(config) {
+  if (!isLiveWorkspaceEnabled(config)) {
+    throw new Error(
+      "live workspace commands require pccxSystemVerilog.mode=liveWorkspace " +
+        "and pccxSystemVerilog.liveWorkspace.enabled=true",
+    );
+  }
+}
+
 export function buildFacadeArgsForCommand(commandId, rawConfig = {}) {
+  assertKnownCommandId(commandId);
   const config = normalizeConfig(rawConfig);
 
   if (
@@ -104,11 +214,19 @@ export function buildFacadeArgsForCommand(commandId, rawConfig = {}) {
     return ["navigation", "--mode", "example", "--source", "declarations"];
   }
 
-  if (commandId === "pccxSystemVerilog.runDiagnosticsLive") {
+  if (
+    commandId === "pccxSystemVerilog.publishLiveWorkspaceDiagnostics" ||
+    commandId === "pccxSystemVerilog.runDiagnosticsLive"
+  ) {
+    assertLiveWorkspaceEnabled(config);
     return ["diagnostics", "--mode", "live", "--from-check", config.defaultSource];
   }
 
-  if (commandId === "pccxSystemVerilog.runNavigationLive") {
+  if (
+    commandId === "pccxSystemVerilog.showLiveWorkspaceNavigation" ||
+    commandId === "pccxSystemVerilog.runNavigationLive"
+  ) {
+    assertLiveWorkspaceEnabled(config);
     return [
       "navigation",
       "--mode",
@@ -121,7 +239,7 @@ export function buildFacadeArgsForCommand(commandId, rawConfig = {}) {
     ];
   }
 
-  throw new Error(`unknown PCCX SystemVerilog command: ${commandId}`);
+  throw new Error(`unhandled PCCX SystemVerilog command: ${commandId}`);
 }
 
 export function isLiveFacadeArgs(args) {

--- a/editors/vscode-prototype/src/context-bundle.mjs
+++ b/editors/vscode-prototype/src/context-bundle.mjs
@@ -1,0 +1,276 @@
+import { isAbsolute, relative } from "node:path";
+
+export const CONTEXT_BUNDLE_VERSION = "pccx.contextBundle.v0";
+export const CONTEXT_BUNDLE_SOURCE = "pccx-systemverilog-ide";
+
+export const DEFAULT_CONTEXT_BUNDLE_LIMITS = Object.freeze({
+  maxFiles: 3,
+  maxDiagnostics: 10,
+  maxDeclarations: 12,
+  maxSnippetLines: 40,
+  maxLogSummaryLines: 20,
+  maxTextCharacters: 4000,
+});
+
+const EXCLUDED_PATH_SEGMENTS = new Set([
+  ".git",
+  ".vscode-test",
+  "node_modules",
+]);
+
+const SECRET_LIKE_PATTERN =
+  /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b/i;
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]/i;
+const PRIVATE_INSTRUCTION_PATH_PATTERN =
+  /(?:^|[/\\])(?:\.codex|private[-_ ]?worker|worker[-_ ]?instruction|subagent[-_ ]?instruction)(?:[/\\]|$)/i;
+
+function mergeLimits(limits = {}) {
+  return {
+    ...DEFAULT_CONTEXT_BUNDLE_LIMITS,
+    ...Object.fromEntries(
+      Object.entries(limits).filter(([, value]) => Number.isInteger(value) && value >= 0),
+    ),
+  };
+}
+
+function normalizeWorkspacePath(workspaceRoot) {
+  if (typeof workspaceRoot !== "string" || workspaceRoot.trim().length === 0) {
+    return null;
+  }
+  return workspaceRoot.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function hasExcludedPathSegment(path) {
+  const segments = path.split("/").filter(Boolean);
+  return segments.some((segment) => EXCLUDED_PATH_SEGMENTS.has(segment));
+}
+
+function normalizePathRef(path, workspaceRoot = null) {
+  if (typeof path !== "string" || path.trim().length === 0) {
+    return null;
+  }
+  if (path.includes("\0") || path.includes("\n") || path.includes("\r")) {
+    return null;
+  }
+
+  const normalizedWorkspaceRoot = normalizeWorkspacePath(workspaceRoot);
+  let normalizedPath = path.replace(/\\/g, "/");
+
+  if (isAbsolute(normalizedPath)) {
+    if (!normalizedWorkspaceRoot) {
+      return null;
+    }
+    const rel = relative(normalizedWorkspaceRoot, normalizedPath).replace(/\\/g, "/");
+    if (rel.startsWith("../") || rel === ".." || isAbsolute(rel)) {
+      return null;
+    }
+    normalizedPath = rel;
+  }
+
+  normalizedPath = normalizedPath.replace(/^\.\//, "");
+  if (
+    normalizedPath === "" ||
+    normalizedPath.startsWith("../") ||
+    normalizedPath === ".." ||
+    hasExcludedPathSegment(normalizedPath) ||
+    SECRET_LIKE_PATTERN.test(normalizedPath) ||
+    PRIVATE_INSTRUCTION_PATH_PATTERN.test(normalizedPath)
+  ) {
+    return null;
+  }
+  return normalizedPath;
+}
+
+function clampNumber(value, fallback = 0) {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function normalizeRange(range) {
+  if (!range || typeof range !== "object") {
+    return null;
+  }
+  return {
+    start: {
+      line: Math.max(0, Math.floor(clampNumber(range.start?.line))),
+      character: Math.max(0, Math.floor(clampNumber(range.start?.character))),
+    },
+    end: {
+      line: Math.max(0, Math.floor(clampNumber(range.end?.line))),
+      character: Math.max(0, Math.floor(clampNumber(range.end?.character))),
+    },
+  };
+}
+
+function scrubText(value, maxCharacters) {
+  if (typeof value !== "string" || value.length === 0 || maxCharacters === 0) {
+    return "";
+  }
+  return value
+    .split(/\r?\n/)
+    .map((line) => (SECRET_ASSIGNMENT_PATTERN.test(line) ? "[redacted]" : line))
+    .join("\n")
+    .slice(0, maxCharacters);
+}
+
+function isBinaryLike(text) {
+  return typeof text !== "string" || text.includes("\0");
+}
+
+function boundedLines(value, limit, maxCharacters) {
+  if (typeof value !== "string" || limit === 0 || maxCharacters === 0) {
+    return [];
+  }
+  return scrubText(value, maxCharacters)
+    .split(/\r?\n/)
+    .slice(0, limit);
+}
+
+function normalizeDiagnostic(diagnostic, workspaceRoot, limits) {
+  const path = normalizePathRef(diagnostic?.path ?? diagnostic?.file, workspaceRoot);
+  if (!path) {
+    return null;
+  }
+  return {
+    path,
+    range: normalizeRange(diagnostic.range),
+    severity: scrubText(diagnostic.severity ?? "Information", 80),
+    message: scrubText(diagnostic.message ?? "", 500),
+    source: scrubText(diagnostic.source ?? "", 120),
+    code: scrubText(diagnostic.code ?? "", 120),
+  };
+}
+
+function normalizeDeclaration(declaration, workspaceRoot, limits) {
+  const path = normalizePathRef(declaration?.path ?? declaration?.file, workspaceRoot);
+  if (!path) {
+    return null;
+  }
+  return {
+    name: scrubText(declaration.name ?? "", 160),
+    kind: scrubText(declaration.kind ?? "any", 80),
+    path,
+    range: normalizeRange(declaration.range),
+    line: declaration.line == null ? undefined : Math.max(1, Math.floor(clampNumber(declaration.line, 1))),
+    column: declaration.column == null ? undefined : Math.max(1, Math.floor(clampNumber(declaration.column, 1))),
+  };
+}
+
+function normalizeSnippet(file, workspaceRoot, limits) {
+  const path = normalizePathRef(file?.path ?? file?.file, workspaceRoot);
+  if (!path || isBinaryLike(file?.text ?? "")) {
+    return null;
+  }
+
+  const lines = boundedLines(file.text ?? "", limits.maxSnippetLines, limits.maxTextCharacters);
+  return {
+    path,
+    language: scrubText(file.language ?? "systemverilog", 80),
+    range: normalizeRange(file.range),
+    lines,
+    truncated: typeof file.text === "string" && file.text.split(/\r?\n/).length > lines.length,
+  };
+}
+
+function sortedByPathAndName(items) {
+  return [...items].sort((a, b) => {
+    const pathOrder = String(a.path ?? "").localeCompare(String(b.path ?? ""));
+    if (pathOrder !== 0) {
+      return pathOrder;
+    }
+    return String(a.name ?? a.message ?? "").localeCompare(String(b.name ?? b.message ?? ""));
+  });
+}
+
+function normalizeLogSummary(entry, limits) {
+  const lines = Array.isArray(entry?.summaryLines)
+    ? entry.summaryLines.join("\n")
+    : entry?.summary ?? "";
+  return {
+    label: scrubText(entry?.label ?? entry?.flow ?? "pccx-lab-output", 160),
+    exitCode: entry?.exitCode == null ? null : Math.floor(clampNumber(entry.exitCode)),
+    lines: boundedLines(lines, limits.maxLogSummaryLines, limits.maxTextCharacters),
+  };
+}
+
+export function buildContextBundle(input = {}, options = {}) {
+  const limits = mergeLimits(options.limits);
+  const workspaceRoot = options.workspaceRoot ?? input.workspaceRoot ?? null;
+  const files = Array.isArray(input.files) ? input.files : [];
+  const diagnostics = Array.isArray(input.activeDiagnostics) ? input.activeDiagnostics : [];
+  const declarations = Array.isArray(input.symbolContext?.declarations)
+    ? input.symbolContext.declarations
+    : [];
+  const pccxLabOutputs = Array.isArray(input.pccxLabOutputs) ? input.pccxLabOutputs : [];
+
+  const snippets = sortedByPathAndName(
+    files
+      .map((file) => normalizeSnippet(file, workspaceRoot, limits))
+      .filter(Boolean),
+  ).slice(0, limits.maxFiles);
+
+  const selectedPath = normalizePathRef(input.selectedFilePath, workspaceRoot);
+
+  return {
+    version: CONTEXT_BUNDLE_VERSION,
+    source: CONTEXT_BUNDLE_SOURCE,
+    limits,
+    selectedFile: selectedPath ? { path: selectedPath } : null,
+    selectedRange: normalizeRange(input.selectedRange),
+    userIntent: scrubText(input.userIntent ?? "", limits.maxTextCharacters),
+    diagnostics: sortedByPathAndName(
+      diagnostics
+        .map((diagnostic) => normalizeDiagnostic(diagnostic, workspaceRoot, limits))
+        .filter(Boolean),
+    ).slice(0, limits.maxDiagnostics),
+    symbols: {
+      selected: input.selectedSymbol
+        ? {
+            name: scrubText(input.selectedSymbol.name ?? "", 160),
+            kind: scrubText(input.selectedSymbol.kind ?? "any", 80),
+            path: normalizePathRef(input.selectedSymbol.path ?? input.selectedSymbol.file, workspaceRoot),
+            range: normalizeRange(input.selectedSymbol.range),
+          }
+        : null,
+      declarations: sortedByPathAndName(
+        declarations
+          .map((declaration) => normalizeDeclaration(declaration, workspaceRoot, limits))
+          .filter(Boolean),
+      ).slice(0, limits.maxDeclarations),
+    },
+    snippets,
+    validation: {
+      recent: input.recentValidation
+        ? {
+            status: scrubText(input.recentValidation.status ?? "unknown", 80),
+            summary: scrubText(input.recentValidation.summary ?? "", 800),
+            exitCode: input.recentValidation.exitCode == null
+              ? null
+              : Math.floor(clampNumber(input.recentValidation.exitCode)),
+          }
+        : null,
+    },
+    pccxLab: {
+      commandBoundary: "pccx_ide_cli",
+      outputs: pccxLabOutputs
+        .map((entry) => normalizeLogSummary(entry, limits))
+        .slice(0, limits.maxFiles),
+    },
+    excludedPathSegments: [...EXCLUDED_PATH_SEGMENTS].sort(),
+  };
+}
+
+export function summarizeContextBundle(bundle) {
+  return {
+    version: bundle?.version ?? CONTEXT_BUNDLE_VERSION,
+    selectedFile: bundle?.selectedFile ?? null,
+    diagnosticCount: Array.isArray(bundle?.diagnostics) ? bundle.diagnostics.length : 0,
+    snippetCount: Array.isArray(bundle?.snippets) ? bundle.snippets.length : 0,
+    declarationCount: Array.isArray(bundle?.symbols?.declarations)
+      ? bundle.symbols.declarations.length
+      : 0,
+    pccxLabOutputCount: Array.isArray(bundle?.pccxLab?.outputs)
+      ? bundle.pccxLab.outputs.length
+      : 0,
+  };
+}

--- a/editors/vscode-prototype/src/extension.mjs
+++ b/editors/vscode-prototype/src/extension.mjs
@@ -6,6 +6,7 @@ import {
   COMMAND_IDS,
   CONFIG_KEYS,
   CONFIG_SECTION,
+  assertKnownCommandId,
   buildFacadeArgsForCommand,
   defaultConfig,
   isLiveFacadeArgs,
@@ -252,12 +253,15 @@ export function createPresenterDeps(vscodeApi, runtime = {}) {
 }
 
 export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
-  createCommandExecutionPlan(commandId, defaultConfig());
+  assertKnownCommandId(commandId);
   return async (input) => {
     const returnsNavigationLocations = commandId === CHECKED_EXAMPLE_NAVIGATION_COMMAND;
     const rawConfig = readRawExtensionConfig(vscodeApi);
     const explicitPath = pathFromCommandInput(input);
-    const request = commandId === "pccxSystemVerilog.runDiagnosticsLive" && explicitPath
+    const request = (
+      commandId === "pccxSystemVerilog.publishLiveWorkspaceDiagnostics" ||
+      commandId === "pccxSystemVerilog.runDiagnosticsLive"
+    ) && explicitPath
       ? { ...rawConfig, defaultSource: explicitPath }
       : rawConfig;
     const presenterDeps = {

--- a/editors/vscode-prototype/test/ai-assistant-boundary.test.mjs
+++ b/editors/vscode-prototype/test/ai-assistant-boundary.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+
+import {
+  AI_ASSISTANT_BOUNDARY_VERSION,
+  AI_ASSISTANT_STATUSES,
+  AI_PROPOSAL_KINDS,
+  DISALLOWED_AI_ACTIONS,
+  createAssistantBoundaryStatus,
+  createAssistantRequest,
+  createCommandProposal,
+} from "../src/ai-assistant-boundary.mjs";
+
+function testDisabledByDefault() {
+  const status = createAssistantBoundaryStatus();
+
+  assert.deepEqual(status, {
+    version: AI_ASSISTANT_BOUNDARY_VERSION,
+    status: AI_ASSISTANT_STATUSES.DISABLED,
+    backend: "none",
+    providerCalls: false,
+    runtimeCalls: false,
+  });
+}
+
+function testEnabledButNoBackendIsNotConfigured() {
+  const status = createAssistantBoundaryStatus({
+    aiAssistant: {
+      enabled: true,
+      backend: "none",
+    },
+  });
+
+  assert.equal(status.status, AI_ASSISTANT_STATUSES.NOT_CONFIGURED);
+  assert.equal(status.backend, "none");
+  assert.equal(status.providerCalls, false);
+  assert.equal(status.runtimeCalls, false);
+}
+
+function testLauncherBackendRemainsProposalBoundary() {
+  const request = createAssistantRequest(
+    {
+      aiAssistant: {
+        enabled: true,
+        backend: "pccx-llm-launcher",
+      },
+    },
+    {
+      workspaceRoot: "/repo",
+      selectedFilePath: "/repo/rtl/top.sv",
+      userIntent: "explain diagnostics",
+      activeDiagnostics: [
+        { file: "/repo/rtl/top.sv", severity: "Error", message: "missing endmodule" },
+      ],
+    },
+    { workspaceRoot: "/repo" },
+  );
+
+  assert.equal(request.status, AI_ASSISTANT_STATUSES.PROPOSAL_BOUNDARY);
+  assert.equal(request.backend, "pccx-llm-launcher");
+  assert.equal(request.providerCalls, false);
+  assert.equal(request.runtimeCalls, false);
+  assert.deepEqual(
+    request.allowedActions.map((action) => action.kind),
+    AI_PROPOSAL_KINDS,
+  );
+  assert.ok(request.allowedActions.every((action) => action.execution === "proposalOnly"));
+  assert.deepEqual(request.disallowedActions, DISALLOWED_AI_ACTIONS);
+  assert.ok(request.disallowedActions.includes("directFileWrite"));
+  assert.ok(request.disallowedActions.includes("arbitraryShellCommand"));
+  assert.equal(request.contextSummary.selectedFile.path, "rtl/top.sv");
+  assert.equal(request.contextSummary.diagnosticCount, 1);
+}
+
+function testCommandProposalsAreProposalOnly() {
+  assert.deepEqual(
+    createCommandProposal("proposeValidationCommand", { flow: "problems from-check" }),
+    {
+      kind: "proposeValidationCommand",
+      execution: "proposalOnly",
+      payload: { flow: "problems from-check" },
+    },
+  );
+  assert.throws(
+    () => createCommandProposal("directFileWrite"),
+    /unsupported AI assistant proposal kind/,
+  );
+}
+
+testDisabledByDefault();
+testEnabledButNoBackendIsNotConfigured();
+testLauncherBackendRemainsProposalBoundary();
+testCommandProposalsAreProposalOnly();
+
+console.log("vscode AI assistant boundary tests ok");

--- a/editors/vscode-prototype/test/command-handlers.test.mjs
+++ b/editors/vscode-prototype/test/command-handlers.test.mjs
@@ -12,6 +12,15 @@ import {
   deactivate,
 } from "../src/extension.mjs";
 
+const LIVE_WORKSPACE_CONFIG = {
+  mode: "liveWorkspace",
+  liveWorkspace: { enabled: true },
+};
+
+function configForCommand(commandId) {
+  return commandId.includes("Live") ? LIVE_WORKSPACE_CONFIG : {};
+}
+
 function mockDeps(payloadOrResult) {
   const calls = {
     runFacade: [],
@@ -49,7 +58,7 @@ function mockDeps(payloadOrResult) {
 
 function testPlansForKnownCommands() {
   for (const commandId of COMMAND_IDS) {
-    const plan = createCommandExecutionPlan(commandId);
+    const plan = createCommandExecutionPlan(commandId, configForCommand(commandId));
     assert.equal(plan.commandId, commandId);
     assert.ok(Array.isArray(plan.facadeArgs));
     assert.ok(plan.facadeArgs.every((arg) => typeof arg === "string"));
@@ -102,7 +111,12 @@ async function testPublishCheckedExampleDiagnosticsAction() {
 
   const result = await runPrototypeCommand(
     "pccxSystemVerilog.publishCheckedExampleDiagnostics",
-    { mode: "live", defaultSource: "live.sv", pythonPath: "python-custom" },
+    {
+      mode: "liveWorkspace",
+      liveWorkspace: { enabled: true },
+      defaultSource: "live.sv",
+      pythonPath: "python-custom",
+    },
     deps,
   );
 
@@ -119,15 +133,17 @@ async function testPublishCheckedExampleDiagnosticsAction() {
   assert.equal(result.action.diagnostics.length, 1);
 }
 
-async function testDiagnosticsLiveAction() {
+async function testPublishLiveWorkspaceDiagnosticsAction() {
   const { calls, deps } = mockDeps({
     kind: "vscode-diagnostics",
     diagnostics: [],
   });
 
   const result = await runPrototypeCommand(
-    "pccxSystemVerilog.runDiagnosticsLive",
+    "pccxSystemVerilog.publishLiveWorkspaceDiagnostics",
     {
+      mode: "liveWorkspace",
+      liveWorkspace: { enabled: true },
       defaultSource: "rtl/top.sv",
       pythonPath: "python-custom",
     },
@@ -185,7 +201,11 @@ async function testCheckedExampleNavigationAction() {
 
   const result = await runPrototypeCommand(
     "pccxSystemVerilog.showCheckedExampleNavigation",
-    { mode: "live", pythonPath: "python-custom" },
+    {
+      mode: "liveWorkspace",
+      liveWorkspace: { enabled: true },
+      pythonPath: "python-custom",
+    },
     deps,
   );
 
@@ -202,15 +222,17 @@ async function testCheckedExampleNavigationAction() {
   assert.deepEqual(result.action.items, [item]);
 }
 
-async function testNavigationLiveAction() {
+async function testShowLiveWorkspaceNavigationAction() {
   const { calls, deps } = mockDeps({
     kind: "vscode-navigation",
     items: [],
   });
 
   const result = await runPrototypeCommand(
-    "pccxSystemVerilog.runNavigationLive",
+    "pccxSystemVerilog.showLiveWorkspaceNavigation",
     {
+      mode: "liveWorkspace",
+      liveWorkspace: { enabled: true },
       defaultModule: "pkg_defs",
       defaultDeclarationKind: "package",
       pythonPath: "python-custom",
@@ -231,6 +253,24 @@ async function testNavigationLiveAction() {
     "package",
   ]);
   assert.deepEqual(calls.runFacade[0].env, { PCCX_IDE_PYTHON: "python-custom" });
+}
+
+async function testLiveWorkspaceDisabledControlledFailure() {
+  const { calls, deps } = mockDeps({
+    kind: "vscode-diagnostics",
+    diagnostics: [],
+  });
+
+  const result = await runPrototypeCommand(
+    "pccxSystemVerilog.publishLiveWorkspaceDiagnostics",
+    {},
+    deps,
+  );
+
+  assert.equal(result.ok, false);
+  assert.match(result.error, /live workspace commands require/);
+  assert.equal(calls.runFacade.length, 0);
+  assert.match(calls.warning[0].message, /live workspace commands require/);
 }
 
 async function testRunFacadeUsesArgumentArray() {
@@ -346,11 +386,12 @@ testPlansForKnownCommands();
 testUnknownCommandRejected();
 await testDiagnosticsExampleAction();
 await testPublishCheckedExampleDiagnosticsAction();
-await testDiagnosticsLiveAction();
+await testPublishLiveWorkspaceDiagnosticsAction();
 await testNavigationExampleAction();
 await testCheckedExampleNavigationAction();
-await testNavigationLiveAction();
+await testShowLiveWorkspaceNavigationAction();
 await testRunFacadeUsesArgumentArray();
+await testLiveWorkspaceDisabledControlledFailure();
 await testInvalidConfigControlledFailure();
 await testFacadeFailureControlledFailure();
 await testInvalidFacadeKindControlledFailure();

--- a/editors/vscode-prototype/test/context-bundle.test.mjs
+++ b/editors/vscode-prototype/test/context-bundle.test.mjs
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+
+import {
+  CONTEXT_BUNDLE_VERSION,
+  buildContextBundle,
+  summarizeContextBundle,
+} from "../src/context-bundle.mjs";
+
+const SECRET_KEY_PATTERN =
+  /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b/i;
+
+function assertNoSecretLikeKeys(value) {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      assertNoSecretLikeKeys(item);
+    }
+    return;
+  }
+  if (!value || typeof value !== "object") {
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    assert.doesNotMatch(key, SECRET_KEY_PATTERN);
+    assertNoSecretLikeKeys(child);
+  }
+}
+
+function fixtureInput() {
+  return {
+    workspaceRoot: "/repo",
+    selectedFilePath: "/repo/rtl/top.sv",
+    selectedRange: {
+      start: { line: 10, character: 2 },
+      end: { line: 12, character: 8 },
+    },
+    selectedSymbol: {
+      name: "top",
+      kind: "module",
+      path: "/repo/rtl/top.sv",
+      range: {
+        start: { line: 10, character: 0 },
+        end: { line: 10, character: 3 },
+      },
+    },
+    activeDiagnostics: [
+      {
+        file: "/repo/rtl/z.sv",
+        severity: "Warning",
+        message: "late declaration",
+        range: {
+          start: { line: 4, character: 1 },
+          end: { line: 4, character: 5 },
+        },
+      },
+      {
+        file: "/repo/rtl/a.sv",
+        severity: "Error",
+        message: "missing endmodule",
+        range: {
+          start: { line: 1, character: 0 },
+          end: { line: 1, character: 6 },
+        },
+      },
+    ],
+    symbolContext: {
+      declarations: [
+        { name: "z_mod", kind: "module", file: "/repo/rtl/z.sv", line: 5, column: 1 },
+        { name: "a_mod", kind: "module", file: "/repo/rtl/a.sv", line: 1, column: 1 },
+      ],
+    },
+    files: [
+      {
+        path: "/repo/rtl/z.sv",
+        text: "module z_mod;\nendmodule\n",
+      },
+      {
+        path: "/repo/rtl/a.sv",
+        text: "module a_mod;\nAPI_KEY=abc123\nendmodule\n",
+      },
+      {
+        path: "/repo/node_modules/pkg/ignored.sv",
+        text: "module ignored;\nendmodule\n",
+      },
+      {
+        path: "/repo/.vscode-test/cache/ignored.sv",
+        text: "module cache_ignored;\nendmodule\n",
+      },
+      {
+        path: "/repo/rtl/binary.sv",
+        text: "module bad;\0endmodule\n",
+      },
+      {
+        path: "/repo/.codex/private-worker/notes.md",
+        text: "private worker instruction\n",
+      },
+    ],
+    recentValidation: {
+      status: "failed",
+      summary: "1 diagnostic",
+      exitCode: 1,
+    },
+    pccxLabOutputs: [
+      {
+        flow: "problems from-check",
+        exitCode: 1,
+        summaryLines: ["token=hidden", "missing endmodule"],
+      },
+    ],
+    userIntent: "explain active diagnostics",
+  };
+}
+
+function testStableBoundedShape() {
+  const bundle = buildContextBundle(fixtureInput(), {
+    workspaceRoot: "/repo",
+    limits: {
+      maxFiles: 2,
+      maxDiagnostics: 1,
+      maxSnippetLines: 2,
+      maxLogSummaryLines: 1,
+    },
+  });
+
+  assert.equal(bundle.version, CONTEXT_BUNDLE_VERSION);
+  assert.equal(bundle.source, "pccx-systemverilog-ide");
+  assert.deepEqual(bundle.selectedFile, { path: "rtl/top.sv" });
+  assert.equal(bundle.diagnostics.length, 1);
+  assert.equal(bundle.diagnostics[0].path, "rtl/a.sv");
+  assert.equal(bundle.snippets.length, 2);
+  assert.deepEqual(bundle.snippets.map((snippet) => snippet.path), ["rtl/a.sv", "rtl/z.sv"]);
+  assert.ok(bundle.snippets.every((snippet) => snippet.lines.length <= 2));
+  assert.equal(bundle.validation.recent.status, "failed");
+  assert.equal(bundle.pccxLab.outputs.length, 1);
+  assert.deepEqual(bundle.pccxLab.outputs[0].lines, ["[redacted]"]);
+  assert.deepEqual(summarizeContextBundle(bundle), {
+    version: CONTEXT_BUNDLE_VERSION,
+    selectedFile: { path: "rtl/top.sv" },
+    diagnosticCount: 1,
+    snippetCount: 2,
+    declarationCount: 2,
+    pccxLabOutputCount: 1,
+  });
+}
+
+function testDeterministicOrdering() {
+  const input = fixtureInput();
+  const reversed = {
+    ...input,
+    activeDiagnostics: [...input.activeDiagnostics].reverse(),
+    files: [...input.files].reverse(),
+    symbolContext: {
+      declarations: [...input.symbolContext.declarations].reverse(),
+    },
+  };
+
+  assert.deepEqual(
+    buildContextBundle(input, { workspaceRoot: "/repo" }),
+    buildContextBundle(reversed, { workspaceRoot: "/repo" }),
+  );
+}
+
+function testNoHugeFileOrRestrictedPathInclusion() {
+  const hugeText = Array.from({ length: 100 }, (_, index) => `line ${index}`).join("\n");
+  const bundle = buildContextBundle(
+    {
+      workspaceRoot: "/repo",
+      files: [
+        { path: "/repo/rtl/huge.sv", text: hugeText },
+        { path: "/repo/node_modules/pkg/ignored.sv", text: hugeText },
+        { path: "/repo/.vscode-test/ignored.sv", text: hugeText },
+      ],
+      activeDiagnostics: [
+        { file: "/repo/node_modules/pkg/ignored.sv", message: "ignored" },
+        { file: "/repo/.vscode-test/ignored.sv", message: "ignored" },
+      ],
+    },
+    {
+      workspaceRoot: "/repo",
+      limits: { maxSnippetLines: 5 },
+    },
+  );
+
+  assert.deepEqual(bundle.snippets.map((snippet) => snippet.path), ["rtl/huge.sv"]);
+  assert.equal(bundle.snippets[0].lines.length, 5);
+  assert.equal(bundle.snippets[0].truncated, true);
+  assert.deepEqual(bundle.diagnostics, []);
+}
+
+function testNoSecretValuesOrSecretLikeKeys() {
+  const bundle = buildContextBundle(fixtureInput(), { workspaceRoot: "/repo" });
+  const serialized = JSON.stringify(bundle);
+
+  assertNoSecretLikeKeys(bundle);
+  assert.doesNotMatch(serialized, /abc123/);
+  assert.doesNotMatch(serialized, /API_KEY=/);
+  assert.doesNotMatch(serialized, /token=hidden/);
+}
+
+testStableBoundedShape();
+testDeterministicOrdering();
+testNoHugeFileOrRestrictedPathInclusion();
+testNoSecretValuesOrSecretLikeKeys();
+
+console.log("vscode context bundle tests ok");

--- a/editors/vscode-prototype/test/extension-config.test.mjs
+++ b/editors/vscode-prototype/test/extension-config.test.mjs
@@ -4,6 +4,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
+  AI_ASSISTANT_BACKENDS,
   DECLARATION_KINDS,
   MODES,
   buildFacadeArgsForCommand,
@@ -15,13 +16,22 @@ const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 const PACKAGE_JSON = resolve(ROOT, "editors/vscode-prototype/package.json");
 
 const REQUIRED_SETTINGS = new Map([
-  ["pccxSystemVerilog.mode", { default: "example" }],
-  ["pccxSystemVerilog.pythonPath", { default: "python3" }],
-  ["pccxSystemVerilog.defaultSource", { default: "fixtures/missing_endmodule.sv" }],
-  ["pccxSystemVerilog.defaultLog", { default: "fixtures/xsim/mixed.log" }],
-  ["pccxSystemVerilog.defaultModule", { default: "simple_mod" }],
-  ["pccxSystemVerilog.defaultDeclarationKind", { default: "module" }],
+  ["pccxSystemVerilog.mode", { type: "string", default: "checkedExample" }],
+  ["pccxSystemVerilog.liveWorkspace.enabled", { type: "boolean", default: false }],
+  ["pccxSystemVerilog.pccxLab.command", { type: "string", default: "pccx_ide_cli" }],
+  ["pccxSystemVerilog.aiAssistant.enabled", { type: "boolean", default: false }],
+  ["pccxSystemVerilog.aiAssistant.backend", { type: "string", default: "none" }],
+  ["pccxSystemVerilog.pythonPath", { type: "string", default: "python3" }],
+  ["pccxSystemVerilog.defaultSource", { type: "string", default: "fixtures/missing_endmodule.sv" }],
+  ["pccxSystemVerilog.defaultLog", { type: "string", default: "fixtures/xsim/mixed.log" }],
+  ["pccxSystemVerilog.defaultModule", { type: "string", default: "simple_mod" }],
+  ["pccxSystemVerilog.defaultDeclarationKind", { type: "string", default: "module" }],
 ]);
+
+const LIVE_WORKSPACE_CONFIG = {
+  mode: "liveWorkspace",
+  liveWorkspace: { enabled: true },
+};
 
 async function readPackageJson() {
   return JSON.parse(await readFile(PACKAGE_JSON, "utf8"));
@@ -41,13 +51,17 @@ async function testPackageConfigurationSchema() {
     assert.ok(setting.startsWith("pccxSystemVerilog."), `${setting} is not prototype-scoped`);
     const property = configuration.properties?.[setting];
     assert.ok(property, `${setting} missing`);
-    assert.equal(property.type, "string");
+    assert.equal(property.type, expected.type);
     assert.equal(property.default, expected.default);
     assert.match(property.description, /experimental local prototype/i);
     assert.match(property.description, /not a stable API/i);
   }
 
   assert.deepEqual(configuration.properties["pccxSystemVerilog.mode"].enum, MODES);
+  assert.deepEqual(
+    configuration.properties["pccxSystemVerilog.aiAssistant.backend"].enum,
+    AI_ASSISTANT_BACKENDS,
+  );
   assert.deepEqual(
     configuration.properties["pccxSystemVerilog.defaultDeclarationKind"].enum,
     DECLARATION_KINDS,
@@ -56,7 +70,17 @@ async function testPackageConfigurationSchema() {
 
 function testDefaultConfig() {
   assert.deepEqual(defaultConfig(), {
-    mode: "example",
+    mode: "checkedExample",
+    liveWorkspace: {
+      enabled: false,
+    },
+    pccxLab: {
+      command: "pccx_ide_cli",
+    },
+    aiAssistant: {
+      enabled: false,
+      backend: "none",
+    },
     pythonPath: "python3",
     defaultSource: "fixtures/missing_endmodule.sv",
     defaultLog: "fixtures/xsim/mixed.log",
@@ -68,7 +92,19 @@ function testDefaultConfig() {
 function testNormalizeConfigRejectsInvalidSettings() {
   assert.throws(
     () => normalizeConfig({ mode: "automatic" }),
-    /pccxSystemVerilog\.mode must be one of: example, live/,
+    /pccxSystemVerilog\.mode must be one of: checkedExample, liveWorkspace/,
+  );
+  assert.throws(
+    () => normalizeConfig({ liveWorkspace: { enabled: "yes" } }),
+    /pccxSystemVerilog\.liveWorkspace\.enabled must be a boolean/,
+  );
+  assert.throws(
+    () => normalizeConfig({ pccxLab: { command: "pccx_ide_cli --format json" } }),
+    /pccxSystemVerilog\.pccxLab\.command must be a command name or path without arguments/,
+  );
+  assert.throws(
+    () => normalizeConfig({ aiAssistant: { backend: "openai" } }),
+    /pccxSystemVerilog\.aiAssistant\.backend must be one of: none, pccx-llm-launcher, mcp/,
   );
   assert.throws(
     () => normalizeConfig({ defaultDeclarationKind: "class" }),
@@ -98,11 +134,25 @@ function testFacadeArgsForKnownCommands() {
     ["navigation", "--mode", "example", "--source", "declarations"],
   );
   assert.deepEqual(
-    buildFacadeArgsForCommand("pccxSystemVerilog.runDiagnosticsLive"),
+    buildFacadeArgsForCommand(
+      "pccxSystemVerilog.publishLiveWorkspaceDiagnostics",
+      LIVE_WORKSPACE_CONFIG,
+    ),
     ["diagnostics", "--mode", "live", "--from-check", "fixtures/missing_endmodule.sv"],
   );
   assert.deepEqual(
-    buildFacadeArgsForCommand("pccxSystemVerilog.runNavigationLive"),
+    buildFacadeArgsForCommand(
+      "pccxSystemVerilog.showLiveWorkspaceNavigation",
+      LIVE_WORKSPACE_CONFIG,
+    ),
+    ["navigation", "--mode", "live", "--locate", "fixtures/modules", "simple_mod", "--kind", "module"],
+  );
+  assert.deepEqual(
+    buildFacadeArgsForCommand("pccxSystemVerilog.runDiagnosticsLive", LIVE_WORKSPACE_CONFIG),
+    ["diagnostics", "--mode", "live", "--from-check", "fixtures/missing_endmodule.sv"],
+  );
+  assert.deepEqual(
+    buildFacadeArgsForCommand("pccxSystemVerilog.runNavigationLive", LIVE_WORKSPACE_CONFIG),
     ["navigation", "--mode", "live", "--locate", "fixtures/modules", "simple_mod", "--kind", "module"],
   );
 }
@@ -110,7 +160,8 @@ function testFacadeArgsForKnownCommands() {
 function testFacadeArgsUseNormalizedLiveConfig() {
   assert.deepEqual(
     buildFacadeArgsForCommand("pccxSystemVerilog.runDiagnosticsLive", {
-      mode: "live",
+      mode: "liveWorkspace",
+      "liveWorkspace.enabled": true,
       defaultSource: "rtl/top.sv",
       defaultLog: "logs/xsim.log",
       pythonPath: "python-custom",
@@ -120,11 +171,35 @@ function testFacadeArgsUseNormalizedLiveConfig() {
 
   assert.deepEqual(
     buildFacadeArgsForCommand("pccxSystemVerilog.runNavigationLive", {
+      mode: "liveWorkspace",
+      liveWorkspace: { enabled: true },
       defaultModule: "pkg_defs",
       defaultDeclarationKind: "any",
     }),
     ["navigation", "--mode", "live", "--locate", "fixtures/modules", "pkg_defs", "--kind", "any"],
   );
+}
+
+function testLiveWorkspaceRequiresExplicitOptIn() {
+  for (const commandId of [
+    "pccxSystemVerilog.publishLiveWorkspaceDiagnostics",
+    "pccxSystemVerilog.showLiveWorkspaceNavigation",
+    "pccxSystemVerilog.runDiagnosticsLive",
+    "pccxSystemVerilog.runNavigationLive",
+  ]) {
+    assert.throws(
+      () => buildFacadeArgsForCommand(commandId),
+      /live workspace commands require pccxSystemVerilog\.mode=liveWorkspace/,
+    );
+    assert.throws(
+      () => buildFacadeArgsForCommand(commandId, { liveWorkspace: { enabled: true } }),
+      /live workspace commands require pccxSystemVerilog\.mode=liveWorkspace/,
+    );
+    assert.throws(
+      () => buildFacadeArgsForCommand(commandId, { mode: "liveWorkspace" }),
+      /live workspace commands require pccxSystemVerilog\.mode=liveWorkspace/,
+    );
+  }
 }
 
 function testUnknownCommandAndShellShape() {
@@ -135,12 +210,17 @@ function testUnknownCommandAndShellShape() {
 
   for (const commandId of [
     "pccxSystemVerilog.showDiagnosticsExample",
+    "pccxSystemVerilog.publishCheckedExampleDiagnostics",
     "pccxSystemVerilog.showCheckedExampleNavigation",
     "pccxSystemVerilog.showNavigationExample",
+    "pccxSystemVerilog.publishLiveWorkspaceDiagnostics",
+    "pccxSystemVerilog.showLiveWorkspaceNavigation",
     "pccxSystemVerilog.runDiagnosticsLive",
     "pccxSystemVerilog.runNavigationLive",
   ]) {
-    const args = buildFacadeArgsForCommand(commandId);
+    const args = commandId.includes("Live")
+      ? buildFacadeArgsForCommand(commandId, LIVE_WORKSPACE_CONFIG)
+      : buildFacadeArgsForCommand(commandId);
     assert.ok(Array.isArray(args));
     assert.ok(args.every((arg) => typeof arg === "string"));
     assert.doesNotMatch(args.join("\n"), /(?:&&|\|\||;|`|\$\()/);
@@ -152,6 +232,7 @@ testDefaultConfig();
 testNormalizeConfigRejectsInvalidSettings();
 testFacadeArgsForKnownCommands();
 testFacadeArgsUseNormalizedLiveConfig();
+testLiveWorkspaceRequiresExplicitOptIn();
 testUnknownCommandAndShellShape();
 
 console.log("vscode extension config tests ok");

--- a/editors/vscode-prototype/test/extension-entrypoint.test.mjs
+++ b/editors/vscode-prototype/test/extension-entrypoint.test.mjs
@@ -33,6 +33,14 @@ const EXPECTED_ARGS = new Map([
     ["navigation", "--mode", "example", "--source", "declarations"],
   ],
   [
+    "pccxSystemVerilog.publishLiveWorkspaceDiagnostics",
+    ["diagnostics", "--mode", "live", "--from-check", "fixtures/missing_endmodule.sv"],
+  ],
+  [
+    "pccxSystemVerilog.showLiveWorkspaceNavigation",
+    ["navigation", "--mode", "live", "--locate", "fixtures/modules", "simple_mod", "--kind", "module"],
+  ],
+  [
     "pccxSystemVerilog.showNavigationExample",
     ["navigation", "--mode", "example", "--source", "declarations"],
   ],
@@ -47,11 +55,22 @@ const EXPECTED_ARGS = new Map([
 ]);
 
 function configFor(commandId) {
-  if (commandId === "pccxSystemVerilog.runDiagnosticsLive") {
-    return { defaultSource: "fixtures/missing_endmodule.sv" };
+  if (commandId === "pccxSystemVerilog.publishLiveWorkspaceDiagnostics" ||
+      commandId === "pccxSystemVerilog.runDiagnosticsLive") {
+    return {
+      mode: "liveWorkspace",
+      liveWorkspace: { enabled: true },
+      defaultSource: "fixtures/missing_endmodule.sv",
+    };
   }
-  if (commandId === "pccxSystemVerilog.runNavigationLive") {
-    return { defaultModule: "simple_mod", defaultDeclarationKind: "module" };
+  if (commandId === "pccxSystemVerilog.showLiveWorkspaceNavigation" ||
+      commandId === "pccxSystemVerilog.runNavigationLive") {
+    return {
+      mode: "liveWorkspace",
+      liveWorkspace: { enabled: true },
+      defaultModule: "simple_mod",
+      defaultDeclarationKind: "module",
+    };
   }
   return {};
 }
@@ -76,7 +95,12 @@ function testCheckedExampleDiagnosticsCommandStaysExampleMode() {
   assert.deepEqual(
     buildFacadeArgsForCommand(
       "pccxSystemVerilog.publishCheckedExampleDiagnostics",
-      { mode: "live", defaultSource: "configured.sv", pythonPath: "python-custom" },
+      {
+        mode: "liveWorkspace",
+        liveWorkspace: { enabled: true },
+        defaultSource: "configured.sv",
+        pythonPath: "python-custom",
+      },
     ),
     ["diagnostics", "--mode", "example", "--source", "check-missing-endmodule"],
   );
@@ -86,7 +110,12 @@ function testCheckedExampleNavigationCommandStaysExampleMode() {
   assert.deepEqual(
     buildFacadeArgsForCommand(
       "pccxSystemVerilog.showCheckedExampleNavigation",
-      { mode: "live", defaultModule: "pkg_defs", pythonPath: "python-custom" },
+      {
+        mode: "liveWorkspace",
+        liveWorkspace: { enabled: true },
+        defaultModule: "pkg_defs",
+        pythonPath: "python-custom",
+      },
     ),
     ["navigation", "--mode", "example", "--source", "declarations"],
   );
@@ -95,7 +124,12 @@ function testCheckedExampleNavigationCommandStaysExampleMode() {
 function testFacadeInvocationIsArgumentArray() {
   const invocation = buildFacadeInvocationForCommand(
     "pccxSystemVerilog.runDiagnosticsLive",
-    { defaultSource: "fixtures/missing_endmodule.sv", pythonPath: "python3" },
+    {
+      mode: "liveWorkspace",
+      liveWorkspace: { enabled: true },
+      defaultSource: "fixtures/missing_endmodule.sv",
+      pythonPath: "python3",
+    },
     { nodeExecutable: "node", facadePath: "editors/vscode-prototype/bin/pccx-vscode-prototype.mjs" },
   );
 
@@ -173,7 +207,11 @@ function testNavigationLocationMapping() {
 
 function testResolveCommandRequestUsesVsCodeSettings() {
   const settings = new Map([
-    ["mode", "live"],
+    ["mode", "liveWorkspace"],
+    ["liveWorkspace.enabled", true],
+    ["pccxLab.command", "pccx_ide_cli"],
+    ["aiAssistant.enabled", false],
+    ["aiAssistant.backend", "none"],
     ["pythonPath", "python-custom"],
     ["defaultSource", "configured.sv"],
     ["defaultLog", "configured.log"],
@@ -194,7 +232,17 @@ function testResolveCommandRequestUsesVsCodeSettings() {
   };
 
   assert.deepEqual(readExtensionConfig(vscodeApi), {
-    mode: "live",
+    mode: "liveWorkspace",
+    liveWorkspace: {
+      enabled: true,
+    },
+    pccxLab: {
+      command: "pccx_ide_cli",
+    },
+    aiAssistant: {
+      enabled: false,
+      backend: "none",
+    },
     pythonPath: "python-custom",
     defaultSource: "configured.sv",
     defaultLog: "configured.log",
@@ -204,7 +252,17 @@ function testResolveCommandRequestUsesVsCodeSettings() {
   assert.deepEqual(
     resolveCommandRequest("pccxSystemVerilog.runDiagnosticsLive", undefined, vscodeApi),
     {
-      mode: "live",
+      mode: "liveWorkspace",
+      liveWorkspace: {
+        enabled: true,
+      },
+      pccxLab: {
+        command: "pccx_ide_cli",
+      },
+      aiAssistant: {
+        enabled: false,
+        backend: "none",
+      },
       pythonPath: "python-custom",
       defaultSource: "configured.sv",
       defaultLog: "configured.log",
@@ -215,7 +273,17 @@ function testResolveCommandRequestUsesVsCodeSettings() {
   assert.deepEqual(
     resolveCommandRequest("pccxSystemVerilog.runNavigationLive", undefined, vscodeApi),
     {
-      mode: "live",
+      mode: "liveWorkspace",
+      liveWorkspace: {
+        enabled: true,
+      },
+      pccxLab: {
+        command: "pccx_ide_cli",
+      },
+      aiAssistant: {
+        enabled: false,
+        backend: "none",
+      },
       pythonPath: "python-custom",
       defaultSource: "configured.sv",
       defaultLog: "configured.log",
@@ -226,7 +294,17 @@ function testResolveCommandRequestUsesVsCodeSettings() {
   assert.deepEqual(
     resolveCommandRequest("pccxSystemVerilog.runDiagnosticsLive", { fsPath: "explicit.sv" }, vscodeApi),
     {
-      mode: "live",
+      mode: "liveWorkspace",
+      liveWorkspace: {
+        enabled: true,
+      },
+      pccxLab: {
+        command: "pccx_ide_cli",
+      },
+      aiAssistant: {
+        enabled: false,
+        backend: "none",
+      },
       pythonPath: "python-custom",
       defaultSource: "explicit.sv",
       defaultLog: "configured.log",

--- a/editors/vscode-prototype/test/extension-host-readiness.test.mjs
+++ b/editors/vscode-prototype/test/extension-host-readiness.test.mjs
@@ -98,6 +98,9 @@ async function testReadinessDocsAndCiPolicy() {
   assert.match(`${readme}\n${readiness}`, /DefinitionProvider/);
   assert.match(`${readme}\n${readiness}`, /VS Code-native\s+provider smoke/i);
   assert.match(`${readme}\n${readiness}`, /command-first navigation/i);
+  assert.match(`${readme}\n${readiness}`, /live workspace .*opt-in/i);
+  assert.match(`${readme}\n${readiness}`, /AI assistant .*boundary/i);
+  assert.match(`${readme}\n${readiness}`, /pccx-llm-launcher .*future local LLM\/chat backend/i);
   assert.match(`${readme}\n${readiness}`, /no LSP provider/i);
   assert.match(`${readme}\n${readiness}`, /host theme first/i);
   assert.match(`${readme}\n${readiness}`, /not a completed\s+custom theme system/i);
@@ -132,6 +135,8 @@ async function testRuntimeRunnerIsPinnedAndBounded() {
   assert.match(suite, /getCommands/);
   assert.match(suite, /publishCheckedExampleDiagnostics/);
   assert.match(suite, /showCheckedExampleNavigation/);
+  assert.match(suite, /publishLiveWorkspaceDiagnostics/);
+  assert.match(suite, /live workspace commands require/);
   assert.match(suite, /getDiagnostics/);
   assert.match(suite, /DiagnosticSeverity\.Error/);
   assert.match(suite, /navigationResult\.locations/);

--- a/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
+++ b/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
@@ -32,6 +32,8 @@ async function run() {
   assert.deepEqual(expectedCommandIds, [
     "pccxSystemVerilog.publishCheckedExampleDiagnostics",
     "pccxSystemVerilog.showCheckedExampleNavigation",
+    "pccxSystemVerilog.publishLiveWorkspaceDiagnostics",
+    "pccxSystemVerilog.showLiveWorkspaceNavigation",
     "pccxSystemVerilog.showDiagnosticsExample",
     "pccxSystemVerilog.showNavigationExample",
     "pccxSystemVerilog.runDiagnosticsLive",
@@ -64,6 +66,12 @@ async function run() {
   for (const commandId of expectedCommandIds) {
     assert.ok(commands.includes(commandId), `${commandId} is not registered`);
   }
+
+  const disabledLiveWorkspaceResult = await vscode.commands.executeCommand(
+    "pccxSystemVerilog.publishLiveWorkspaceDiagnostics",
+  );
+  assert.equal(disabledLiveWorkspaceResult.ok, false);
+  assert.match(disabledLiveWorkspaceResult.error, /live workspace commands require/);
 
   const result = await vscode.commands.executeCommand(
     "pccxSystemVerilog.publishCheckedExampleDiagnostics",

--- a/editors/vscode-prototype/test/extension-manifest.test.mjs
+++ b/editors/vscode-prototype/test/extension-manifest.test.mjs
@@ -8,6 +8,8 @@ const EXTENSION_ROOT = resolve(ROOT, "editors/vscode-prototype");
 const COMMAND_IDS = [
   "pccxSystemVerilog.publishCheckedExampleDiagnostics",
   "pccxSystemVerilog.showCheckedExampleNavigation",
+  "pccxSystemVerilog.publishLiveWorkspaceDiagnostics",
+  "pccxSystemVerilog.showLiveWorkspaceNavigation",
   "pccxSystemVerilog.showDiagnosticsExample",
   "pccxSystemVerilog.showNavigationExample",
   "pccxSystemVerilog.runDiagnosticsLive",
@@ -102,6 +104,12 @@ async function testDocsKeepExperimentalScope() {
   assert.match(combined, /static\/mock tests/i);
   assert.match(combined, /limited opt-in Extension Host runtime smoke/i);
   assert.match(combined, /not a product claim/i);
+  assert.match(combined, /checked-example remains the default/i);
+  assert.match(combined, /live workspace .*opt-in/i);
+  assert.match(combined, /AI-assisted SystemVerilog development workflow/i);
+  assert.match(combined, /boundary\/stub/i);
+  assert.match(combined, /no AI provider calls/i);
+  assert.match(combined, /no MCP server implementation/i);
 }
 
 await testPackageManifestShape();

--- a/editors/vscode-prototype/test/static-boundary.test.mjs
+++ b/editors/vscode-prototype/test/static-boundary.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const EXTENSION_ROOT = resolve(ROOT, "editors/vscode-prototype");
+
+async function readText(path) {
+  return readFile(path, "utf8");
+}
+
+async function readPackageJson() {
+  return JSON.parse(await readText(resolve(EXTENSION_ROOT, "package.json")));
+}
+
+async function testNoDirectAiProviderOrNetworkCalls() {
+  const sourceFiles = [
+    "src/ai-assistant-boundary.mjs",
+    "src/context-bundle.mjs",
+    "src/command-handlers.mjs",
+    "src/extension.mjs",
+    "src/definition-provider.mjs",
+  ];
+  const combined = (await Promise.all(
+    sourceFiles.map((file) => readText(resolve(EXTENSION_ROOT, file))),
+  )).join("\n");
+
+  assert.doesNotMatch(combined, /\bfetch\s*\(/);
+  assert.doesNotMatch(combined, /XMLHttpRequest/);
+  assert.doesNotMatch(combined, /node:https|node:http/);
+  assert.doesNotMatch(combined, /\b(?:openai|anthropic|gemini)\b/i);
+  assert.doesNotMatch(combined, /chat\.completions|responses\.create/i);
+}
+
+async function testNoLauncherOrMcpRuntimeImplementation() {
+  const manifest = await readPackageJson();
+  const source = await readText(resolve(EXTENSION_ROOT, "src/ai-assistant-boundary.mjs"));
+  const packageStrings = JSON.stringify({
+    dependencies: manifest.dependencies,
+    devDependencies: manifest.devDependencies,
+  });
+
+  assert.doesNotMatch(source, /execFile|spawn|pccx-llm-launcher.*(?:request|connect|run)/i);
+  assert.doesNotMatch(packageStrings, /modelcontextprotocol|mcp-server|llm-launcher/i);
+}
+
+async function testNoDirectCliCallsFromUiOrProviderLayers() {
+  const uiLayerFiles = [
+    "src/extension.mjs",
+    "src/extension.cjs",
+    "src/command-handlers.mjs",
+    "src/definition-provider.mjs",
+    "src/presenter.mjs",
+  ];
+  const combined = (await Promise.all(
+    uiLayerFiles.map((file) => readText(resolve(EXTENSION_ROOT, file))),
+  )).join("\n");
+
+  assert.doesNotMatch(combined, /pccx_ide_cli/);
+  assert.doesNotMatch(combined, /LanguageClient|vscode-languageclient/);
+}
+
+async function testNoPackagingPublisherOrLspDependencies() {
+  const manifest = await readPackageJson();
+  const manifestText = JSON.stringify(manifest);
+
+  assert.equal(Object.hasOwn(manifest, "publisher"), false);
+  assert.equal(Object.hasOwn(manifest, "galleryBanner"), false);
+  assert.equal(manifest.dependencies, undefined);
+  assert.equal(manifest.scripts, undefined);
+  assert.doesNotMatch(manifestText, /\bvsce\b/i);
+  assert.doesNotMatch(manifestText, /vscode-languageclient|LanguageClient/);
+}
+
+await testNoDirectAiProviderOrNetworkCalls();
+await testNoLauncherOrMcpRuntimeImplementation();
+await testNoDirectCliCallsFromUiOrProviderLayers();
+await testNoPackagingPublisherOrLspDependencies();
+
+console.log("vscode static boundary tests ok");

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -14,6 +14,9 @@ node editors/vscode-prototype/test/cli-runner.test.mjs
 node editors/vscode-prototype/test/facade.test.mjs
 node editors/vscode-prototype/test/extension-manifest.test.mjs
 node editors/vscode-prototype/test/extension-config.test.mjs
+node editors/vscode-prototype/test/context-bundle.test.mjs
+node editors/vscode-prototype/test/ai-assistant-boundary.test.mjs
+node editors/vscode-prototype/test/static-boundary.test.mjs
 node editors/vscode-prototype/test/extension-entrypoint.test.mjs
 node editors/vscode-prototype/test/command-handlers.test.mjs
 node editors/vscode-prototype/test/presenter.test.mjs


### PR DESCRIPTION
## Summary
- Adds an explicit VS Code live workspace configuration boundary while keeping checked-example mode as the default.
- Adds opt-in live workspace command IDs that fail clearly unless both live workspace settings are explicitly enabled.
- Adds AI assistant boundary/stub modules and a token-saving context bundle contract for future AI-assisted SystemVerilog development workflow experiments.
- Documents pccx-lab as the CLI-first verification/tooling backend and pccx-llm-launcher as a future local LLM/chat backend candidate.

## Scope Notes
- Experimental only; this does not claim production readiness.
- checked-example remains default.
- live workspace is opt-in.
- AI assistant is boundary/stub only.
- No AI provider calls.
- No pccx-llm-launcher runtime calls yet.
- No MCP server implementation yet.
- No LSP.
- No marketplace packaging, publisher, or vsce.
- No stable API/ABI claim.
- No release or tag.

## Validation
- npm ci --prefix editors/vscode-prototype
- bash scripts/vscode-adapter-smoke.sh
- PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh
- bash scripts/vscode-extension-host-smoke.sh exits 2 by default as the intentional guard
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- python3 -m pytest -q
- git diff --check