### PR TITLE
feat: add VS Code live fixture and AI context command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ signal to add a back door from the GUI.
   CLI/core contract instead of being duplicated here.
 - `pccx-llm-launcher` is a future local LLM/chat backend candidate for
   local coding-assistant mode. This repository currently contains only
-  boundary/stub work for AI-assisted SystemVerilog development workflow
-  experiments: no AI provider calls, no pccx-llm-launcher runtime calls
-  yet, and no MCP server implementation.
+  boundary work for AI-assisted SystemVerilog development workflow
+  experiments: AI assistant status/context commands, no AI provider calls,
+  no pccx-llm-launcher runtime calls yet, and no MCP server implementation.
 
 ## Initial track (near-term)
 
@@ -167,16 +167,19 @@ python -m pytest -q
 bash scripts/editor-bridge-smoke.sh
 ```
 
-The envelope shape is fixed in [`schema/diagnostics-v0.json`](./schema/diagnostics-v0.json).
+The current pre-stable envelope shape is described in
+[`schema/diagnostics-v0.json`](./schema/diagnostics-v0.json).
 Handoff notes for the eventual `pccx-lab` and xsim integration paths
 live in [`docs/HANDOFF.md`](./docs/HANDOFF.md).
 
 The experimental VS Code prototype under
 [`editors/vscode-prototype`](./editors/vscode-prototype) keeps
 checked-example mode as the safe default. Live workspace commands are
-opt-in and require an explicit configuration gate; the current AI
-assistant work is only a proposal boundary and token-saving context
-bundle stub.
+opt-in and require an explicit configuration gate; the current local
+coding-assistant mode work is limited to AI assistant status and
+token-saving context bundle commands with no provider calls.  The
+guarded Extension Host runtime smoke uses only the controlled fixture
+under `editors/vscode-prototype/test/fixtures/live-workspace`.
 
 ## Later track (deferred)
 

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -89,10 +89,10 @@ Checked-example remains the default.  Live workspace mode is explicit
 opt-in and requires both `pccxSystemVerilog.mode=liveWorkspace` and
 `pccxSystemVerilog.liveWorkspace.enabled=true`; disabled live workspace
 commands fail clearly instead of falling back to examples.  The current
-AI-assisted SystemVerilog development workflow work is boundary/stub
-only: a context bundle JSON contract and proposal model, with no AI
-provider calls, no pccx-llm-launcher runtime calls yet, and no MCP server
-implementation.
+AI-assisted SystemVerilog development workflow work is boundary-only:
+AI assistant status and context bundle commands expose local status,
+bounded context, and proposal actions, with no AI provider calls, no
+pccx-llm-launcher runtime calls yet, and no MCP server implementation.
 
 The same directory now includes an experimental local VS Code extension
 scaffold.  Its command handlers are thin wrappers around the local facade:
@@ -106,11 +106,13 @@ The presenter scaffold maps those UI action models to mockable
 DiagnosticCollection-like and QuickPick-like APIs without requiring real
 VS Code GUI tests.  A limited opt-in Extension Host runtime smoke exists,
 but it is disabled by default, remains local-only, and is not a product
-claim.
-The scaffold is not published, is not marketplace-ready, has no LSP, and
-is not a stable ABI/API.  Current coverage is mostly static/mock tests
-and smoke tests; CI does not run the real Extension Host runtime smoke
-yet.
+claim.  When explicitly enabled, it opens the controlled
+`editors/vscode-prototype/test/fixtures/live-workspace` fixture and runs
+live diagnostics only against that tiny fixture path.
+The scaffold is not published, has no marketplace packaging, has no LSP,
+and is not a stable ABI/API.  Current coverage is mostly static/mock
+tests and smoke tests; CI does not run the real Extension Host runtime
+smoke yet.
 The prototype documents the 1-based CLI position to 0-based editor
 position conversion expected by editor adapters.
 
@@ -136,11 +138,11 @@ VS Code command
 
 Future local coding-assistant mode should use the same controlled data
 path.  Context bundle records should carry selected file/range,
-diagnostics, declaration references, validation summaries, and bounded
-snippets by path/range instead of whole workspaces.  Any command proposal
-or validation proposal must route through the facade or pccx-lab
-CLI/core boundary and remain a proposal until an editor/user-controlled
-executor accepts it.
+diagnostics, declaration references, recent command status, current mode,
+validation summaries, and bounded snippets by path/range instead of whole
+workspaces.  Any command proposal or validation proposal must route
+through the facade or pccx-lab CLI/core boundary and remain a proposal
+until an editor/user-controlled executor accepts it.
 
 `problems` converts local diagnostics and log records into editor-friendly
 problem records.  `index` provides scanner-based module/package/interface
@@ -151,7 +153,8 @@ declaration records.  `declarations` exports those records directly, and
 
 - Scanner-based scaffolds, not full SystemVerilog parsing.
 - No LSP server in this repository today.
-- No published or marketplace-ready editor extension is implemented here.
+- No published editor extension or marketplace packaging is implemented
+  here.
 - No VS Code GUI integration test in this repository today.
 - No stable schema yet.
 - No real xsim or Vivado execution.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -335,10 +335,10 @@ python -m pccx_ide_cli problems from-xsim-log fixtures/xsim/mixed.log --format t
   should relax at v1 to allow forward-compatible extension fields.
 - How a future local coding-assistant mode should pass token-saving
   context bundles to pccx-llm-launcher or an MCP-style controlled tool
-  boundary.  The current VS Code prototype only has boundary/stub types
-  and tests: no AI provider calls, no local chat backend runtime calls,
-  no MCP server implementation, and no direct execution of command or
-  validation proposals.
+  boundary.  The current VS Code prototype only has boundary types,
+  status/context commands, and tests: no AI provider calls, no local chat
+  backend runtime calls, no MCP server implementation, and no direct
+  execution of command or validation proposals.
 
 These are intentionally unresolved while both sides mature.
 

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -4,8 +4,8 @@ This directory is an experimental local VS Code prototype for translating
 pre-stable editor bridge JSON into VS Code-style data records and for
 hosting a minimal local VS Code extension package scaffold.
 
-The extension scaffold is not published, is not marketplace-ready, has no
-LSP, and does not define a stable ABI/API.  It can consume the checked
+The extension scaffold is not published, has no marketplace packaging,
+has no LSP, and does not define a stable ABI/API.  It can consume the checked
 examples under `docs/examples/editor-bridge` and can also run limited
 live JSON flows from this source tree through the local command facade.
 The default tests are mostly static/mock tests, not VS Code GUI
@@ -26,9 +26,10 @@ handoff should flow through the existing facade and CLI/core boundary
 rather than being duplicated inside this extension scaffold.
 
 `pccx-llm-launcher` is a future local LLM/chat/model backend candidate.
-This prototype only adds an AI assistant boundary/stub and context bundle
-contract.  There are no AI provider calls, no pccx-llm-launcher runtime
-calls, and no MCP server implementation in this scaffold.
+This prototype only adds AI assistant status and context bundle commands
+behind a controlled tool boundary.  There are no AI provider calls, no
+pccx-llm-launcher runtime calls, and no MCP server implementation in this
+scaffold.
 
 ## Data Mapping
 
@@ -77,9 +78,11 @@ The live workspace command shape is limited to known facade argument
 arrays.  `pccxSystemVerilog.publishLiveWorkspaceDiagnostics` maps to the
 known diagnostics facade flow for the configured default source, and
 `pccxSystemVerilog.showLiveWorkspaceNavigation` maps to the known locate
-flow for the configured default module/kind.  The older
+flow for the configured navigation root, module, and kind.  The older
 `runDiagnosticsLive` and `runNavigationLive` command IDs remain
-experimental opt-in aliases for now.
+experimental opt-in aliases for now.  A controlled tiny fixture workspace
+lives at `test/fixtures/live-workspace`; the opt-in runtime smoke uses
+that fixture only and does not scan a user workspace.
 
 ## Command Facade
 
@@ -126,6 +129,8 @@ The contributed commands are:
 - `pccxSystemVerilog.showNavigationExample`
 - `pccxSystemVerilog.runDiagnosticsLive`
 - `pccxSystemVerilog.runNavigationLive`
+- `pccxSystemVerilog.showAIAssistantStatus`
+- `pccxSystemVerilog.buildAIContextBundle`
 
 The prototype-only settings are:
 
@@ -137,6 +142,7 @@ The prototype-only settings are:
 - `pccxSystemVerilog.pythonPath`, default `python3`
 - `pccxSystemVerilog.defaultSource`, default `fixtures/missing_endmodule.sv`
 - `pccxSystemVerilog.defaultLog`, default `fixtures/xsim/mixed.log`
+- `pccxSystemVerilog.defaultNavigationRoot`, default `fixtures/modules`
 - `pccxSystemVerilog.defaultModule`, default `simple_mod`
 - `pccxSystemVerilog.defaultDeclarationKind`, default `module`
 
@@ -153,7 +159,7 @@ has no LSP provider yet.  The explicit example commands always build
 checked-example facade arguments, and the explicit live commands always
 build known live facade arguments.  Live diagnostics uses
 `--from-check <defaultSource>`.  Live navigation uses
-`--locate fixtures/modules <defaultModule> --kind <defaultDeclarationKind>`.
+`--locate <defaultNavigationRoot> <defaultModule> --kind <defaultDeclarationKind>`.
 Live mode remains separate and explicit; the extension does not silently
 fall back between live and checked-example modes.
 
@@ -198,45 +204,49 @@ checked-example diagnostics command publishes at least one real VS Code
 diagnostic with URI, range, severity, message, and source fields through
 a `DiagnosticCollection`, and that the checked-example navigation
 command returns at least one Location-style record with URI, range,
-symbol, target kind, and source fields.  The same opt-in smoke also
-opens a temporary SystemVerilog-like document and executes
-`vscode.executeDefinitionProvider` to verify that the experimental
-VS Code-native `DefinitionProvider` returns at least one `Location` with
-sane URI and range fields.  A guarded local-only Extension Host runtime
-smoke now exists at
+symbol, target kind, and source fields.  The same opt-in smoke opens the
+controlled fixture workspace and executes `vscode.executeDefinitionProvider`
+to verify that the experimental VS Code-native `DefinitionProvider`
+returns at least one `Location` with sane URI and range fields.  A guarded
+local-only Extension Host runtime smoke exists at
 `scripts/vscode-extension-host-smoke.sh`, but it exits 2 by default and
 only runs when `PCCX_RUN_EXTENSION_HOST_SMOKE=1` is set.  The runtime
 smoke loads the local extension package, verifies activation/command
-registration, confirms the live workspace diagnostics command fails
-clearly while disabled by default, and executes the checked-example
-diagnostics publishing command plus the checked-example navigation
-command and provider smoke.  It does not run an enabled live CLI path,
-package the extension, add an LSP
-provider, or install from the marketplace.  Extension Host gates are
+registration, confirms live workspace commands fail clearly while
+disabled, runs live diagnostics against the controlled fixture only, and
+executes the checked-example diagnostics/navigation command paths plus
+the provider smoke.  It also checks the AI assistant status command and
+context bundle command without provider/runtime calls.  It does not
+package the extension, add an LSP provider, or install through a
+marketplace flow.  Extension Host gates are
 tracked in
 [`docs/EXTENSION_HOST_READINESS.md`](./docs/EXTENSION_HOST_READINESS.md).
 
 ## AI Assistant Boundary and Context Bundle
 
 `src/ai-assistant-boundary.mjs` models a future local coding-assistant
-mode as proposals only.  Allowed proposal kinds include explaining
-diagnostics, proposing a patch, proposing a validation command,
-summarizing xsim/log output, asking for more context, opening a related
-symbol, and proposing a pccx-lab tool call through a controlled tool
-boundary.  Direct file writes, git commits, pushes, release/tag actions,
-ruleset/settings/secrets changes, staging/private repo access, and
-arbitrary shell commands are disallowed by default.
+mode as proposals only.  `pccxSystemVerilog.showAIAssistantStatus`
+returns the local status, configured backend, and proposal boundaries.
+Allowed proposal kinds are `explainDiagnostics`, `proposePatch`,
+`proposeValidationCommand`, `summarizeLog`, `askForMoreContext`, and
+`openRelatedSymbol`.  Direct `writeFile`, `commit`, `push`, `merge`,
+`release`, `tag`, `changeRuleset`, `accessSecrets`, and `accessStaging`
+actions are disallowed.  User approval remains required before any patch,
+validation command, or commit is executed outside this proposal boundary.
 
-`src/context-bundle.mjs` is a token-saving context bundle stub for future
-AI-assisted SystemVerilog development workflow experiments.  It prefers
-the current file, selected range/symbol, active diagnostics, declaration
-references, recent validation summaries, pccx-lab output summaries, and
-small bounded snippets.  It references files by path/range instead of
-including whole workspaces, excludes `node_modules`, `.vscode-test`,
-binary-like content, and private worker instruction paths, and redacts
-secret-like assignments.  This is a JSON contract/stub only: no AI
-provider calls, no pccx-llm-launcher runtime calls yet, no MCP server
-implementation, no direct file modification, and no stable API claim.
+`src/context-bundle.mjs` is a token-saving context bundle contract for
+future AI-assisted SystemVerilog development workflow experiments.
+`pccxSystemVerilog.buildAIContextBundle` returns a bounded JSON object
+for the active editor state without calling a provider.  It prefers the
+current file path, selected range, active diagnostics, recent navigation
+references, recent command status, current mode/configuration, and small
+bounded snippets only for explicit selections.  It references files by
+path/range instead of including whole workspaces, excludes `node_modules`,
+`.vscode-test`, `AGENTS.md`, `package-lock.json`, binary-like content,
+and private worker instruction paths, and redacts secret-like assignment
+lines.  This is a JSON contract only: no AI provider calls, no
+pccx-llm-launcher runtime calls yet, no MCP server implementation, no
+direct file modification, and no stable API claim.
 The boundary notes are tracked in
 [`docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md`](./docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md).
 
@@ -255,8 +265,29 @@ not implemented skins and not completion claims.  This is not a completed
 custom theme system, and the current work is not a custom theme engine.
 
 This scaffold is not LSP, not a full IDE replacement, not a stable
-ABI/API, and not a marketplace-ready or published extension.
+ABI/API, and has no marketplace packaging or published extension.
 CI does not run the real Extension Host runtime smoke yet.
+
+## Daily-Driver Roadmap
+
+Now:
+
+- checked-example diagnostics, navigation, and DefinitionProvider smoke
+- explicit live workspace boundary with controlled fixture diagnostics
+- AI assistant status command and bounded context bundle command
+
+Next:
+
+- fixture-backed live diagnostics/navigation coverage with richer status
+- selected symbol context and definition-aware bundle references
+- validation command proposal and pccx-lab command palette integration
+
+Later:
+
+- pccx-llm-launcher local assistant backend behind a reviewed contract
+- MCP controlled tool boundary
+- richer editor UI/panels
+- optional theme presets through host/user theme tokens
 
 ## Local Smoke
 

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -3,7 +3,7 @@
 ## Current Status
 
 This is a local experimental VS Code extension scaffold.  It is not
-published, not marketplace-ready, not LSP, and not a stable ABI/API.
+published, has no marketplace packaging, is not LSP, and is not a stable ABI/API.
 
 Feasibility decision for this phase: Option A, local-only.  A limited
 Extension Host runtime smoke is enabled behind
@@ -21,8 +21,8 @@ should earn CI promotion separately.
   require both `mode=liveWorkspace` and `liveWorkspace.enabled=true`.
 - Known facade argument arrays.
 - Command handlers and UI action models.
-- AI assistant boundary and token-saving context bundle unit tests.  The
-  current AI assistant work is boundary/stub only.
+- AI assistant status/context commands and token-saving context bundle
+  unit tests.  The current AI assistant work is boundary-only.
 - Presenter behavior with mocked VS Code-like dependencies.
 - Real VS Code `DiagnosticCollection` population for the checked-example
   diagnostics command when the local runtime smoke is explicitly enabled.
@@ -36,6 +36,10 @@ should earn CI promotion separately.
   VS Code `Location` results in the opt-in runtime smoke.
 - Checked editor bridge examples.
 - Live CLI runner for known local JSON flows.
+- Controlled live workspace fixture diagnostics in the opt-in Extension
+  Host runtime smoke.
+- AI assistant status and context bundle command smoke with provider and
+  runtime calls reported as unimplemented.
 - Guard behavior for the local-only Extension Host runtime smoke.
 - Pinned Extension Host activation and command-registration smoke when
   explicitly enabled locally.
@@ -54,9 +58,10 @@ should earn CI promotion separately.
   calls, or MCP server implementation.
 
 The runtime smoke is limited coverage for the activation, command facade,
-and VS Code-native provider boundary only.  It is not a product claim and
-does not imply marketplace readiness, a published extension, LSP support,
-complete semantic navigation, or a stable ABI/API.
+controlled fixture, context bundle, and VS Code-native provider boundary
+only.  It is not a product claim and does not imply a published extension,
+marketplace packaging, LSP support, complete semantic navigation, or a
+stable ABI/API.
 
 ## Guarded Local Scaffold
 
@@ -72,26 +77,34 @@ PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh
 ```
 
 The runner lives under `editors/vscode-prototype/test/extension-host/`.
-It uses `@vscode/test-electron@2.5.2`, pins VS Code to `1.90.2`, creates
-a temporary workspace, loads the local extension package, verifies the
-expected command IDs, checks that
-`pccxSystemVerilog.publishLiveWorkspaceDiagnostics` fails clearly while
-live workspace is disabled by default, and executes only the
-checked-example diagnostics/navigation command paths.  The diagnostics
-command uses checked example diagnostics by default, goes through the
-facade boundary, and verifies that VS Code receives at least one
-diagnostic with URI, range, severity, message, and source fields.  The
-navigation command uses checked example mode by default through
+It uses `@vscode/test-electron@2.5.2`, pins VS Code to `1.90.2`, opens
+`test/fixtures/live-workspace`, loads the local extension package,
+verifies the expected command IDs, checks that live diagnostics and
+navigation fail clearly while live workspace is disabled, and executes
+the checked-example diagnostics/navigation command paths.  The
+diagnostics command uses checked example diagnostics by default, goes
+through the facade boundary, and verifies that VS Code receives at least
+one diagnostic with URI, range, severity, message, and source fields.
+The navigation command uses checked example mode by default through
 `navigation --mode example --source declarations`; it returns
 Location-style records with URI, range, symbol, target kind, and source
-fields.  The same smoke opens a temporary SystemVerilog-like document
-and executes `vscode.executeDefinitionProvider` to verify that the
+fields.  The same smoke opens a fixture SystemVerilog document and
+executes `vscode.executeDefinitionProvider` to verify that the
 experimental VS Code-native `DefinitionProvider` returns at least one
-`Location` with sane URI and range fields.  The provider currently
-reuses the checked-example declaration result and does not complete
-semantic cursor/symbol resolution.  Live mode remains explicit and
-separate, and the runtime smoke does not execute enabled live CLI
-commands by default.  This is not LSP, and there is no LSP provider yet.
+`Location` with sane URI and range fields.  The provider currently reuses
+the checked-example declaration result and does not complete semantic
+cursor/symbol resolution.
+
+The enabled live path is limited to the controlled fixture.  The smoke
+explicitly sets `mode=liveWorkspace` and `liveWorkspace.enabled=true`,
+runs `pccxSystemVerilog.publishLiveWorkspaceDiagnostics` against
+`broken_missing_endmodule.sv`, and asserts the returned diagnostics came
+from that fixture rather than checked examples.  It also executes
+`pccxSystemVerilog.showAIAssistantStatus` and
+`pccxSystemVerilog.buildAIContextBundle`, verifying disabled/backend
+`none` status, proposal-only actions, bounded active-file context, and no
+provider/runtime calls.  This is not LSP, and there is no LSP provider
+yet.
 
 ## AI Assistant Boundary
 
@@ -100,7 +113,9 @@ boundary, not a model integration.  pccx-llm-launcher is a future local LLM/chat
 contract.  The current extension code makes no AI provider calls, no
 pccx-llm-launcher runtime calls, and implements no MCP server.  AI
 actions are modeled as proposals, including command proposal and
-validation proposal shapes, rather than direct execution.
+validation proposal shapes, rather than direct execution.  User approval
+is still required before applying patches, running validation commands,
+or committing changes.
 
 The guarded script is not run by CI today.
 
@@ -137,7 +152,8 @@ system.
 
 1. Keep the facade boundary.
 2. Do not call `pccx_ide_cli` directly from activation.
-3. Do not run live CLI commands in the runtime smoke by default.
+3. Keep runtime live CLI coverage limited to the controlled fixture until
+   broader live workspace behavior has separate evidence.
 4. Keep the VS Code-native `DefinitionProvider` separate from any LSP
    implementation.
 5. Promote the runtime smoke to CI only after separate stability evidence.

--- a/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
+++ b/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
@@ -3,8 +3,9 @@
 ## Status
 
 This is experimental boundary documentation for the local VS Code
-prototype.  It is not production-ready, not a stable API/ABI, not LSP,
-not marketplace packaging, and not a complete AI integration.
+prototype.  It is not a production promise, not a stable API/ABI, not
+LSP, has no marketplace packaging, and the AI surface is status/context
+only.
 
 Checked-example remains the default.  Live workspace mode is opt-in and
 requires both:
@@ -61,42 +62,58 @@ known flows only.  They do not accept arbitrary shell commands, do not
 use shell interpolation, do not silently fall back to checked-example
 mode, and do not start background scanning.
 
+The controlled fixture workspace is
+`editors/vscode-prototype/test/fixtures/live-workspace`.  The opt-in
+Extension Host runtime smoke opens that fixture, explicitly enables live
+workspace mode, runs live diagnostics against the tiny broken fixture
+file, and asserts the result did not come from checked examples.  This
+does not make live mode a production promise.
+
 ## AI Assistant Proposal Boundary
 
-The current AI assistant boundary is a proposal model only.  There are
-no AI provider calls, no external API keys, no pccx-llm-launcher runtime
-calls yet, and no MCP server implementation.
+The current AI assistant boundary is a proposal model only.
+`pccxSystemVerilog.showAIAssistantStatus` returns local status and
+proposal boundaries.  `pccxSystemVerilog.buildAIContextBundle` returns a
+bounded context bundle for the active editor state.  There are no AI
+provider calls, no external API keys, no pccx-llm-launcher runtime calls
+yet, and no MCP server implementation.
 
 Allowed proposal kinds:
 
-- explain diagnostics
-- propose patch
-- propose validation command
-- summarize xsim/log output
-- ask for more context
-- open related symbol
-- call pccx-lab tool through a controlled boundary
+- `explainDiagnostics`
+- `proposePatch`
+- `proposeValidationCommand`
+- `summarizeLog`
+- `askForMoreContext`
+- `openRelatedSymbol`
 
 Disallowed by default:
 
-- direct file write
-- direct git commit
-- direct push
-- direct release/tag
-- direct ruleset/settings/secrets change
-- staging/private repo access
-- arbitrary shell command
+- `writeFile`
+- `commit`
+- `push`
+- `merge`
+- `release`
+- `tag`
+- `changeRuleset`
+- `accessSecrets`
+- `accessStaging`
+
+Patch, validation, and commit execution stay outside these commands and
+require explicit user approval.
 
 ## Context Bundle Contract
 
-The context bundle is a token-saving JSON contract stub.  It prefers:
+The context bundle is a token-saving JSON contract.  It prefers:
 
 - selected file path and selected range
-- selected symbol and declaration references
+- selected symbol and recent declaration references
 - active diagnostics around the selected range
+- current mode/configuration
+- recent command status
 - recent validation status
 - pccx-lab command output summaries
-- bounded snippets with path/range references
+- bounded snippets for explicit selections with path/range references
 - summarized logs, not full logs
 
 Limits are enforced by `src/context-bundle.mjs`:
@@ -109,6 +126,29 @@ Limits are enforced by `src/context-bundle.mjs`:
 - max text characters
 
 The builder excludes binary-like content, `node_modules`, `.vscode-test`,
-`.git`, secret-like path names, and private worker instruction paths.  It
-redacts secret-like assignment lines and keeps deterministic ordering for
-reviewable tests.
+`.git`, `AGENTS.md`, `package-lock.json`, secret-like path names, and
+private worker instruction paths.  It redacts secret-like assignment
+lines, emits redaction/exclusion metadata, keeps deterministic ordering,
+and avoids absolute home-path leakage when a workspace root is known.
+
+## Daily-Driver Roadmap
+
+Now:
+
+- checked-example diagnostics/navigation/definition
+- explicit live workspace boundary
+- context bundle command
+
+Next:
+
+- fixture-backed live diagnostics/navigation coverage
+- selected symbol context
+- validation command proposal
+- pccx-lab command palette integration
+
+Later:
+
+- pccx-llm-launcher local assistant backend
+- MCP controlled tool boundary
+- richer editor UI/panels
+- optional theme presets via tokens

--- a/editors/vscode-prototype/package.json
+++ b/editors/vscode-prototype/package.json
@@ -20,7 +20,9 @@
     "onCommand:pccxSystemVerilog.showDiagnosticsExample",
     "onCommand:pccxSystemVerilog.showNavigationExample",
     "onCommand:pccxSystemVerilog.runDiagnosticsLive",
-    "onCommand:pccxSystemVerilog.runNavigationLive"
+    "onCommand:pccxSystemVerilog.runNavigationLive",
+    "onCommand:pccxSystemVerilog.showAIAssistantStatus",
+    "onCommand:pccxSystemVerilog.buildAIContextBundle"
   ],
   "contributes": {
     "commands": [
@@ -55,6 +57,14 @@
       {
         "command": "pccxSystemVerilog.runNavigationLive",
         "title": "PCCX SystemVerilog: Run Navigation Live (Experimental, Opt-In Alias)"
+      },
+      {
+        "command": "pccxSystemVerilog.showAIAssistantStatus",
+        "title": "PCCX SystemVerilog: Show AI Assistant Status (Experimental)"
+      },
+      {
+        "command": "pccxSystemVerilog.buildAIContextBundle",
+        "title": "PCCX SystemVerilog: Build AI Context Bundle (Experimental)"
       }
     ],
     "configuration": {
@@ -108,6 +118,11 @@
           "type": "string",
           "default": "fixtures/xsim/mixed.log",
           "description": "Experimental local prototype workspace-relative default synthetic xsim-style log used by live diagnostics; not a stable API."
+        },
+        "pccxSystemVerilog.defaultNavigationRoot": {
+          "type": "string",
+          "default": "fixtures/modules",
+          "description": "Experimental local prototype workspace-relative source root used by live navigation; not a stable API."
         },
         "pccxSystemVerilog.defaultModule": {
           "type": "string",

--- a/editors/vscode-prototype/src/ai-assistant-boundary.mjs
+++ b/editors/vscode-prototype/src/ai-assistant-boundary.mjs
@@ -16,20 +16,21 @@ export const AI_PROPOSAL_KINDS = Object.freeze([
   "explainDiagnostics",
   "proposePatch",
   "proposeValidationCommand",
-  "summarizeXsimLogOutput",
+  "summarizeLog",
   "askForMoreContext",
   "openRelatedSymbol",
-  "callPccxLabTool",
 ]);
 
 export const DISALLOWED_AI_ACTIONS = Object.freeze([
-  "directFileWrite",
-  "directGitCommit",
-  "directGitPush",
-  "directReleaseOrTag",
-  "directRulesetSettingsOrSecretsChange",
-  "stagingOrPrivateRepoAccess",
-  "arbitraryShellCommand",
+  "writeFile",
+  "commit",
+  "push",
+  "merge",
+  "release",
+  "tag",
+  "changeRuleset",
+  "accessSecrets",
+  "accessStaging",
 ]);
 
 function proposalAction(kind) {
@@ -41,30 +42,35 @@ function proposalAction(kind) {
 
 export function createAssistantBoundaryStatus(rawConfig = {}) {
   const config = normalizeConfig(rawConfig);
+  const baseStatus = {
+    version: AI_ASSISTANT_BOUNDARY_VERSION,
+    backend: config.aiAssistant.backend,
+    providerCalls: false,
+    runtimeCalls: false,
+    providerCallsImplemented: false,
+    runtimeCallsImplemented: false,
+    mcpServerImplemented: false,
+    directExecution: false,
+    proposalOnly: true,
+    allowedActions: AI_PROPOSAL_KINDS.map(proposalAction),
+    disallowedActions: [...DISALLOWED_AI_ACTIONS],
+  };
+
   if (!config.aiAssistant.enabled) {
     return {
-      version: AI_ASSISTANT_BOUNDARY_VERSION,
+      ...baseStatus,
       status: AI_ASSISTANT_STATUSES.DISABLED,
-      backend: config.aiAssistant.backend,
-      providerCalls: false,
-      runtimeCalls: false,
     };
   }
   if (config.aiAssistant.backend === "none") {
     return {
-      version: AI_ASSISTANT_BOUNDARY_VERSION,
+      ...baseStatus,
       status: AI_ASSISTANT_STATUSES.NOT_CONFIGURED,
-      backend: config.aiAssistant.backend,
-      providerCalls: false,
-      runtimeCalls: false,
     };
   }
   return {
-    version: AI_ASSISTANT_BOUNDARY_VERSION,
+    ...baseStatus,
     status: AI_ASSISTANT_STATUSES.PROPOSAL_BOUNDARY,
-    backend: config.aiAssistant.backend,
-    providerCalls: false,
-    runtimeCalls: false,
   };
 }
 
@@ -74,10 +80,9 @@ export function createAssistantRequest(rawConfig = {}, contextInput = {}, option
 
   return {
     ...status,
+    kind: "ai-context-bundle",
     contextBundle,
     contextSummary: summarizeContextBundle(contextBundle),
-    allowedActions: AI_PROPOSAL_KINDS.map(proposalAction),
-    disallowedActions: [...DISALLOWED_AI_ACTIONS],
   };
 }
 

--- a/editors/vscode-prototype/src/config.mjs
+++ b/editors/vscode-prototype/src/config.mjs
@@ -9,11 +9,12 @@ export const CONFIG_KEYS = Object.freeze([
   "pythonPath",
   "defaultSource",
   "defaultLog",
+  "defaultNavigationRoot",
   "defaultModule",
   "defaultDeclarationKind",
 ]);
 
-export const COMMAND_IDS = Object.freeze([
+export const FACADE_COMMAND_IDS = Object.freeze([
   "pccxSystemVerilog.publishCheckedExampleDiagnostics",
   "pccxSystemVerilog.showCheckedExampleNavigation",
   "pccxSystemVerilog.publishLiveWorkspaceDiagnostics",
@@ -22,6 +23,16 @@ export const COMMAND_IDS = Object.freeze([
   "pccxSystemVerilog.showNavigationExample",
   "pccxSystemVerilog.runDiagnosticsLive",
   "pccxSystemVerilog.runNavigationLive",
+]);
+
+export const AI_COMMAND_IDS = Object.freeze([
+  "pccxSystemVerilog.showAIAssistantStatus",
+  "pccxSystemVerilog.buildAIContextBundle",
+]);
+
+export const COMMAND_IDS = Object.freeze([
+  ...FACADE_COMMAND_IDS,
+  ...AI_COMMAND_IDS,
 ]);
 
 export const MODES = Object.freeze(["checkedExample", "liveWorkspace"]);
@@ -49,11 +60,11 @@ const DEFAULT_CONFIG = Object.freeze({
   pythonPath: "python3",
   defaultSource: "fixtures/missing_endmodule.sv",
   defaultLog: "fixtures/xsim/mixed.log",
+  defaultNavigationRoot: "fixtures/modules",
   defaultModule: "simple_mod",
   defaultDeclarationKind: "module",
 });
 
-const NAVIGATION_ROOT = "fixtures/modules";
 const SHELL_CONTROL_PATTERN = /(?:&&|\|\||;|`|\$\()/;
 
 function rawConfigValue(rawConfig, key) {
@@ -159,6 +170,11 @@ export function normalizeConfig(rawConfig = {}) {
     pythonPath: stringSetting(rawConfig, "pythonPath", DEFAULT_CONFIG.pythonPath),
     defaultSource: stringSetting(rawConfig, "defaultSource", DEFAULT_CONFIG.defaultSource),
     defaultLog: stringSetting(rawConfig, "defaultLog", DEFAULT_CONFIG.defaultLog),
+    defaultNavigationRoot: stringSetting(
+      rawConfig,
+      "defaultNavigationRoot",
+      DEFAULT_CONFIG.defaultNavigationRoot,
+    ),
     defaultModule: stringSetting(rawConfig, "defaultModule", DEFAULT_CONFIG.defaultModule),
     defaultDeclarationKind: enumSetting(
       rawConfig,
@@ -173,9 +189,20 @@ export function isKnownCommandId(commandId) {
   return COMMAND_IDS.includes(commandId);
 }
 
+export function isFacadeCommandId(commandId) {
+  return FACADE_COMMAND_IDS.includes(commandId);
+}
+
 export function assertKnownCommandId(commandId) {
   if (!isKnownCommandId(commandId)) {
     throw new Error(`unknown PCCX SystemVerilog command: ${commandId}`);
+  }
+}
+
+export function assertFacadeCommandId(commandId) {
+  if (!isFacadeCommandId(commandId)) {
+    assertKnownCommandId(commandId);
+    throw new Error(`PCCX SystemVerilog command does not use the facade: ${commandId}`);
   }
 }
 
@@ -197,7 +224,7 @@ export function assertLiveWorkspaceEnabled(config) {
 }
 
 export function buildFacadeArgsForCommand(commandId, rawConfig = {}) {
-  assertKnownCommandId(commandId);
+  assertFacadeCommandId(commandId);
   const config = normalizeConfig(rawConfig);
 
   if (
@@ -232,7 +259,7 @@ export function buildFacadeArgsForCommand(commandId, rawConfig = {}) {
       "--mode",
       "live",
       "--locate",
-      NAVIGATION_ROOT,
+      config.defaultNavigationRoot,
       config.defaultModule,
       "--kind",
       config.defaultDeclarationKind,

--- a/editors/vscode-prototype/src/context-bundle.mjs
+++ b/editors/vscode-prototype/src/context-bundle.mjs
@@ -18,6 +18,23 @@ const EXCLUDED_PATH_SEGMENTS = new Set([
   "node_modules",
 ]);
 
+const EXCLUDED_PATH_NAMES = new Set([
+  "AGENTS.md",
+  "package-lock.json",
+]);
+
+const EXCLUDED_PATH_PATTERNS = Object.freeze([
+  ".git/**",
+  ".vscode-test/**",
+  "node_modules/**",
+  "AGENTS.md",
+  "package-lock.json",
+  ".codex/**",
+  "private-worker/**",
+  "worker-instruction/**",
+  "subagent-instruction/**",
+]);
+
 const SECRET_LIKE_PATTERN =
   /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b/i;
 const SECRET_ASSIGNMENT_PATTERN =
@@ -44,6 +61,11 @@ function normalizeWorkspacePath(workspaceRoot) {
 function hasExcludedPathSegment(path) {
   const segments = path.split("/").filter(Boolean);
   return segments.some((segment) => EXCLUDED_PATH_SEGMENTS.has(segment));
+}
+
+function hasExcludedPathName(path) {
+  const segments = path.split("/").filter(Boolean);
+  return segments.some((segment) => EXCLUDED_PATH_NAMES.has(segment));
 }
 
 function normalizePathRef(path, workspaceRoot = null) {
@@ -74,6 +96,7 @@ function normalizePathRef(path, workspaceRoot = null) {
     normalizedPath.startsWith("../") ||
     normalizedPath === ".." ||
     hasExcludedPathSegment(normalizedPath) ||
+    hasExcludedPathName(normalizedPath) ||
     SECRET_LIKE_PATTERN.test(normalizedPath) ||
     PRIVATE_INSTRUCTION_PATH_PATTERN.test(normalizedPath)
   ) {
@@ -90,7 +113,7 @@ function normalizeRange(range) {
   if (!range || typeof range !== "object") {
     return null;
   }
-  return {
+  const normalized = {
     start: {
       line: Math.max(0, Math.floor(clampNumber(range.start?.line))),
       character: Math.max(0, Math.floor(clampNumber(range.start?.character))),
@@ -100,17 +123,30 @@ function normalizeRange(range) {
       character: Math.max(0, Math.floor(clampNumber(range.end?.character))),
     },
   };
+  if (
+    normalized.end.line < normalized.start.line ||
+    (
+      normalized.end.line === normalized.start.line &&
+      normalized.end.character < normalized.start.character
+    )
+  ) {
+    normalized.end = { ...normalized.start };
+  }
+  return normalized;
+}
+
+function redactSecretAssignments(value) {
+  return value
+    .split(/\r?\n/)
+    .map((line) => (SECRET_ASSIGNMENT_PATTERN.test(line) ? "[redacted]" : line))
+    .join("\n");
 }
 
 function scrubText(value, maxCharacters) {
   if (typeof value !== "string" || value.length === 0 || maxCharacters === 0) {
     return "";
   }
-  return value
-    .split(/\r?\n/)
-    .map((line) => (SECRET_ASSIGNMENT_PATTERN.test(line) ? "[redacted]" : line))
-    .join("\n")
-    .slice(0, maxCharacters);
+  return redactSecretAssignments(value).slice(0, maxCharacters);
 }
 
 function isBinaryLike(text) {
@@ -124,6 +160,20 @@ function boundedLines(value, limit, maxCharacters) {
   return scrubText(value, maxCharacters)
     .split(/\r?\n/)
     .slice(0, limit);
+}
+
+function boundedSnippetLines(value, limit, maxCharacters) {
+  if (typeof value !== "string" || limit === 0 || maxCharacters === 0) {
+    return { lines: [], truncated: typeof value === "string" && value.length > 0 };
+  }
+  const redacted = redactSecretAssignments(value);
+  const charLimited = redacted.slice(0, maxCharacters);
+  const allLines = charLimited.split(/\r?\n/);
+  const lines = allLines.slice(0, limit);
+  return {
+    lines,
+    truncated: redacted.length > charLimited.length || allLines.length > lines.length,
+  };
 }
 
 function normalizeDiagnostic(diagnostic, workspaceRoot, limits) {
@@ -162,13 +212,17 @@ function normalizeSnippet(file, workspaceRoot, limits) {
     return null;
   }
 
-  const lines = boundedLines(file.text ?? "", limits.maxSnippetLines, limits.maxTextCharacters);
+  const snippet = boundedSnippetLines(
+    file.text ?? "",
+    limits.maxSnippetLines,
+    limits.maxTextCharacters,
+  );
   return {
     path,
     language: scrubText(file.language ?? "systemverilog", 80),
     range: normalizeRange(file.range),
-    lines,
-    truncated: typeof file.text === "string" && file.text.split(/\r?\n/).length > lines.length,
+    lines: snippet.lines,
+    truncated: snippet.truncated,
   };
 }
 
@@ -179,6 +233,38 @@ function sortedByPathAndName(items) {
       return pathOrder;
     }
     return String(a.name ?? a.message ?? "").localeCompare(String(b.name ?? b.message ?? ""));
+  });
+}
+
+function sortedSnippets(items, selectedPath) {
+  return sortedByPathAndName(items).sort((a, b) => {
+    const aSelected = selectedPath && a.path === selectedPath ? 0 : 1;
+    const bSelected = selectedPath && b.path === selectedPath ? 0 : 1;
+    return aSelected - bSelected;
+  });
+}
+
+function rangeStartsWithin(range, selectedRange) {
+  if (!range || !selectedRange) {
+    return false;
+  }
+  const line = range.start?.line;
+  const selectedStart = selectedRange.start?.line;
+  const selectedEnd = selectedRange.end?.line;
+  return Number.isInteger(line) &&
+    Number.isInteger(selectedStart) &&
+    Number.isInteger(selectedEnd) &&
+    line >= selectedStart &&
+    line <= selectedEnd;
+}
+
+function sortedDiagnostics(items, selectedPath, selectedRange) {
+  return sortedByPathAndName(items).sort((a, b) => {
+    const aScore = (selectedPath && a.path === selectedPath ? 0 : 2) +
+      (rangeStartsWithin(a.range, selectedRange) ? 0 : 1);
+    const bScore = (selectedPath && b.path === selectedPath ? 0 : 2) +
+      (rangeStartsWithin(b.range, selectedRange) ? 0 : 1);
+    return aScore - bScore;
   });
 }
 
@@ -193,6 +279,67 @@ function normalizeLogSummary(entry, limits) {
   };
 }
 
+function normalizeConfiguration(configuration) {
+  if (!configuration || typeof configuration !== "object") {
+    return {
+      mode: "unknown",
+      liveWorkspace: { enabled: false },
+      aiAssistant: { enabled: false, backend: "none" },
+      pccxLab: { commandBoundary: "pccx_ide_cli" },
+    };
+  }
+  return {
+    mode: scrubText(configuration.mode ?? "unknown", 80),
+    liveWorkspace: {
+      enabled: configuration.liveWorkspace?.enabled === true,
+    },
+    aiAssistant: {
+      enabled: configuration.aiAssistant?.enabled === true,
+      backend: scrubText(configuration.aiAssistant?.backend ?? "none", 80),
+    },
+    pccxLab: {
+      commandBoundary: scrubText(configuration.pccxLab?.commandBoundary ?? "pccx_ide_cli", 120),
+    },
+  };
+}
+
+function normalizeSelectedSymbol(symbol, workspaceRoot) {
+  if (!symbol) {
+    return null;
+  }
+  const path = normalizePathRef(symbol.path ?? symbol.file, workspaceRoot);
+  if (!path) {
+    return null;
+  }
+  return {
+    name: scrubText(symbol.name ?? "", 160),
+    kind: scrubText(symbol.kind ?? "any", 80),
+    path,
+    range: normalizeRange(symbol.range),
+  };
+}
+
+function normalizeRecentCommandStatus(status, limits) {
+  if (!status || typeof status !== "object") {
+    return null;
+  }
+  return {
+    commandId: scrubText(status.commandId ?? "", 160),
+    ok: status.ok === true,
+    actionKind: scrubText(status.actionKind ?? "", 80),
+    summary: scrubText(status.summary ?? "", 500),
+    facade: status.facade
+      ? {
+          command: scrubText(status.facade.command ?? "", 80),
+          mode: scrubText(status.facade.mode ?? "", 80),
+        }
+      : null,
+    diagnosticCount: Math.max(0, Math.floor(clampNumber(status.diagnosticCount))),
+    navigationItemCount: Math.max(0, Math.floor(clampNumber(status.navigationItemCount))),
+    error: scrubText(status.error ?? "", limits.maxTextCharacters),
+  };
+}
+
 export function buildContextBundle(input = {}, options = {}) {
   const limits = mergeLimits(options.limits);
   const workspaceRoot = options.workspaceRoot ?? input.workspaceRoot ?? null;
@@ -202,36 +349,33 @@ export function buildContextBundle(input = {}, options = {}) {
     ? input.symbolContext.declarations
     : [];
   const pccxLabOutputs = Array.isArray(input.pccxLabOutputs) ? input.pccxLabOutputs : [];
+  const selectedPath = normalizePathRef(input.selectedFilePath, workspaceRoot);
+  const selectedRange = normalizeRange(input.selectedRange);
 
-  const snippets = sortedByPathAndName(
+  const snippets = sortedSnippets(
     files
       .map((file) => normalizeSnippet(file, workspaceRoot, limits))
       .filter(Boolean),
+    selectedPath,
   ).slice(0, limits.maxFiles);
-
-  const selectedPath = normalizePathRef(input.selectedFilePath, workspaceRoot);
 
   return {
     version: CONTEXT_BUNDLE_VERSION,
     source: CONTEXT_BUNDLE_SOURCE,
     limits,
+    configuration: normalizeConfiguration(input.configuration),
     selectedFile: selectedPath ? { path: selectedPath } : null,
-    selectedRange: normalizeRange(input.selectedRange),
+    selectedRange,
     userIntent: scrubText(input.userIntent ?? "", limits.maxTextCharacters),
-    diagnostics: sortedByPathAndName(
+    diagnostics: sortedDiagnostics(
       diagnostics
         .map((diagnostic) => normalizeDiagnostic(diagnostic, workspaceRoot, limits))
         .filter(Boolean),
+      selectedPath,
+      selectedRange,
     ).slice(0, limits.maxDiagnostics),
     symbols: {
-      selected: input.selectedSymbol
-        ? {
-            name: scrubText(input.selectedSymbol.name ?? "", 160),
-            kind: scrubText(input.selectedSymbol.kind ?? "any", 80),
-            path: normalizePathRef(input.selectedSymbol.path ?? input.selectedSymbol.file, workspaceRoot),
-            range: normalizeRange(input.selectedSymbol.range),
-          }
-        : null,
+      selected: normalizeSelectedSymbol(input.selectedSymbol, workspaceRoot),
       declarations: sortedByPathAndName(
         declarations
           .map((declaration) => normalizeDeclaration(declaration, workspaceRoot, limits))
@@ -250,6 +394,7 @@ export function buildContextBundle(input = {}, options = {}) {
           }
         : null,
     },
+    recentCommand: normalizeRecentCommandStatus(input.recentCommandStatus, limits),
     pccxLab: {
       commandBoundary: "pccx_ide_cli",
       outputs: pccxLabOutputs
@@ -257,6 +402,12 @@ export function buildContextBundle(input = {}, options = {}) {
         .slice(0, limits.maxFiles),
     },
     excludedPathSegments: [...EXCLUDED_PATH_SEGMENTS].sort(),
+    excludedPathPatterns: [...EXCLUDED_PATH_PATTERNS],
+    redaction: {
+      assignmentPolicy: "secret-like-lines-redacted",
+      absolutePaths: "workspaceRelativeOnly",
+      privateInstructionPathsExcluded: true,
+    },
   };
 }
 

--- a/editors/vscode-prototype/src/extension.mjs
+++ b/editors/vscode-prototype/src/extension.mjs
@@ -6,7 +6,9 @@ import {
   COMMAND_IDS,
   CONFIG_KEYS,
   CONFIG_SECTION,
+  FACADE_COMMAND_IDS,
   assertKnownCommandId,
+  isFacadeCommandId,
   buildFacadeArgsForCommand,
   defaultConfig,
   isLiveFacadeArgs,
@@ -25,6 +27,10 @@ import {
 import {
   registerCheckedExampleDefinitionProvider,
 } from "./definition-provider.mjs";
+import {
+  createAssistantBoundaryStatus,
+  createAssistantRequest,
+} from "./ai-assistant-boundary.mjs";
 
 const EXTENSION_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_DIAGNOSTIC_FILE_ROOT = resolve(EXTENSION_ROOT, "../..");
@@ -33,9 +39,14 @@ const DEFAULT_FACADE_PATH = resolve(EXTENSION_ROOT, "bin/pccx-vscode-prototype.m
 const OUTPUT_CHANNEL_NAME = "PCCX SystemVerilog IDE Prototype";
 export const CHECKED_EXAMPLE_NAVIGATION_COMMAND =
   "pccxSystemVerilog.showCheckedExampleNavigation";
+export const AI_ASSISTANT_STATUS_COMMAND =
+  "pccxSystemVerilog.showAIAssistantStatus";
+export const AI_CONTEXT_BUNDLE_COMMAND =
+  "pccxSystemVerilog.buildAIContextBundle";
 
 export {
   COMMAND_IDS,
+  FACADE_COMMAND_IDS,
   buildFacadeArgsForCommand,
   createNavigationLocationRecords,
   createCommandExecutionPlan,
@@ -152,7 +163,11 @@ export function resolveCommandRequest(commandId, input, vscodeApi, rawConfig = r
     ? normalizeConfig({ ...config, defaultSource: explicitPath })
     : config;
 
-  buildFacadeArgsForCommand(commandId, commandConfig);
+  if (isFacadeCommandId(commandId)) {
+    buildFacadeArgsForCommand(commandId, commandConfig);
+  } else {
+    assertKnownCommandId(commandId);
+  }
   return commandConfig;
 }
 
@@ -177,6 +192,12 @@ function appendCommandOutput(outputChannel, commandId, result) {
   }
 
   outputChannel.appendLine(`[${commandId}]`);
+  if (result.status?.status) {
+    outputChannel.appendLine(`AI assistant status: ${result.status.status}`);
+  }
+  if (result.contextSummary) {
+    outputChannel.appendLine(JSON.stringify(result.contextSummary, null, 2));
+  }
   if (result.action?.summary) {
     outputChannel.appendLine(result.action.summary);
   }
@@ -252,11 +273,212 @@ export function createPresenterDeps(vscodeApi, runtime = {}) {
   };
 }
 
+function plainRange(range) {
+  if (!range) {
+    return null;
+  }
+  return {
+    start: {
+      line: Number.isInteger(range.start?.line) ? range.start.line : 0,
+      character: Number.isInteger(range.start?.character) ? range.start.character : 0,
+    },
+    end: {
+      line: Number.isInteger(range.end?.line) ? range.end.line : 0,
+      character: Number.isInteger(range.end?.character) ? range.end.character : 0,
+    },
+  };
+}
+
+function rangeIsEmpty(range) {
+  return !range ||
+    (
+      range.start?.line === range.end?.line &&
+      range.start?.character === range.end?.character
+    );
+}
+
+function diagnosticSeverityName(vscodeApi, severity) {
+  const diagnosticSeverity = vscodeApi?.DiagnosticSeverity ?? {};
+  if (severity === diagnosticSeverity.Error || severity === 0) {
+    return "Error";
+  }
+  if (severity === diagnosticSeverity.Warning || severity === 1) {
+    return "Warning";
+  }
+  if (severity === diagnosticSeverity.Information || severity === 2) {
+    return "Information";
+  }
+  if (severity === diagnosticSeverity.Hint || severity === 3) {
+    return "Hint";
+  }
+  return "Information";
+}
+
+function diagnosticCode(value) {
+  if (value == null) {
+    return "";
+  }
+  if (typeof value === "object" && value.value != null) {
+    return String(value.value);
+  }
+  return String(value);
+}
+
+function workspaceRootForDocument(vscodeApi, document) {
+  const folder = document?.uri
+    ? vscodeApi?.workspace?.getWorkspaceFolder?.(document.uri)
+    : null;
+  return folder?.uri?.fsPath ?? vscodeApi?.workspace?.workspaceFolders?.[0]?.uri?.fsPath ?? null;
+}
+
+function contextConfiguration(config) {
+  const defaultPccxLabCommand = defaultConfig().pccxLab.command;
+  return {
+    mode: config.mode,
+    liveWorkspace: {
+      enabled: config.liveWorkspace.enabled,
+    },
+    aiAssistant: {
+      enabled: config.aiAssistant.enabled,
+      backend: config.aiAssistant.backend,
+    },
+    pccxLab: {
+      commandBoundary: config.pccxLab.command === defaultPccxLabCommand
+        ? defaultPccxLabCommand
+        : "custom",
+    },
+  };
+}
+
+function collectActiveDiagnostics(vscodeApi, runtime, document) {
+  if (!document?.uri) {
+    return [];
+  }
+  const diagnostics = typeof vscodeApi?.languages?.getDiagnostics === "function"
+    ? vscodeApi.languages.getDiagnostics(document.uri)
+    : runtime.diagnosticsCollection?.get?.(document.uri);
+  if (!Array.isArray(diagnostics)) {
+    return [];
+  }
+  return diagnostics.map((diagnostic) => ({
+    file: document.uri.fsPath,
+    range: plainRange(diagnostic.range),
+    severity: diagnosticSeverityName(vscodeApi, diagnostic.severity),
+    message: diagnostic.message,
+    source: diagnostic.source,
+    code: diagnosticCode(diagnostic.code),
+  }));
+}
+
+function collectActiveDocumentContext(vscodeApi, runtime, config) {
+  const editor = vscodeApi?.window?.activeTextEditor;
+  const document = editor?.document;
+  const workspaceRoot = workspaceRootForDocument(vscodeApi, document);
+  const selectionRange = plainRange(editor?.selection);
+  const files = [];
+
+  if (
+    document?.uri?.fsPath &&
+    editor?.selection &&
+    !rangeIsEmpty(editor.selection) &&
+    typeof document.getText === "function"
+  ) {
+    files.push({
+      path: document.uri.fsPath,
+      language: document.languageId ?? "systemverilog",
+      range: selectionRange,
+      text: document.getText(editor.selection),
+    });
+  }
+
+  return {
+    workspaceRoot,
+    input: {
+      workspaceRoot,
+      selectedFilePath: document?.uri?.fsPath,
+      selectedRange: selectionRange,
+      activeDiagnostics: collectActiveDiagnostics(vscodeApi, runtime, document),
+      symbolContext: {
+        declarations: Array.isArray(runtime.recentNavigationItems)
+          ? runtime.recentNavigationItems
+          : [],
+      },
+      files,
+      configuration: contextConfiguration(config),
+      recentCommandStatus: runtime.recentCommandStatus ?? null,
+    },
+  };
+}
+
+function facadeStatusFromPlan(plan) {
+  const args = Array.isArray(plan?.facadeArgs) ? plan.facadeArgs : [];
+  const modeIndex = args.indexOf("--mode");
+  return {
+    command: args[0] ?? "",
+    mode: modeIndex >= 0 ? args[modeIndex + 1] ?? "" : "",
+  };
+}
+
+function rememberCommandResult(runtime, commandId, result) {
+  runtime.recentCommandStatus = {
+    commandId,
+    ok: result?.ok === true,
+    actionKind: result?.action?.kind ?? "",
+    summary: result?.action?.summary ?? "",
+    facade: facadeStatusFromPlan(result?.plan),
+    diagnosticCount: Array.isArray(result?.action?.diagnostics)
+      ? result.action.diagnostics.length
+      : 0,
+    navigationItemCount: Array.isArray(result?.action?.items)
+      ? result.action.items.length
+      : 0,
+    error: result?.error ?? "",
+  };
+  if (Array.isArray(result?.action?.items)) {
+    runtime.recentNavigationItems = result.action.items;
+  }
+}
+
 export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
   assertKnownCommandId(commandId);
   return async (input) => {
-    const returnsNavigationLocations = commandId === CHECKED_EXAMPLE_NAVIGATION_COMMAND;
     const rawConfig = readRawExtensionConfig(vscodeApi);
+
+    if (commandId === AI_ASSISTANT_STATUS_COMMAND) {
+      let result;
+      try {
+        const status = createAssistantBoundaryStatus(rawConfig);
+        result = { ok: true, commandId, status };
+      } catch (error) {
+        result = { ok: false, commandId, error: error.message };
+        vscodeApi?.window?.showWarningMessage?.(result.error, result);
+      }
+      appendCommandOutput(runtime.outputChannel, commandId, result);
+      return result;
+    }
+
+    if (commandId === AI_CONTEXT_BUNDLE_COMMAND) {
+      let result;
+      try {
+        const config = normalizeConfig(rawConfig);
+        const context = collectActiveDocumentContext(vscodeApi, runtime, config);
+        const request = createAssistantRequest(config, context.input, {
+          workspaceRoot: context.workspaceRoot,
+        });
+        result = {
+          ok: true,
+          commandId,
+          ...request,
+        };
+      } catch (error) {
+        result = { ok: false, commandId, error: error.message };
+        vscodeApi?.window?.showWarningMessage?.(result.error, result);
+      }
+      appendCommandOutput(runtime.outputChannel, commandId, result);
+      return result;
+    }
+
+    const returnsNavigationLocations = commandId === CHECKED_EXAMPLE_NAVIGATION_COMMAND;
     const explicitPath = pathFromCommandInput(input);
     const request = (
       commandId === "pccxSystemVerilog.publishLiveWorkspaceDiagnostics" ||
@@ -282,6 +504,7 @@ export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
         fileRoot: runtime.navigationFileRoot ?? DEFAULT_NAVIGATION_FILE_ROOT,
       })
       : await runPrototypeCommand(commandId, request, deps);
+    rememberCommandResult(runtime, commandId, result);
     if (!result.ok) {
       presenterDeps.showWarningMessage?.(result.error, result);
     }

--- a/editors/vscode-prototype/test/ai-assistant-boundary.test.mjs
+++ b/editors/vscode-prototype/test/ai-assistant-boundary.test.mjs
@@ -13,13 +13,20 @@ import {
 function testDisabledByDefault() {
   const status = createAssistantBoundaryStatus();
 
-  assert.deepEqual(status, {
-    version: AI_ASSISTANT_BOUNDARY_VERSION,
-    status: AI_ASSISTANT_STATUSES.DISABLED,
-    backend: "none",
-    providerCalls: false,
-    runtimeCalls: false,
-  });
+  assert.equal(status.version, AI_ASSISTANT_BOUNDARY_VERSION);
+  assert.equal(status.status, AI_ASSISTANT_STATUSES.DISABLED);
+  assert.equal(status.backend, "none");
+  assert.equal(status.providerCalls, false);
+  assert.equal(status.runtimeCalls, false);
+  assert.equal(status.providerCallsImplemented, false);
+  assert.equal(status.runtimeCallsImplemented, false);
+  assert.equal(status.mcpServerImplemented, false);
+  assert.equal(status.proposalOnly, true);
+  assert.deepEqual(
+    status.allowedActions.map((action) => action.kind),
+    AI_PROPOSAL_KINDS,
+  );
+  assert.deepEqual(status.disallowedActions, DISALLOWED_AI_ACTIONS);
 }
 
 function testEnabledButNoBackendIsNotConfigured() {
@@ -65,8 +72,10 @@ function testLauncherBackendRemainsProposalBoundary() {
   );
   assert.ok(request.allowedActions.every((action) => action.execution === "proposalOnly"));
   assert.deepEqual(request.disallowedActions, DISALLOWED_AI_ACTIONS);
-  assert.ok(request.disallowedActions.includes("directFileWrite"));
-  assert.ok(request.disallowedActions.includes("arbitraryShellCommand"));
+  assert.ok(request.disallowedActions.includes("writeFile"));
+  assert.ok(request.disallowedActions.includes("commit"));
+  assert.ok(request.disallowedActions.includes("accessSecrets"));
+  assert.equal(request.kind, "ai-context-bundle");
   assert.equal(request.contextSummary.selectedFile.path, "rtl/top.sv");
   assert.equal(request.contextSummary.diagnosticCount, 1);
 }
@@ -81,7 +90,7 @@ function testCommandProposalsAreProposalOnly() {
     },
   );
   assert.throws(
-    () => createCommandProposal("directFileWrite"),
+    () => createCommandProposal("writeFile"),
     /unsupported AI assistant proposal kind/,
   );
 }

--- a/editors/vscode-prototype/test/command-handlers.test.mjs
+++ b/editors/vscode-prototype/test/command-handlers.test.mjs
@@ -1,12 +1,15 @@
 import assert from "node:assert/strict";
 
 import {
-  COMMAND_IDS,
   createCommandExecutionPlan,
   runPrototypeCommand,
   toDiagnosticsUiAction,
   toNavigationUiAction,
 } from "../src/command-handlers.mjs";
+import {
+  COMMAND_IDS,
+  FACADE_COMMAND_IDS,
+} from "../src/config.mjs";
 import {
   activate,
   deactivate,
@@ -57,7 +60,7 @@ function mockDeps(payloadOrResult) {
 }
 
 function testPlansForKnownCommands() {
-  for (const commandId of COMMAND_IDS) {
+  for (const commandId of FACADE_COMMAND_IDS) {
     const plan = createCommandExecutionPlan(commandId, configForCommand(commandId));
     assert.equal(plan.commandId, commandId);
     assert.ok(Array.isArray(plan.facadeArgs));
@@ -233,6 +236,7 @@ async function testShowLiveWorkspaceNavigationAction() {
     {
       mode: "liveWorkspace",
       liveWorkspace: { enabled: true },
+      defaultNavigationRoot: "editors/vscode-prototype/test/fixtures/live-workspace",
       defaultModule: "pkg_defs",
       defaultDeclarationKind: "package",
       pythonPath: "python-custom",
@@ -247,7 +251,7 @@ async function testShowLiveWorkspaceNavigationAction() {
     "--mode",
     "live",
     "--locate",
-    "fixtures/modules",
+    "editors/vscode-prototype/test/fixtures/live-workspace",
     "pkg_defs",
     "--kind",
     "package",

--- a/editors/vscode-prototype/test/context-bundle.test.mjs
+++ b/editors/vscode-prototype/test/context-bundle.test.mjs
@@ -93,7 +93,30 @@ function fixtureInput() {
         path: "/repo/.codex/private-worker/notes.md",
         text: "private worker instruction\n",
       },
+      {
+        path: "/repo/AGENTS.md",
+        text: "private worker instruction\n",
+      },
+      {
+        path: "/repo/package-lock.json",
+        text: "{\"packages\":{}}\n",
+      },
     ],
+    configuration: {
+      mode: "checkedExample",
+      liveWorkspace: { enabled: false },
+      aiAssistant: { enabled: false, backend: "none" },
+      pccxLab: { commandBoundary: "pccx_ide_cli" },
+    },
+    recentCommandStatus: {
+      commandId: "pccxSystemVerilog.publishCheckedExampleDiagnostics",
+      ok: true,
+      actionKind: "diagnostics",
+      summary: "1 diagnostic(s)",
+      facade: { command: "diagnostics", mode: "example" },
+      diagnosticCount: 1,
+      navigationItemCount: 0,
+    },
     recentValidation: {
       status: "failed",
       summary: "1 diagnostic",
@@ -123,6 +146,8 @@ function testStableBoundedShape() {
 
   assert.equal(bundle.version, CONTEXT_BUNDLE_VERSION);
   assert.equal(bundle.source, "pccx-systemverilog-ide");
+  assert.equal(bundle.configuration.mode, "checkedExample");
+  assert.equal(bundle.configuration.aiAssistant.backend, "none");
   assert.deepEqual(bundle.selectedFile, { path: "rtl/top.sv" });
   assert.equal(bundle.diagnostics.length, 1);
   assert.equal(bundle.diagnostics[0].path, "rtl/a.sv");
@@ -130,8 +155,12 @@ function testStableBoundedShape() {
   assert.deepEqual(bundle.snippets.map((snippet) => snippet.path), ["rtl/a.sv", "rtl/z.sv"]);
   assert.ok(bundle.snippets.every((snippet) => snippet.lines.length <= 2));
   assert.equal(bundle.validation.recent.status, "failed");
+  assert.equal(bundle.recentCommand.commandId, "pccxSystemVerilog.publishCheckedExampleDiagnostics");
+  assert.equal(bundle.recentCommand.facade.mode, "example");
   assert.equal(bundle.pccxLab.outputs.length, 1);
   assert.deepEqual(bundle.pccxLab.outputs[0].lines, ["[redacted]"]);
+  assert.ok(bundle.excludedPathPatterns.includes("AGENTS.md"));
+  assert.equal(bundle.redaction.assignmentPolicy, "secret-like-lines-redacted");
   assert.deepEqual(summarizeContextBundle(bundle), {
     version: CONTEXT_BUNDLE_VERSION,
     selectedFile: { path: "rtl/top.sv" },
@@ -159,6 +188,100 @@ function testDeterministicOrdering() {
   );
 }
 
+function testSelectedFileSnippetAndDiagnosticsArePrioritized() {
+  const bundle = buildContextBundle(
+    {
+      workspaceRoot: "/repo",
+      selectedFilePath: "/repo/rtl/z_selected.sv",
+      selectedRange: {
+        start: { line: 7, character: 0 },
+        end: { line: 9, character: 0 },
+      },
+      files: [
+        { path: "/repo/rtl/a_first.sv", text: "module a_first;\nendmodule\n" },
+        { path: "/repo/rtl/z_selected.sv", text: "module z_selected;\nendmodule\n" },
+      ],
+      activeDiagnostics: [
+        {
+          file: "/repo/rtl/a_first.sv",
+          message: "unrelated",
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 1 },
+          },
+        },
+        {
+          file: "/repo/rtl/z_selected.sv",
+          message: "selected range diagnostic",
+          range: {
+            start: { line: 8, character: 0 },
+            end: { line: 8, character: 1 },
+          },
+        },
+      ],
+    },
+    {
+      workspaceRoot: "/repo",
+      limits: {
+        maxFiles: 1,
+        maxDiagnostics: 1,
+      },
+    },
+  );
+
+  assert.deepEqual(bundle.snippets.map((snippet) => snippet.path), ["rtl/z_selected.sv"]);
+  assert.deepEqual(bundle.diagnostics.map((diagnostic) => diagnostic.path), ["rtl/z_selected.sv"]);
+  assert.equal(bundle.diagnostics[0].message, "selected range diagnostic");
+}
+
+function testInvalidSelectedSymbolAndRangesAreControlled() {
+  const bundle = buildContextBundle(
+    {
+      workspaceRoot: "/repo",
+      selectedFilePath: "/repo/rtl/top.sv",
+      selectedRange: {
+        start: { line: 5, character: 10 },
+        end: { line: 4, character: 1 },
+      },
+      selectedSymbol: {
+        name: "ignored",
+        kind: "module",
+        path: "/repo/node_modules/pkg/ignored.sv",
+      },
+    },
+    { workspaceRoot: "/repo" },
+  );
+
+  assert.deepEqual(bundle.selectedRange, {
+    start: { line: 5, character: 10 },
+    end: { line: 5, character: 10 },
+  });
+  assert.equal(bundle.symbols.selected, null);
+}
+
+function testLongSingleLineSnippetReportsTruncation() {
+  const bundle = buildContextBundle(
+    {
+      workspaceRoot: "/repo",
+      selectedFilePath: "/repo/rtl/top.sv",
+      files: [
+        { path: "/repo/rtl/top.sv", text: "module top; " + "x".repeat(200) },
+      ],
+    },
+    {
+      workspaceRoot: "/repo",
+      limits: {
+        maxTextCharacters: 24,
+        maxSnippetLines: 10,
+      },
+    },
+  );
+
+  assert.equal(bundle.snippets.length, 1);
+  assert.equal(bundle.snippets[0].truncated, true);
+  assert.ok(bundle.snippets[0].lines[0].length <= 24);
+}
+
 function testNoHugeFileOrRestrictedPathInclusion() {
   const hugeText = Array.from({ length: 100 }, (_, index) => `line ${index}`).join("\n");
   const bundle = buildContextBundle(
@@ -168,6 +291,8 @@ function testNoHugeFileOrRestrictedPathInclusion() {
         { path: "/repo/rtl/huge.sv", text: hugeText },
         { path: "/repo/node_modules/pkg/ignored.sv", text: hugeText },
         { path: "/repo/.vscode-test/ignored.sv", text: hugeText },
+        { path: "/repo/AGENTS.md", text: hugeText },
+        { path: "/repo/package-lock.json", text: hugeText },
       ],
       activeDiagnostics: [
         { file: "/repo/node_modules/pkg/ignored.sv", message: "ignored" },
@@ -196,9 +321,50 @@ function testNoSecretValuesOrSecretLikeKeys() {
   assert.doesNotMatch(serialized, /token=hidden/);
 }
 
+function testNoAbsoluteHomePathLeakage() {
+  const bundle = buildContextBundle(
+    {
+      workspaceRoot: "/home/dev/work/repo",
+      selectedFilePath: "/home/dev/work/repo/rtl/top.sv",
+      files: [
+        { path: "/home/dev/work/repo/rtl/top.sv", text: "module top;\nendmodule\n" },
+        { path: "/home/dev/.ssh/config", text: "Host example\n" },
+      ],
+      activeDiagnostics: [
+        { file: "/home/dev/work/repo/rtl/top.sv", message: "inside" },
+        { file: "/home/dev/outside.sv", message: "outside" },
+      ],
+    },
+    { workspaceRoot: "/home/dev/work/repo" },
+  );
+  const serialized = JSON.stringify(bundle);
+
+  assert.deepEqual(bundle.selectedFile, { path: "rtl/top.sv" });
+  assert.equal(bundle.snippets.length, 1);
+  assert.equal(bundle.diagnostics.length, 1);
+  assert.doesNotMatch(serialized, /\/home\/dev/);
+  assert.doesNotMatch(serialized, /\.ssh/);
+}
+
+function testNoActiveEditorContextShape() {
+  const bundle = buildContextBundle({}, {});
+
+  assert.equal(bundle.selectedFile, null);
+  assert.equal(bundle.selectedRange, null);
+  assert.deepEqual(bundle.diagnostics, []);
+  assert.deepEqual(bundle.snippets, []);
+  assert.equal(bundle.recentCommand, null);
+  assert.equal(bundle.configuration.mode, "unknown");
+}
+
 testStableBoundedShape();
 testDeterministicOrdering();
+testSelectedFileSnippetAndDiagnosticsArePrioritized();
+testInvalidSelectedSymbolAndRangesAreControlled();
+testLongSingleLineSnippetReportsTruncation();
 testNoHugeFileOrRestrictedPathInclusion();
 testNoSecretValuesOrSecretLikeKeys();
+testNoAbsoluteHomePathLeakage();
+testNoActiveEditorContextShape();
 
 console.log("vscode context bundle tests ok");

--- a/editors/vscode-prototype/test/extension-config.test.mjs
+++ b/editors/vscode-prototype/test/extension-config.test.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import {
   AI_ASSISTANT_BACKENDS,
   DECLARATION_KINDS,
+  FACADE_COMMAND_IDS,
   MODES,
   buildFacadeArgsForCommand,
   defaultConfig,
@@ -24,6 +25,7 @@ const REQUIRED_SETTINGS = new Map([
   ["pccxSystemVerilog.pythonPath", { type: "string", default: "python3" }],
   ["pccxSystemVerilog.defaultSource", { type: "string", default: "fixtures/missing_endmodule.sv" }],
   ["pccxSystemVerilog.defaultLog", { type: "string", default: "fixtures/xsim/mixed.log" }],
+  ["pccxSystemVerilog.defaultNavigationRoot", { type: "string", default: "fixtures/modules" }],
   ["pccxSystemVerilog.defaultModule", { type: "string", default: "simple_mod" }],
   ["pccxSystemVerilog.defaultDeclarationKind", { type: "string", default: "module" }],
 ]);
@@ -84,6 +86,7 @@ function testDefaultConfig() {
     pythonPath: "python3",
     defaultSource: "fixtures/missing_endmodule.sv",
     defaultLog: "fixtures/xsim/mixed.log",
+    defaultNavigationRoot: "fixtures/modules",
     defaultModule: "simple_mod",
     defaultDeclarationKind: "module",
   });
@@ -117,6 +120,10 @@ function testNormalizeConfigRejectsInvalidSettings() {
   assert.throws(
     () => normalizeConfig({ defaultSource: "fixtures/ok_module.sv; rm -rf /" }),
     /pccxSystemVerilog\.defaultSource must not contain shell control syntax/,
+  );
+  assert.throws(
+    () => normalizeConfig({ defaultNavigationRoot: "fixtures/modules && whoami" }),
+    /pccxSystemVerilog\.defaultNavigationRoot must not contain shell control syntax/,
   );
 }
 
@@ -164,6 +171,7 @@ function testFacadeArgsUseNormalizedLiveConfig() {
       "liveWorkspace.enabled": true,
       defaultSource: "rtl/top.sv",
       defaultLog: "logs/xsim.log",
+      defaultNavigationRoot: "rtl",
       pythonPath: "python-custom",
     }),
     ["diagnostics", "--mode", "live", "--from-check", "rtl/top.sv"],
@@ -173,10 +181,11 @@ function testFacadeArgsUseNormalizedLiveConfig() {
     buildFacadeArgsForCommand("pccxSystemVerilog.runNavigationLive", {
       mode: "liveWorkspace",
       liveWorkspace: { enabled: true },
+      defaultNavigationRoot: "rtl",
       defaultModule: "pkg_defs",
       defaultDeclarationKind: "any",
     }),
-    ["navigation", "--mode", "live", "--locate", "fixtures/modules", "pkg_defs", "--kind", "any"],
+    ["navigation", "--mode", "live", "--locate", "rtl", "pkg_defs", "--kind", "any"],
   );
 }
 
@@ -208,16 +217,7 @@ function testUnknownCommandAndShellShape() {
     /unknown PCCX SystemVerilog command/,
   );
 
-  for (const commandId of [
-    "pccxSystemVerilog.showDiagnosticsExample",
-    "pccxSystemVerilog.publishCheckedExampleDiagnostics",
-    "pccxSystemVerilog.showCheckedExampleNavigation",
-    "pccxSystemVerilog.showNavigationExample",
-    "pccxSystemVerilog.publishLiveWorkspaceDiagnostics",
-    "pccxSystemVerilog.showLiveWorkspaceNavigation",
-    "pccxSystemVerilog.runDiagnosticsLive",
-    "pccxSystemVerilog.runNavigationLive",
-  ]) {
+  for (const commandId of FACADE_COMMAND_IDS) {
     const args = commandId.includes("Live")
       ? buildFacadeArgsForCommand(commandId, LIVE_WORKSPACE_CONFIG)
       : buildFacadeArgsForCommand(commandId);

--- a/editors/vscode-prototype/test/extension-entrypoint.test.mjs
+++ b/editors/vscode-prototype/test/extension-entrypoint.test.mjs
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
 
 import {
+  AI_CONTEXT_BUNDLE_COMMAND,
+  AI_ASSISTANT_STATUS_COMMAND,
   COMMAND_IDS,
   CHECKED_EXAMPLE_NAVIGATION_COMMAND,
+  FACADE_COMMAND_IDS,
   activate,
   buildFacadeArgsForCommand,
   buildFacadeInvocationForCommand,
@@ -76,7 +79,7 @@ function configFor(commandId) {
 }
 
 function testKnownFacadeArgs() {
-  for (const commandId of COMMAND_IDS) {
+  for (const commandId of FACADE_COMMAND_IDS) {
     assert.deepEqual(
       buildFacadeArgsForCommand(commandId, configFor(commandId)),
       EXPECTED_ARGS.get(commandId),
@@ -215,6 +218,7 @@ function testResolveCommandRequestUsesVsCodeSettings() {
     ["pythonPath", "python-custom"],
     ["defaultSource", "configured.sv"],
     ["defaultLog", "configured.log"],
+    ["defaultNavigationRoot", "configured/modules"],
     ["defaultModule", "pkg_defs"],
     ["defaultDeclarationKind", "package"],
   ]);
@@ -246,6 +250,7 @@ function testResolveCommandRequestUsesVsCodeSettings() {
     pythonPath: "python-custom",
     defaultSource: "configured.sv",
     defaultLog: "configured.log",
+    defaultNavigationRoot: "configured/modules",
     defaultModule: "pkg_defs",
     defaultDeclarationKind: "package",
   });
@@ -266,6 +271,7 @@ function testResolveCommandRequestUsesVsCodeSettings() {
       pythonPath: "python-custom",
       defaultSource: "configured.sv",
       defaultLog: "configured.log",
+      defaultNavigationRoot: "configured/modules",
       defaultModule: "pkg_defs",
       defaultDeclarationKind: "package",
     },
@@ -287,6 +293,7 @@ function testResolveCommandRequestUsesVsCodeSettings() {
       pythonPath: "python-custom",
       defaultSource: "configured.sv",
       defaultLog: "configured.log",
+      defaultNavigationRoot: "configured/modules",
       defaultModule: "pkg_defs",
       defaultDeclarationKind: "package",
     },
@@ -308,6 +315,7 @@ function testResolveCommandRequestUsesVsCodeSettings() {
       pythonPath: "python-custom",
       defaultSource: "explicit.sv",
       defaultLog: "configured.log",
+      defaultNavigationRoot: "configured/modules",
       defaultModule: "pkg_defs",
       defaultDeclarationKind: "package",
     },
@@ -607,6 +615,132 @@ async function testCommandHandlerCanBeUsedWithoutRealVsCode() {
   assert.equal(result.ok, true);
 }
 
+async function testAIStatusCommandReturnsDisabledBackendNone() {
+  const handler = createCommandHandler(AI_ASSISTANT_STATUS_COMMAND, null, {});
+
+  const result = await handler();
+
+  assert.equal(result.ok, true);
+  assert.equal(result.commandId, AI_ASSISTANT_STATUS_COMMAND);
+  assert.equal(result.status.status, "disabled");
+  assert.equal(result.status.backend, "none");
+  assert.equal(result.status.providerCalls, false);
+  assert.equal(result.status.runtimeCalls, false);
+  assert.equal(result.status.providerCallsImplemented, false);
+  assert.equal(result.status.runtimeCallsImplemented, false);
+  assert.equal(result.status.mcpServerImplemented, false);
+  assert.deepEqual(
+    result.status.allowedActions.map((action) => action.kind),
+    [
+      "explainDiagnostics",
+      "proposePatch",
+      "proposeValidationCommand",
+      "summarizeLog",
+      "askForMoreContext",
+      "openRelatedSymbol",
+    ],
+  );
+  assert.ok(result.status.allowedActions.every((action) => action.execution === "proposalOnly"));
+  assert.ok(result.status.disallowedActions.includes("writeFile"));
+  assert.ok(result.status.disallowedActions.includes("release"));
+  assert.ok(result.status.disallowedActions.includes("accessSecrets"));
+}
+
+async function testAIContextBundleCommandUsesActiveEditorSelectionAndDiagnostics() {
+  const document = {
+    uri: { fsPath: "/repo/rtl/top.sv" },
+    languageId: "systemverilog",
+    getText(range) {
+      assert.equal(range.start.line, 0);
+      return "module top;\nendmodule\n";
+    },
+  };
+  const selection = {
+    start: { line: 0, character: 0 },
+    end: { line: 1, character: 9 },
+  };
+  const vscodeApi = {
+    DiagnosticSeverity: {
+      Error: 0,
+      Warning: 1,
+      Information: 2,
+      Hint: 3,
+    },
+    workspace: {
+      workspaceFolders: [{ uri: { fsPath: "/repo" } }],
+      getWorkspaceFolder() {
+        return { uri: { fsPath: "/repo" } };
+      },
+    },
+    window: {
+      activeTextEditor: {
+        document,
+        selection,
+      },
+    },
+    languages: {
+      getDiagnostics(uri) {
+        assert.equal(uri.fsPath, "/repo/rtl/top.sv");
+        return [
+          {
+            range: {
+              start: { line: 0, character: 0 },
+              end: { line: 0, character: 6 },
+            },
+            severity: 0,
+            message: "missing endmodule",
+            source: "pccx_ide_cli",
+            code: "PCCX-SCAFFOLD-003",
+          },
+        ];
+      },
+    },
+  };
+  const runtime = {
+    recentNavigationItems: [
+      {
+        name: "top",
+        kind: "module",
+        file: "/repo/rtl/top.sv",
+        line: 1,
+        column: 1,
+      },
+    ],
+    recentCommandStatus: {
+      commandId: "pccxSystemVerilog.publishCheckedExampleDiagnostics",
+      ok: true,
+      actionKind: "diagnostics",
+      summary: "1 diagnostic(s)",
+      facade: { command: "diagnostics", mode: "example" },
+      diagnosticCount: 1,
+      navigationItemCount: 0,
+    },
+  };
+  const handler = createCommandHandler(AI_CONTEXT_BUNDLE_COMMAND, vscodeApi, runtime);
+
+  const result = await handler();
+
+  assert.equal(result.ok, true);
+  assert.equal(result.commandId, AI_CONTEXT_BUNDLE_COMMAND);
+  assert.equal(result.kind, "ai-context-bundle");
+  assert.equal(result.status, "disabled");
+  assert.equal(result.backend, "none");
+  assert.equal(result.providerCalls, false);
+  assert.equal(result.runtimeCalls, false);
+  assert.deepEqual(result.contextBundle.selectedFile, { path: "rtl/top.sv" });
+  assert.equal(result.contextBundle.selectedRange.start.line, 0);
+  assert.equal(result.contextBundle.configuration.mode, "checkedExample");
+  assert.equal(result.contextBundle.configuration.aiAssistant.enabled, false);
+  assert.equal(result.contextBundle.diagnostics.length, 1);
+  assert.equal(result.contextBundle.diagnostics[0].path, "rtl/top.sv");
+  assert.equal(result.contextBundle.snippets.length, 1);
+  assert.equal(result.contextBundle.snippets[0].path, "rtl/top.sv");
+  assert.equal(result.contextBundle.symbols.declarations.length, 1);
+  assert.equal(result.contextBundle.symbols.declarations[0].path, "rtl/top.sv");
+  assert.equal(result.contextBundle.recentCommand.commandId, "pccxSystemVerilog.publishCheckedExampleDiagnostics");
+  assert.doesNotMatch(JSON.stringify(result.contextBundle), /\/repo/);
+}
+
 testKnownFacadeArgs();
 testUnknownCommandsRejected();
 testCheckedExampleDiagnosticsCommandStaysExampleMode();
@@ -621,5 +755,7 @@ await testCheckedExampleDefinitionProviderReturnsLocations();
 await testActivationRegistersCheckedExampleDefinitionProvider();
 await testNoVsCodeRuntimeIsANoop();
 await testCommandHandlerCanBeUsedWithoutRealVsCode();
+await testAIStatusCommandReturnsDisabledBackendNone();
+await testAIContextBundleCommandUsesActiveEditorSelectionAndDiagnostics();
 
 console.log("vscode extension entrypoint tests ok");

--- a/editors/vscode-prototype/test/extension-host-readiness.test.mjs
+++ b/editors/vscode-prototype/test/extension-host-readiness.test.mjs
@@ -89,7 +89,7 @@ async function testReadinessDocsAndCiPolicy() {
   assert.match(readiness, /local-only Extension Host runtime smoke/i);
   assert.match(readiness, /not a product claim/i);
   assert.match(readiness, /PCCX_RUN_EXTENSION_HOST_SMOKE=1/);
-  assert.match(readiness, /does not imply\s+marketplace readiness/i);
+  assert.match(readiness, /marketplace packaging/i);
   assert.match(readiness, /(?:not LSP|LSP support|LSP server)/i);
   assert.match(readiness, /(?:not a stable ABI\/API|stable ABI\/API claim)/i);
   assert.match(readiness, /facade boundary/i);
@@ -99,6 +99,10 @@ async function testReadinessDocsAndCiPolicy() {
   assert.match(`${readme}\n${readiness}`, /VS Code-native\s+provider smoke/i);
   assert.match(`${readme}\n${readiness}`, /command-first navigation/i);
   assert.match(`${readme}\n${readiness}`, /live workspace .*opt-in/i);
+  assert.match(`${readme}\n${readiness}`, /controlled fixture/i);
+  assert.match(`${readme}\n${readiness}`, /showAIAssistantStatus/);
+  assert.match(`${readme}\n${readiness}`, /buildAIContextBundle/);
+  assert.match(`${readme}\n${readiness}`, /context bundle command/i);
   assert.match(`${readme}\n${readiness}`, /AI assistant .*boundary/i);
   assert.match(`${readme}\n${readiness}`, /pccx-llm-launcher .*future local LLM\/chat backend/i);
   assert.match(`${readme}\n${readiness}`, /no LSP provider/i);
@@ -129,6 +133,8 @@ async function testRuntimeRunnerIsPinnedAndBounded() {
   assert.match(runner, /VSCODE_TEST_VERSION = "1\.90\.2"/);
   assert.match(runner, /runTests/);
   assert.match(runner, /extensionDevelopmentPath/);
+  assert.match(runner, /LIVE_WORKSPACE_FIXTURE/);
+  assert.match(runner, /test\/fixtures\/live-workspace/);
   assert.match(runner, /\.vscode-test/);
   assert.match(runner, /--extensions-dir=/);
   assert.match(runner, /--user-data-dir=/);
@@ -136,7 +142,12 @@ async function testRuntimeRunnerIsPinnedAndBounded() {
   assert.match(suite, /publishCheckedExampleDiagnostics/);
   assert.match(suite, /showCheckedExampleNavigation/);
   assert.match(suite, /publishLiveWorkspaceDiagnostics/);
+  assert.match(suite, /showLiveWorkspaceNavigation/);
   assert.match(suite, /live workspace commands require/);
+  assert.match(suite, /broken_missing_endmodule\.sv/);
+  assert.match(suite, /showAIAssistantStatus/);
+  assert.match(suite, /buildAIContextBundle/);
+  assert.match(suite, /providerCallsImplemented/);
   assert.match(suite, /getDiagnostics/);
   assert.match(suite, /DiagnosticSeverity\.Error/);
   assert.match(suite, /navigationResult\.locations/);

--- a/editors/vscode-prototype/test/extension-host/run-extension-host-smoke.mjs
+++ b/editors/vscode-prototype/test/extension-host/run-extension-host-smoke.mjs
@@ -1,6 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { runTests } from "@vscode/test-electron";
@@ -10,41 +8,31 @@ import { COMMAND_IDS } from "../../src/config.mjs";
 const EXTENSION_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const ROOT = resolve(EXTENSION_ROOT, "../..");
 const VSCODE_TEST_VERSION = "1.90.2";
-
-async function createWorkspace() {
-  const workspace = await mkdtemp(join(tmpdir(), "pccx-vscode-extension-host-"));
-  await writeFile(
-    join(workspace, "smoke.sv"),
-    "module smoke;\nendmodule\n",
-    "utf8",
-  );
-  return workspace;
-}
+const LIVE_WORKSPACE_FIXTURE = resolve(
+  EXTENSION_ROOT,
+  "test/fixtures/live-workspace",
+);
 
 async function main() {
-  const workspace = await createWorkspace();
-  try {
-    await runTests({
-      version: VSCODE_TEST_VERSION,
-      cachePath: resolve(EXTENSION_ROOT, ".vscode-test"),
-      extensionDevelopmentPath: EXTENSION_ROOT,
-      extensionTestsPath: resolve(EXTENSION_ROOT, "test/extension-host/smoke-suite.cjs"),
-      launchArgs: [
-        workspace,
-        `--extensions-dir=${resolve(EXTENSION_ROOT, ".vscode-test/extensions")}`,
-        `--user-data-dir=${resolve(EXTENSION_ROOT, ".vscode-test/user-data")}`,
-        "--disable-extensions",
-      ],
-      extensionTestsEnv: {
-        PCCX_EXTENSION_ROOT: EXTENSION_ROOT,
-        PCCX_REPO_ROOT: ROOT,
-        PCCX_EXPECTED_COMMAND_IDS: COMMAND_IDS.join(","),
-        PCCX_VSCODE_TEST_VERSION: VSCODE_TEST_VERSION,
-      },
-    });
-  } finally {
-    await rm(workspace, { recursive: true, force: true });
-  }
+  await runTests({
+    version: VSCODE_TEST_VERSION,
+    cachePath: resolve(EXTENSION_ROOT, ".vscode-test"),
+    extensionDevelopmentPath: EXTENSION_ROOT,
+    extensionTestsPath: resolve(EXTENSION_ROOT, "test/extension-host/smoke-suite.cjs"),
+    launchArgs: [
+      LIVE_WORKSPACE_FIXTURE,
+      `--extensions-dir=${resolve(EXTENSION_ROOT, ".vscode-test/extensions")}`,
+      `--user-data-dir=${resolve(EXTENSION_ROOT, ".vscode-test/user-data")}`,
+      "--disable-extensions",
+    ],
+    extensionTestsEnv: {
+      PCCX_EXTENSION_ROOT: EXTENSION_ROOT,
+      PCCX_REPO_ROOT: ROOT,
+      PCCX_EXPECTED_COMMAND_IDS: COMMAND_IDS.join(","),
+      PCCX_LIVE_WORKSPACE_FIXTURE: LIVE_WORKSPACE_FIXTURE,
+      PCCX_VSCODE_TEST_VERSION: VSCODE_TEST_VERSION,
+    },
+  });
 }
 
 await main();

--- a/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
+++ b/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
@@ -26,9 +26,30 @@ async function importExtensionEntrypoint() {
   return import(pathToFileURL(entrypoint).href);
 }
 
+async function updatePrototypeConfig(key, value) {
+  await vscode.workspace
+    .getConfiguration("pccxSystemVerilog")
+    .update(key, value, vscode.ConfigurationTarget.Global);
+}
+
+async function resetPrototypeConfig() {
+  await updatePrototypeConfig("mode", "checkedExample");
+  await updatePrototypeConfig("liveWorkspace.enabled", false);
+  await updatePrototypeConfig("aiAssistant.enabled", false);
+  await updatePrototypeConfig("aiAssistant.backend", "none");
+  await updatePrototypeConfig("pythonPath", "python3");
+  await updatePrototypeConfig("pccxLab.command", "pccx_ide_cli");
+  await updatePrototypeConfig("defaultSource", "fixtures/missing_endmodule.sv");
+  await updatePrototypeConfig("defaultNavigationRoot", "fixtures/modules");
+  await updatePrototypeConfig("defaultModule", "simple_mod");
+  await updatePrototypeConfig("defaultDeclarationKind", "module");
+}
+
 async function run() {
   assert.ok(extensionRoot, "PCCX_EXTENSION_ROOT must be set");
   assert.ok(process.env.PCCX_REPO_ROOT, "PCCX_REPO_ROOT must be set");
+  assert.ok(process.env.PCCX_LIVE_WORKSPACE_FIXTURE, "PCCX_LIVE_WORKSPACE_FIXTURE must be set");
+  await resetPrototypeConfig();
   assert.deepEqual(expectedCommandIds, [
     "pccxSystemVerilog.publishCheckedExampleDiagnostics",
     "pccxSystemVerilog.showCheckedExampleNavigation",
@@ -38,6 +59,8 @@ async function run() {
     "pccxSystemVerilog.showNavigationExample",
     "pccxSystemVerilog.runDiagnosticsLive",
     "pccxSystemVerilog.runNavigationLive",
+    "pccxSystemVerilog.showAIAssistantStatus",
+    "pccxSystemVerilog.buildAIContextBundle",
   ]);
 
   const manifest = readManifest();
@@ -72,6 +95,12 @@ async function run() {
   );
   assert.equal(disabledLiveWorkspaceResult.ok, false);
   assert.match(disabledLiveWorkspaceResult.error, /live workspace commands require/);
+
+  const disabledLiveNavigationResult = await vscode.commands.executeCommand(
+    "pccxSystemVerilog.showLiveWorkspaceNavigation",
+  );
+  assert.equal(disabledLiveNavigationResult.ok, false);
+  assert.match(disabledLiveNavigationResult.error, /live workspace commands require/);
 
   const result = await vscode.commands.executeCommand(
     "pccxSystemVerilog.publishCheckedExampleDiagnostics",
@@ -144,6 +173,10 @@ async function run() {
 
   const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
   assert.ok(workspaceRoot, "runtime smoke workspace was not opened");
+  assert.equal(
+    path.resolve(workspaceRoot),
+    path.resolve(process.env.PCCX_LIVE_WORKSPACE_FIXTURE),
+  );
   const definitionUri = vscode.Uri.file(path.join(workspaceRoot, "smoke.sv"));
   const document = await vscode.workspace.openTextDocument(definitionUri);
   assert.equal(document.uri.toString(), definitionUri.toString());
@@ -168,9 +201,95 @@ async function run() {
     providerLocation.range.start.character + 1,
   );
 
+  const liveBrokenPath = path.join(workspaceRoot, "broken_missing_endmodule.sv");
+  await updatePrototypeConfig("mode", "liveWorkspace");
+  await updatePrototypeConfig("liveWorkspace.enabled", true);
+  await updatePrototypeConfig("defaultSource", liveBrokenPath);
+  await updatePrototypeConfig("defaultNavigationRoot", workspaceRoot);
+  await updatePrototypeConfig("defaultModule", "live_top");
+  await updatePrototypeConfig("defaultDeclarationKind", "module");
+
+  const liveResult = await vscode.commands.executeCommand(
+    "pccxSystemVerilog.publishLiveWorkspaceDiagnostics",
+    vscode.Uri.file(liveBrokenPath),
+  );
+  assert.equal(liveResult.ok, true);
+  assert.equal(liveResult.commandId, "pccxSystemVerilog.publishLiveWorkspaceDiagnostics");
+  assert.equal(liveResult.action.kind, "diagnostics");
+  assert.equal(liveResult.plan.config.mode, "liveWorkspace");
+  assert.equal(liveResult.plan.config.liveWorkspace.enabled, true);
+  assert.deepEqual(liveResult.plan.facadeArgs.slice(0, 3), [
+    "diagnostics",
+    "--mode",
+    "live",
+  ]);
+  assert.equal(liveResult.plan.facadeArgs[3], "--from-check");
+  assert.equal(liveResult.plan.facadeArgs[4], liveBrokenPath);
+  assert.ok(liveResult.action.diagnostics.length > 0);
+  assert.ok(
+    liveResult.action.diagnostics.every((diagnostic) => (
+      path.resolve(diagnostic.file) === path.resolve(liveBrokenPath)
+    )),
+    "live diagnostics must come from the controlled fixture, not checked examples",
+  );
+  assert.ok(
+    liveResult.action.diagnostics.every((diagnostic) => (
+      diagnostic.file !== "fixtures/missing_endmodule.sv"
+    )),
+    "live diagnostics unexpectedly fell back to the checked example fixture",
+  );
+  const liveDiagnostics = vscode.languages.getDiagnostics(vscode.Uri.file(liveBrokenPath));
+  assert.ok(liveDiagnostics.length > 0, "live fixture diagnostics were not published");
+
+  const aiStatus = await vscode.commands.executeCommand(
+    "pccxSystemVerilog.showAIAssistantStatus",
+  );
+  assert.equal(aiStatus.ok, true);
+  assert.equal(aiStatus.status.status, "disabled");
+  assert.equal(aiStatus.status.backend, "none");
+  assert.equal(aiStatus.status.providerCalls, false);
+  assert.equal(aiStatus.status.runtimeCalls, false);
+  assert.equal(aiStatus.status.providerCallsImplemented, false);
+  assert.equal(aiStatus.status.runtimeCallsImplemented, false);
+  assert.equal(aiStatus.status.mcpServerImplemented, false);
+  assert.ok(aiStatus.status.allowedActions.some((action) => action.kind === "proposePatch"));
+  assert.ok(aiStatus.status.disallowedActions.includes("writeFile"));
+  assert.ok(aiStatus.status.disallowedActions.includes("release"));
+
+  const liveDocument = await vscode.workspace.openTextDocument(vscode.Uri.file(liveBrokenPath));
+  const liveEditor = await vscode.window.showTextDocument(liveDocument, { preview: false });
+  liveEditor.selection = new vscode.Selection(0, 0, 0, 12);
+  const contextResult = await vscode.commands.executeCommand(
+    "pccxSystemVerilog.buildAIContextBundle",
+  );
+  assert.equal(contextResult.ok, true);
+  assert.equal(contextResult.kind, "ai-context-bundle");
+  assert.equal(contextResult.status, "disabled");
+  assert.equal(contextResult.backend, "none");
+  assert.equal(contextResult.providerCalls, false);
+  assert.equal(contextResult.runtimeCalls, false);
+  assert.deepEqual(contextResult.contextBundle.selectedFile, {
+    path: "broken_missing_endmodule.sv",
+  });
+  assert.equal(contextResult.contextBundle.configuration.mode, "liveWorkspace");
+  assert.equal(contextResult.contextBundle.configuration.aiAssistant.enabled, false);
+  assert.equal(contextResult.contextBundle.configuration.aiAssistant.backend, "none");
+  assert.ok(contextResult.contextBundle.diagnostics.length > 0);
+  assert.equal(contextResult.contextBundle.diagnostics[0].path, "broken_missing_endmodule.sv");
+  assert.equal(contextResult.contextBundle.snippets.length, 1);
+  assert.equal(contextResult.contextBundle.snippets[0].path, "broken_missing_endmodule.sv");
+  assert.equal(
+    contextResult.contextBundle.recentCommand.commandId,
+    "pccxSystemVerilog.publishLiveWorkspaceDiagnostics",
+  );
+  assert.doesNotMatch(JSON.stringify(contextResult.contextBundle), /\/home\//);
+  assert.ok(contextResult.contextBundle.excludedPathPatterns.includes("node_modules/**"));
+  assert.equal(contextResult.contextBundle.redaction.assignmentPolicy, "secret-like-lines-redacted");
+
   const extensionModule = await importExtensionEntrypoint();
   assert.equal(typeof extensionModule.deactivate, "function");
   extensionModule.deactivate();
+  await resetPrototypeConfig();
 }
 
 module.exports = { run };

--- a/editors/vscode-prototype/test/extension-manifest.test.mjs
+++ b/editors/vscode-prototype/test/extension-manifest.test.mjs
@@ -14,6 +14,8 @@ const COMMAND_IDS = [
   "pccxSystemVerilog.showNavigationExample",
   "pccxSystemVerilog.runDiagnosticsLive",
   "pccxSystemVerilog.runNavigationLive",
+  "pccxSystemVerilog.showAIAssistantStatus",
+  "pccxSystemVerilog.buildAIContextBundle",
 ];
 
 async function readText(path) {
@@ -98,7 +100,7 @@ async function testDocsKeepExperimentalScope() {
 
   assert.match(combined, /experimental local VS Code extension scaffold/i);
   assert.match(combined, /not published/i);
-  assert.match(combined, /not marketplace-ready/i);
+  assert.match(combined, /no marketplace packaging/i);
   assert.match(combined, /no LSP/i);
   assert.match(combined, /not a stable ABI\/API/i);
   assert.match(combined, /static\/mock tests/i);
@@ -107,7 +109,9 @@ async function testDocsKeepExperimentalScope() {
   assert.match(combined, /checked-example remains the default/i);
   assert.match(combined, /live workspace .*opt-in/i);
   assert.match(combined, /AI-assisted SystemVerilog development workflow/i);
-  assert.match(combined, /boundary\/stub/i);
+  assert.match(combined, /boundary-only/i);
+  assert.match(combined, /context bundle command/i);
+  assert.match(combined, /AI assistant status command/i);
   assert.match(combined, /no AI provider calls/i);
   assert.match(combined, /no MCP server implementation/i);
 }

--- a/editors/vscode-prototype/test/facade.test.mjs
+++ b/editors/vscode-prototype/test/facade.test.mjs
@@ -64,6 +64,22 @@ async function testDiagnosticsLiveFromCheck() {
   assert.equal(output.diagnostics[0].range.start.line, 0);
 }
 
+async function testDiagnosticsLiveFromControlledFixture() {
+  const fixture = "editors/vscode-prototype/test/fixtures/live-workspace/broken_missing_endmodule.sv";
+  const output = await runSuccess([
+    "diagnostics",
+    "--mode",
+    "live",
+    "--from-check",
+    fixture,
+  ]);
+
+  assert.equal(output.kind, "vscode-diagnostics");
+  assert.equal(output.mode, "live");
+  assert.equal(output.diagnostics.length, 1);
+  assert.equal(output.diagnostics[0].file, fixture);
+}
+
 async function testDiagnosticsLiveFromXsimLog() {
   const output = await runSuccess([
     "diagnostics",
@@ -126,6 +142,29 @@ async function testNavigationLiveLocatePackage() {
   assert.equal(output.items[0].name, "pkg_defs");
 }
 
+async function testNavigationLiveLocateControlledFixture() {
+  const output = await runSuccess([
+    "navigation",
+    "--mode",
+    "live",
+    "--locate",
+    "editors/vscode-prototype/test/fixtures/live-workspace",
+    "live_top",
+    "--kind",
+    "module",
+  ]);
+
+  assert.equal(output.kind, "vscode-navigation");
+  assert.equal(output.mode, "live");
+  assert.equal(output.items.length, 1);
+  assert.equal(output.items[0].kind, "module");
+  assert.equal(output.items[0].name, "live_top");
+  assert.equal(
+    output.items[0].file,
+    "editors/vscode-prototype/test/fixtures/live-workspace/top.sv",
+  );
+}
+
 async function testInvalidModeFails() {
   const result = await runFacade([
     "diagnostics",
@@ -178,10 +217,12 @@ async function testWrongFlowOptionFails() {
 
 await testDiagnosticsExampleMode();
 await testDiagnosticsLiveFromCheck();
+await testDiagnosticsLiveFromControlledFixture();
 await testDiagnosticsLiveFromXsimLog();
 await testNavigationExampleMode();
 await testNavigationLiveDeclarations();
 await testNavigationLiveLocatePackage();
+await testNavigationLiveLocateControlledFixture();
 await testInvalidModeFails();
 await testMissingRequiredArgsFail();
 await testNoArbitraryCommandOption();

--- a/editors/vscode-prototype/test/fixtures/live-workspace/broken_missing_endmodule.sv
+++ b/editors/vscode-prototype/test/fixtures/live-workspace/broken_missing_endmodule.sv
@@ -1,0 +1,1 @@
+module live_broken;

--- a/editors/vscode-prototype/test/fixtures/live-workspace/live_pkg.sv
+++ b/editors/vscode-prototype/test/fixtures/live-workspace/live_pkg.sv
@@ -1,0 +1,2 @@
+package live_pkg;
+endpackage

--- a/editors/vscode-prototype/test/fixtures/live-workspace/smoke.sv
+++ b/editors/vscode-prototype/test/fixtures/live-workspace/smoke.sv
@@ -1,0 +1,2 @@
+module smoke;
+endmodule

--- a/editors/vscode-prototype/test/fixtures/live-workspace/top.sv
+++ b/editors/vscode-prototype/test/fixtures/live-workspace/top.sv
@@ -1,0 +1,2 @@
+module live_top;
+endmodule

--- a/editors/vscode-prototype/test/static-boundary.test.mjs
+++ b/editors/vscode-prototype/test/static-boundary.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -14,34 +14,68 @@ async function readPackageJson() {
   return JSON.parse(await readText(resolve(EXTENSION_ROOT, "package.json")));
 }
 
-async function testNoDirectAiProviderOrNetworkCalls() {
-  const sourceFiles = [
-    "src/ai-assistant-boundary.mjs",
-    "src/context-bundle.mjs",
-    "src/command-handlers.mjs",
-    "src/extension.mjs",
-    "src/definition-provider.mjs",
+async function listFiles(root, options = {}) {
+  const skipDirs = new Set(options.skipDirs ?? [".git", ".vscode-test", "node_modules"]);
+  const allowedExtensions = options.allowedExtensions ?? null;
+  const results = [];
+  async function visit(dir) {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const path = resolve(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (!skipDirs.has(entry.name)) {
+          await visit(path);
+        }
+      } else if (!allowedExtensions || allowedExtensions.some((ext) => path.endsWith(ext))) {
+        results.push(path);
+      }
+    }
+  }
+  await visit(root);
+  return results.sort();
+}
+
+async function readCombined(paths) {
+  return (await Promise.all(paths.map((path) => readText(path)))).join("\n");
+}
+
+async function extensionSourceFiles() {
+  return [
+    ...await listFiles(resolve(EXTENSION_ROOT, "src"), {
+      allowedExtensions: [".mjs", ".cjs", ".js"],
+    }),
+    ...await listFiles(resolve(EXTENSION_ROOT, "bin"), {
+      allowedExtensions: [".mjs", ".cjs", ".js"],
+    }),
   ];
-  const combined = (await Promise.all(
-    sourceFiles.map((file) => readText(resolve(EXTENSION_ROOT, file))),
-  )).join("\n");
+}
+
+async function testNoDirectAiProviderOrNetworkCalls() {
+  const combined = await readCombined(await extensionSourceFiles());
 
   assert.doesNotMatch(combined, /\bfetch\s*\(/);
   assert.doesNotMatch(combined, /XMLHttpRequest/);
+  assert.doesNotMatch(combined, /\bWebSocket\b/);
+  assert.doesNotMatch(combined, /\bEventSource\b/);
   assert.doesNotMatch(combined, /node:https|node:http/);
+  assert.doesNotMatch(combined, /node:net|node:tls/);
   assert.doesNotMatch(combined, /\b(?:openai|anthropic|gemini)\b/i);
   assert.doesNotMatch(combined, /chat\.completions|responses\.create/i);
 }
 
 async function testNoLauncherOrMcpRuntimeImplementation() {
   const manifest = await readPackageJson();
-  const source = await readText(resolve(EXTENSION_ROOT, "src/ai-assistant-boundary.mjs"));
+  const source = await readCombined(await extensionSourceFiles());
   const packageStrings = JSON.stringify({
     dependencies: manifest.dependencies,
     devDependencies: manifest.devDependencies,
   });
 
-  assert.doesNotMatch(source, /execFile|spawn|pccx-llm-launcher.*(?:request|connect|run)/i);
+  assert.doesNotMatch(
+    source,
+    /(?:execFile|spawn|request|connect|run)[\s\S]{0,120}pccx-llm-launcher|pccx-llm-launcher[\s\S]{0,120}(?:execFile|spawn|request|connect|run)/i,
+  );
+  assert.doesNotMatch(source, /\bMcpServer\s*\(|modelcontextprotocol|mcp-server/i);
   assert.doesNotMatch(packageStrings, /modelcontextprotocol|mcp-server|llm-launcher/i);
 }
 
@@ -64,18 +98,75 @@ async function testNoDirectCliCallsFromUiOrProviderLayers() {
 async function testNoPackagingPublisherOrLspDependencies() {
   const manifest = await readPackageJson();
   const manifestText = JSON.stringify(manifest);
+  const repoPolicyFiles = [
+    ...await listFiles(resolve(ROOT, "scripts"), {
+      allowedExtensions: [".sh", ".mjs", ".js", ".py"],
+    }),
+    ...await listFiles(resolve(ROOT, ".github"), {
+      allowedExtensions: [".yml", ".yaml"],
+    }),
+  ];
+  const policyText = `${manifestText}\n${await readCombined(repoPolicyFiles)}`;
 
   assert.equal(Object.hasOwn(manifest, "publisher"), false);
   assert.equal(Object.hasOwn(manifest, "galleryBanner"), false);
   assert.equal(manifest.dependencies, undefined);
   assert.equal(manifest.scripts, undefined);
-  assert.doesNotMatch(manifestText, /\bvsce\b/i);
+  assert.doesNotMatch(policyText, /\bvsce\s+(?:package|publish|login|create-publisher)\b/i);
   assert.doesNotMatch(manifestText, /vscode-languageclient|LanguageClient/);
+}
+
+async function testNoDirectShellInterpolation() {
+  const source = await readCombined([
+    ...await extensionSourceFiles(),
+    ...await listFiles(resolve(ROOT, "src"), {
+      allowedExtensions: [".py"],
+    }),
+  ]);
+
+  assert.doesNotMatch(source, /\bexec\s*\(/);
+  assert.doesNotMatch(source, /shell\s*:\s*true/);
+  assert.doesNotMatch(source, /shell\s*=\s*True/);
+}
+
+async function testNoPositiveReadinessClaims() {
+  const files = [
+    ...await listFiles(ROOT, {
+      allowedExtensions: [".md", ".sh", ".yml", ".yaml", ".py", ".mjs", ".cjs", ".js", ".json"],
+    }),
+  ].filter((path) => (
+    !path.includes("/package-lock.json") &&
+    !path.includes("/tests/") &&
+    !path.endsWith("/editors/vscode-prototype/test/static-boundary.test.mjs")
+  ));
+  const positiveClaim =
+    /\b(?:production[- ]ready|(?<!pre-)stable API|(?<!pre-)stable ABI|(?<!pre-)stable diagnostics envelope|marketplace-ready|complete AI integration)\b/i;
+  const negation = /\b(?:no|not|never|without|does not|is not|are not|avoid|do not)\b/i;
+  const violations = [];
+
+  for (const file of files) {
+    const lines = (await readText(file)).split(/\r?\n/);
+    lines.forEach((line, index) => {
+      const context = [
+        lines[index - 2] ?? "",
+        lines[index - 1] ?? "",
+        line,
+        lines[index + 1] ?? "",
+      ].join(" ");
+      if (positiveClaim.test(line) && !negation.test(context)) {
+        violations.push(`${file}:${index + 1}: ${line}`);
+      }
+    });
+  }
+
+  assert.deepEqual(violations, []);
 }
 
 await testNoDirectAiProviderOrNetworkCalls();
 await testNoLauncherOrMcpRuntimeImplementation();
 await testNoDirectCliCallsFromUiOrProviderLayers();
 await testNoPackagingPublisherOrLspDependencies();
+await testNoDirectShellInterpolation();
+await testNoPositiveReadinessClaims();
 
 console.log("vscode static boundary tests ok");

--- a/src/pccx_ide_cli/__init__.py
+++ b/src/pccx_ide_cli/__init__.py
@@ -1,7 +1,7 @@
 """Scaffold CLI for the pccx SystemVerilog IDE spin-out.
 
 Real analysis is expected to land in pccx-lab and be consumed through its
-CLI / core boundary; this package only emits a stable diagnostics envelope.
+CLI / core boundary; this package emits a pre-stable diagnostics envelope.
 """
 
 __version__ = "0.0.1"


### PR DESCRIPTION
## Summary

This PR keeps the VS Code prototype experimental while adding a controlled live workspace fixture path and local AI assistant boundary commands.

- Adds a tiny `editors/vscode-prototype/test/fixtures/live-workspace` fixture.
- Adds explicit `defaultNavigationRoot` configuration for live navigation roots.
- Extends the opt-in Extension Host smoke to open the fixture workspace, prove disabled live commands fail clearly, run live diagnostics only against the fixture, and verify no checked-example fallback.
- Adds `pccxSystemVerilog.showAIAssistantStatus` and `pccxSystemVerilog.buildAIContextBundle` commands.
- Tightens context bundle limits, deterministic ordering, selected-file priority, path exclusions, redaction metadata, and static guards.
- Updates docs with daily-driver roadmap wording grounded in the current boundary.

## Scope and Boundaries

Experimental only.

- checked-example remains default
- live workspace remains explicit opt-in
- fixture smoke is controlled/local only
- AI assistant commands are context/status only
- no AI provider calls
- no pccx-llm-launcher runtime calls yet
- no MCP server implementation
- no LSP
- no marketplace packaging
- no stable API/ABI claim
- no release/tag

## Local Validation

- `git status --short --branch`
- `npm ci --prefix editors/vscode-prototype`
- `bash scripts/vscode-adapter-smoke.sh`
- `bash scripts/vscode-extension-host-smoke.sh` expected guarded exit 2
- `PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `python3 -m pytest -q`
- `git diff --check`
