### PR TITLE
feat: add selected-symbol context and validation proposals

### DIFF
--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -91,7 +91,8 @@ opt-in and requires both `pccxSystemVerilog.mode=liveWorkspace` and
 commands fail clearly instead of falling back to examples.  The current
 AI-assisted SystemVerilog development workflow work is boundary-only:
 AI assistant status and context bundle commands expose local status,
-bounded context, and proposal actions, with no AI provider calls, no
+bounded context, selected-symbol context, validation command proposal
+data, and proposal actions, with no AI provider calls, no
 pccx-llm-launcher runtime calls yet, and no MCP server implementation.
 
 The same directory now includes an experimental local VS Code extension
@@ -108,7 +109,9 @@ VS Code GUI tests.  A limited opt-in Extension Host runtime smoke exists,
 but it is disabled by default, remains local-only, and is not a product
 claim.  When explicitly enabled, it opens the controlled
 `editors/vscode-prototype/test/fixtures/live-workspace` fixture and runs
-live diagnostics only against that tiny fixture path.
+live diagnostics and live navigation only against that tiny fixture path.
+Live navigation verifies `live_top` through the explicit live workspace
+opt-in command path without falling back to checked examples.
 The scaffold is not published, has no marketplace packaging, has no LSP,
 and is not a stable ABI/API.  Current coverage is mostly static/mock
 tests and smoke tests; CI does not run the real Extension Host runtime
@@ -138,11 +141,12 @@ VS Code command
 
 Future local coding-assistant mode should use the same controlled data
 path.  Context bundle records should carry selected file/range,
-diagnostics, declaration references, recent command status, current mode,
-validation summaries, and bounded snippets by path/range instead of whole
-workspaces.  Any command proposal or validation proposal must route
-through the facade or pccx-lab CLI/core boundary and remain a proposal
-until an editor/user-controlled executor accepts it.
+bounded lexical selected-symbol context, diagnostics, declaration
+references, recent command status, current mode, validation summaries, and
+bounded snippets by path/range instead of whole workspaces.  Any command
+proposal or validation proposal must route through the facade or pccx-lab
+CLI/core boundary and remain a proposal until an editor/user-controlled
+executor accepts it.
 
 `problems` converts local diagnostics and log records into editor-friendly
 problem records.  `index` provides scanner-based module/package/interface

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -27,7 +27,8 @@ rather than being duplicated inside this extension scaffold.
 
 `pccx-llm-launcher` is a future local LLM/chat/model backend candidate.
 This prototype only adds AI assistant status and context bundle commands
-behind a controlled tool boundary.  There are no AI provider calls, no
+behind a controlled tool boundary, plus a validation command proposal
+surface that returns data only.  There are no AI provider calls, no
 pccx-llm-launcher runtime calls, and no MCP server implementation in this
 scaffold.
 
@@ -82,7 +83,10 @@ flow for the configured navigation root, module, and kind.  The older
 `runDiagnosticsLive` and `runNavigationLive` command IDs remain
 experimental opt-in aliases for now.  A controlled tiny fixture workspace
 lives at `test/fixtures/live-workspace`; the opt-in runtime smoke uses
-that fixture only and does not scan a user workspace.
+that fixture only and does not scan a user workspace.  The runtime smoke
+now covers live diagnostics and live navigation against that fixture; live
+navigation returns Location-style data and avoids QuickPick prompts in the
+smoke path.
 
 ## Command Facade
 
@@ -131,6 +135,8 @@ The contributed commands are:
 - `pccxSystemVerilog.runNavigationLive`
 - `pccxSystemVerilog.showAIAssistantStatus`
 - `pccxSystemVerilog.buildAIContextBundle`
+- `pccxSystemVerilog.proposeValidationCommand`
+- `pccxSystemVerilog.showPccxLabBackendStatus`
 
 The prototype-only settings are:
 
@@ -170,6 +176,13 @@ directly from the extension entry point, do not invoke raw shell command
 strings, and do not accept arbitrary command execution.  Live mode calls
 only known facade flows.  Live paths are still prototype-only and are
 passed to known facade flows as argument-array entries.
+
+`pccxSystemVerilog.showPccxLabBackendStatus` prepares a command palette
+status surface for future pccx-lab integration.  It returns the configured
+`pccxSystemVerilog.pccxLab.command` value, marks the integration as a
+placeholder/status-only boundary, lists future controlled operations such
+as diagnostics, index, locate, declarations, xsim-log analysis, and
+validation summary, and does not execute pccx-lab.
 
 `src/command-handlers.mjs` is the experimental local command-handler
 scaffold.  It maps command ID -> normalized prototype settings -> known
@@ -214,9 +227,12 @@ only runs when `PCCX_RUN_EXTENSION_HOST_SMOKE=1` is set.  The runtime
 smoke loads the local extension package, verifies activation/command
 registration, confirms live workspace commands fail clearly while
 disabled, runs live diagnostics against the controlled fixture only, and
-executes the checked-example diagnostics/navigation command paths plus
-the provider smoke.  It also checks the AI assistant status command and
-context bundle command without provider/runtime calls.  It does not
+executes live navigation against the same fixture without QuickPick
+blocking.  It also executes the checked-example diagnostics/navigation
+command paths plus the provider smoke.  It checks the AI assistant status
+command, selected-symbol context bundle command, validation command
+proposal, and pccx-lab backend status command without provider/runtime
+calls.  It does not
 package the extension, add an LSP provider, or install through a
 marketplace flow.  Extension Host gates are
 tracked in
@@ -238,17 +254,28 @@ validation command, or commit is executed outside this proposal boundary.
 future AI-assisted SystemVerilog development workflow experiments.
 `pccxSystemVerilog.buildAIContextBundle` returns a bounded JSON object
 for the active editor state without calling a provider.  It prefers the
-current file path, selected range, active diagnostics, recent navigation
+current file path, selected range, bounded lexical selected-symbol
+context, active diagnostics near the selection, recent navigation
 references, recent command status, current mode/configuration, and small
-bounded snippets only for explicit selections.  It references files by
-path/range instead of including whole workspaces, excludes `node_modules`,
-`.vscode-test`, `AGENTS.md`, `package-lock.json`, binary-like content,
-and private worker instruction paths, and redacts secret-like assignment
-lines.  This is a JSON contract only: no AI provider calls, no
+bounded snippets only for explicit selections.  The selected-symbol
+context extracts simple SystemVerilog-like lexical cues such as the symbol
+text, current line, and nearby module/package/interface/parameter/function
+or task declaration; it is not full semantic analysis.  The bundle
+references files by path/range instead of including whole workspaces,
+excludes dependency caches, generated test runtime directories, lockfiles,
+agent instruction files, binary-like content, and internal instruction
+paths, and redacts secret-like assignment lines.  This is a
+JSON contract only: no AI provider calls, no
 pccx-llm-launcher runtime calls yet, no MCP server implementation, no
 direct file modification, and no stable API claim.
 The boundary notes are tracked in
 [`docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md`](./docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md).
+
+`pccxSystemVerilog.proposeValidationCommand` returns allowlisted
+validation command proposals as JSON data.  The proposal includes
+argument-array templates, reasons, risk levels, and explicit user approval
+requirements.  It does not spawn a process, call pccx-lab, call an AI
+provider, write files, or run git operations.
 
 ## Theme-Neutral Presentation Boundary
 
@@ -274,13 +301,19 @@ Now:
 
 - checked-example diagnostics, navigation, and DefinitionProvider smoke
 - explicit live workspace boundary with controlled fixture diagnostics
+- fixture-backed live navigation smoke
 - AI assistant status command and bounded context bundle command
+- selected-symbol context
+- validation command proposal
+- pccx-lab backend status command
 
 Next:
 
-- fixture-backed live diagnostics/navigation coverage with richer status
-- selected symbol context and definition-aware bundle references
-- validation command proposal and pccx-lab command palette integration
+- pccx-lab command palette execution with allowlisted commands
+- selected-symbol to declaration context through live navigation
+- diagnostics-aware prompt builder
+- validation result cache
+- patch proposal format
 
 Later:
 
@@ -298,7 +331,9 @@ node editors/vscode-prototype/test/facade.test.mjs
 node editors/vscode-prototype/test/extension-manifest.test.mjs
 node editors/vscode-prototype/test/extension-config.test.mjs
 node editors/vscode-prototype/test/context-bundle.test.mjs
+node editors/vscode-prototype/test/selected-symbol-context.test.mjs
 node editors/vscode-prototype/test/ai-assistant-boundary.test.mjs
+node editors/vscode-prototype/test/validation-proposals.test.mjs
 node editors/vscode-prototype/test/static-boundary.test.mjs
 node editors/vscode-prototype/test/extension-entrypoint.test.mjs
 node editors/vscode-prototype/test/command-handlers.test.mjs

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -38,8 +38,16 @@ should earn CI promotion separately.
 - Live CLI runner for known local JSON flows.
 - Controlled live workspace fixture diagnostics in the opt-in Extension
   Host runtime smoke.
+- Fixture-backed live navigation in the opt-in Extension Host runtime
+  smoke, returning Location-style records without QuickPick/UI blocking.
 - AI assistant status and context bundle command smoke with provider and
   runtime calls reported as unimplemented.
+- Selected-symbol context smoke for the context bundle.  The selected
+  symbol context is lexical and bounded, not full semantic analysis.
+- Validation command proposal smoke.  The command returns data only and
+  does not execute validation commands.
+- pccx-lab backend status smoke.  The command reports the configured
+  boundary and does not execute pccx-lab.
 - Guard behavior for the local-only Extension Host runtime smoke.
 - Pinned Extension Host activation and command-registration smoke when
   explicitly enabled locally.
@@ -99,10 +107,17 @@ The enabled live path is limited to the controlled fixture.  The smoke
 explicitly sets `mode=liveWorkspace` and `liveWorkspace.enabled=true`,
 runs `pccxSystemVerilog.publishLiveWorkspaceDiagnostics` against
 `broken_missing_endmodule.sv`, and asserts the returned diagnostics came
-from that fixture rather than checked examples.  It also executes
-`pccxSystemVerilog.showAIAssistantStatus` and
-`pccxSystemVerilog.buildAIContextBundle`, verifying disabled/backend
-`none` status, proposal-only actions, bounded active-file context, and no
+from that fixture rather than checked examples.  It also runs
+`pccxSystemVerilog.showLiveWorkspaceNavigation` with the fixture as the
+navigation root and `live_top` as the requested module, verifies
+Location-style records, and checks that the result did not fall back to
+checked-example symbols.  It executes
+`pccxSystemVerilog.showAIAssistantStatus`,
+`pccxSystemVerilog.buildAIContextBundle`,
+`pccxSystemVerilog.proposeValidationCommand`, and
+`pccxSystemVerilog.showPccxLabBackendStatus`, verifying disabled/backend
+`none` status, proposal-only actions, bounded active-file and
+selected-symbol context, status-only pccx-lab boundary data, and no
 provider/runtime calls.  This is not LSP, and there is no LSP provider
 yet.
 
@@ -116,6 +131,18 @@ actions are modeled as proposals, including command proposal and
 validation proposal shapes, rather than direct execution.  User approval
 is still required before applying patches, running validation commands,
 or committing changes.
+
+`pccxSystemVerilog.proposeValidationCommand` currently proposes only
+allowlisted templates, including the VS Code adapter smoke, editor bridge
+smoke, example drift check, pytest baseline, and opt-in Extension Host
+smoke.  The command returns JSON data with reasons, risk levels, and a
+required user approval marker; it does not execute the command.
+
+`pccxSystemVerilog.showPccxLabBackendStatus` is preparation for future
+command palette integration.  It reports the configured
+`pccxSystemVerilog.pccxLab.command`, lists future controlled operations
+such as diagnostics, index, locate, declarations, xsim-log analysis, and
+validation summary, and does not execute pccx-lab.
 
 The guarded script is not run by CI today.
 

--- a/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
+++ b/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
@@ -5,7 +5,7 @@
 This is experimental boundary documentation for the local VS Code
 prototype.  It is not a production promise, not a stable API/ABI, not
 LSP, has no marketplace packaging, and the AI surface is status/context
-only.
+and proposal data only.
 
 Checked-example remains the default.  Live workspace mode is opt-in and
 requires both:
@@ -66,17 +66,23 @@ The controlled fixture workspace is
 `editors/vscode-prototype/test/fixtures/live-workspace`.  The opt-in
 Extension Host runtime smoke opens that fixture, explicitly enables live
 workspace mode, runs live diagnostics against the tiny broken fixture
-file, and asserts the result did not come from checked examples.  This
-does not make live mode a production promise.
+file, runs live navigation for `live_top`, and asserts the results did
+not come from checked examples.  Live navigation returns structured
+Location-style records in the smoke path and avoids QuickPick/UI prompts.
+This does not make live mode a production promise.
 
 ## AI Assistant Proposal Boundary
 
 The current AI assistant boundary is a proposal model only.
 `pccxSystemVerilog.showAIAssistantStatus` returns local status and
 proposal boundaries.  `pccxSystemVerilog.buildAIContextBundle` returns a
-bounded context bundle for the active editor state.  There are no AI
-provider calls, no external API keys, no pccx-llm-launcher runtime calls
-yet, and no MCP server implementation.
+bounded context bundle for the active editor state.
+`pccxSystemVerilog.proposeValidationCommand` returns allowlisted
+validation command proposals as data and does not execute them.
+`pccxSystemVerilog.showPccxLabBackendStatus` reports the configured
+pccx-lab command boundary and future controlled operations without
+running pccx-lab.  There are no AI provider calls, no external API keys,
+no pccx-llm-launcher runtime calls yet, and no MCP server implementation.
 
 Allowed proposal kinds:
 
@@ -107,7 +113,7 @@ require explicit user approval.
 The context bundle is a token-saving JSON contract.  It prefers:
 
 - selected file path and selected range
-- selected symbol and recent declaration references
+- selected-symbol context and recent declaration references
 - active diagnostics around the selected range
 - current mode/configuration
 - recent command status
@@ -126,10 +132,24 @@ Limits are enforced by `src/context-bundle.mjs`:
 - max text characters
 
 The builder excludes binary-like content, `node_modules`, `.vscode-test`,
-`.git`, `AGENTS.md`, `package-lock.json`, secret-like path names, and
-private worker instruction paths.  It redacts secret-like assignment
+`.git`, lockfiles, agent instruction files, secret-like path names, and
+internal instruction paths.  It redacts secret-like assignment
 lines, emits redaction/exclusion metadata, keeps deterministic ordering,
 and avoids absolute home-path leakage when a workspace root is known.
+
+Selected-symbol context is lexical and bounded.  It may include the symbol
+text under the cursor or selected text, current line, a nearby simple
+declaration such as `module`, `package`, `interface`, `typedef`,
+`parameter`, `localparam`, `function`, or `task`, diagnostics near the
+selection, and recent navigation references.  It is not full semantic
+SystemVerilog resolution.
+
+Validation command proposals use allowlisted templates such as the VS Code
+adapter smoke, editor bridge smoke, example drift check, pytest baseline,
+and the opt-in Extension Host smoke.  They include reasons, risk levels,
+and a required user approval marker.  The command returns JSON data only:
+it does not spawn a process, call pccx-lab, call an AI provider, write
+files, or run git commands.
 
 ## Daily-Driver Roadmap
 
@@ -137,14 +157,19 @@ Now:
 
 - checked-example diagnostics/navigation/definition
 - explicit live workspace boundary
+- live fixture diagnostics/navigation smoke
 - context bundle command
+- selected-symbol context
+- validation command proposal
+- pccx-lab backend status
 
 Next:
 
-- fixture-backed live diagnostics/navigation coverage
-- selected symbol context
-- validation command proposal
-- pccx-lab command palette integration
+- pccx-lab command palette execution with allowlisted commands
+- selected-symbol to declaration context through live navigation
+- diagnostics-aware prompt builder
+- validation result cache
+- patch proposal format
 
 Later:
 

--- a/editors/vscode-prototype/package.json
+++ b/editors/vscode-prototype/package.json
@@ -22,7 +22,9 @@
     "onCommand:pccxSystemVerilog.runDiagnosticsLive",
     "onCommand:pccxSystemVerilog.runNavigationLive",
     "onCommand:pccxSystemVerilog.showAIAssistantStatus",
-    "onCommand:pccxSystemVerilog.buildAIContextBundle"
+    "onCommand:pccxSystemVerilog.buildAIContextBundle",
+    "onCommand:pccxSystemVerilog.proposeValidationCommand",
+    "onCommand:pccxSystemVerilog.showPccxLabBackendStatus"
   ],
   "contributes": {
     "commands": [
@@ -65,6 +67,14 @@
       {
         "command": "pccxSystemVerilog.buildAIContextBundle",
         "title": "PCCX SystemVerilog: Build AI Context Bundle (Experimental)"
+      },
+      {
+        "command": "pccxSystemVerilog.proposeValidationCommand",
+        "title": "PCCX SystemVerilog: Propose Validation Command (Experimental)"
+      },
+      {
+        "command": "pccxSystemVerilog.showPccxLabBackendStatus",
+        "title": "PCCX SystemVerilog: Show pccx-lab Backend Status (Experimental)"
       }
     ],
     "configuration": {

--- a/editors/vscode-prototype/src/config.mjs
+++ b/editors/vscode-prototype/src/config.mjs
@@ -28,11 +28,17 @@ export const FACADE_COMMAND_IDS = Object.freeze([
 export const AI_COMMAND_IDS = Object.freeze([
   "pccxSystemVerilog.showAIAssistantStatus",
   "pccxSystemVerilog.buildAIContextBundle",
+  "pccxSystemVerilog.proposeValidationCommand",
+]);
+
+export const PCCX_LAB_COMMAND_IDS = Object.freeze([
+  "pccxSystemVerilog.showPccxLabBackendStatus",
 ]);
 
 export const COMMAND_IDS = Object.freeze([
   ...FACADE_COMMAND_IDS,
   ...AI_COMMAND_IDS,
+  ...PCCX_LAB_COMMAND_IDS,
 ]);
 
 export const MODES = Object.freeze(["checkedExample", "liveWorkspace"]);

--- a/editors/vscode-prototype/src/context-bundle.mjs
+++ b/editors/vscode-prototype/src/context-bundle.mjs
@@ -27,8 +27,8 @@ const EXCLUDED_PATH_PATTERNS = Object.freeze([
   ".git/**",
   ".vscode-test/**",
   "node_modules/**",
-  "AGENTS.md",
-  "package-lock.json",
+  "agent-instruction-files",
+  "lockfiles",
   ".codex/**",
   "private-worker/**",
   "worker-instruction/**",
@@ -319,6 +319,82 @@ function normalizeSelectedSymbol(symbol, workspaceRoot) {
   };
 }
 
+function normalizeCurrentLine(currentLine, limits) {
+  if (!currentLine || typeof currentLine !== "object") {
+    return null;
+  }
+  return {
+    number: Math.max(1, Math.floor(clampNumber(currentLine.number, 1))),
+    text: scrubText(currentLine.text ?? "", limits.maxTextCharacters),
+    truncated: currentLine.truncated === true,
+  };
+}
+
+function normalizeSelectionSummary(summary, limits) {
+  if (!summary || typeof summary !== "object") {
+    return null;
+  }
+  const previewLines = Array.isArray(summary.previewLines)
+    ? summary.previewLines
+      .map((line) => scrubText(line, limits.maxTextCharacters))
+      .slice(0, limits.maxSnippetLines)
+    : [];
+  return {
+    lineCount: Math.max(0, Math.floor(clampNumber(summary.lineCount))),
+    characterCount: Math.max(0, Math.floor(clampNumber(summary.characterCount))),
+    previewLines,
+    truncated: summary.truncated === true,
+  };
+}
+
+function normalizeCursor(cursor) {
+  if (!cursor || typeof cursor !== "object") {
+    return null;
+  }
+  return {
+    line: Math.max(0, Math.floor(clampNumber(cursor.line))),
+    character: Math.max(0, Math.floor(clampNumber(cursor.character))),
+  };
+}
+
+function normalizeSelectedSymbolContext(context, workspaceRoot, limits) {
+  if (!context || typeof context !== "object") {
+    return null;
+  }
+  const path = normalizePathRef(context.path ?? context.file, workspaceRoot);
+  if (!path) {
+    return null;
+  }
+  return {
+    version: scrubText(context.version ?? "", 80),
+    path,
+    language: scrubText(context.language ?? "systemverilog", 80),
+    symbolText: scrubText(context.symbolText ?? context.name ?? "", 160),
+    lexicalKind: scrubText(context.lexicalKind ?? context.kind ?? "identifier", 80),
+    range: normalizeRange(context.range),
+    cursor: normalizeCursor(context.cursor),
+    currentLine: normalizeCurrentLine(context.currentLine, limits),
+    selectionSummary: normalizeSelectionSummary(context.selectionSummary, limits),
+    enclosingDeclaration: normalizeDeclaration(context.enclosingDeclaration, workspaceRoot, limits),
+    relatedNavigation: Array.isArray(context.relatedNavigation)
+      ? sortedByPathAndName(context.relatedNavigation
+        .map((item) => normalizeDeclaration(item, workspaceRoot, limits))
+        .filter(Boolean))
+        .slice(0, limits.maxDeclarations)
+      : [],
+    nearbyDiagnostics: Array.isArray(context.nearbyDiagnostics)
+      ? sortedDiagnostics(context.nearbyDiagnostics
+        .map((diagnostic) => normalizeDiagnostic(diagnostic, workspaceRoot, limits))
+        .filter(Boolean), path, normalizeRange(context.range))
+        .slice(0, limits.maxDiagnostics)
+      : [],
+    analysis: {
+      kind: scrubText(context.analysis?.kind ?? "lexical", 80),
+      semanticResolution: context.analysis?.semanticResolution === true,
+    },
+  };
+}
+
 function normalizeRecentCommandStatus(status, limits) {
   if (!status || typeof status !== "object") {
     return null;
@@ -376,6 +452,7 @@ export function buildContextBundle(input = {}, options = {}) {
     ).slice(0, limits.maxDiagnostics),
     symbols: {
       selected: normalizeSelectedSymbol(input.selectedSymbol, workspaceRoot),
+      selectedContext: normalizeSelectedSymbolContext(input.selectedSymbolContext, workspaceRoot, limits),
       declarations: sortedByPathAndName(
         declarations
           .map((declaration) => normalizeDeclaration(declaration, workspaceRoot, limits))
@@ -415,6 +492,13 @@ export function summarizeContextBundle(bundle) {
   return {
     version: bundle?.version ?? CONTEXT_BUNDLE_VERSION,
     selectedFile: bundle?.selectedFile ?? null,
+    selectedSymbol: bundle?.symbols?.selected
+      ? {
+          name: bundle.symbols.selected.name,
+          kind: bundle.symbols.selected.kind,
+          path: bundle.symbols.selected.path,
+        }
+      : null,
     diagnosticCount: Array.isArray(bundle?.diagnostics) ? bundle.diagnostics.length : 0,
     snippetCount: Array.isArray(bundle?.snippets) ? bundle.snippets.length : 0,
     declarationCount: Array.isArray(bundle?.symbols?.declarations)

--- a/editors/vscode-prototype/src/extension.mjs
+++ b/editors/vscode-prototype/src/extension.mjs
@@ -31,6 +31,15 @@ import {
   createAssistantBoundaryStatus,
   createAssistantRequest,
 } from "./ai-assistant-boundary.mjs";
+import {
+  buildSelectedSymbolContext,
+} from "./selected-symbol-context.mjs";
+import {
+  createValidationCommandProposal,
+} from "./validation-proposals.mjs";
+import {
+  createPccxLabBackendStatus,
+} from "./pccx-lab-status.mjs";
 
 const EXTENSION_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_DIAGNOSTIC_FILE_ROOT = resolve(EXTENSION_ROOT, "../..");
@@ -39,10 +48,24 @@ const DEFAULT_FACADE_PATH = resolve(EXTENSION_ROOT, "bin/pccx-vscode-prototype.m
 const OUTPUT_CHANNEL_NAME = "PCCX SystemVerilog IDE Prototype";
 export const CHECKED_EXAMPLE_NAVIGATION_COMMAND =
   "pccxSystemVerilog.showCheckedExampleNavigation";
+export const LIVE_WORKSPACE_NAVIGATION_COMMAND =
+  "pccxSystemVerilog.showLiveWorkspaceNavigation";
+export const RUN_LIVE_NAVIGATION_COMMAND =
+  "pccxSystemVerilog.runNavigationLive";
 export const AI_ASSISTANT_STATUS_COMMAND =
   "pccxSystemVerilog.showAIAssistantStatus";
 export const AI_CONTEXT_BUNDLE_COMMAND =
   "pccxSystemVerilog.buildAIContextBundle";
+export const VALIDATION_PROPOSAL_COMMAND =
+  "pccxSystemVerilog.proposeValidationCommand";
+export const PCCX_LAB_BACKEND_STATUS_COMMAND =
+  "pccxSystemVerilog.showPccxLabBackendStatus";
+
+const NAVIGATION_LOCATION_COMMAND_IDS = Object.freeze([
+  CHECKED_EXAMPLE_NAVIGATION_COMMAND,
+  LIVE_WORKSPACE_NAVIGATION_COMMAND,
+  RUN_LIVE_NAVIGATION_COMMAND,
+]);
 
 export {
   COMMAND_IDS,
@@ -176,8 +199,8 @@ export async function runFacadeForCommand(commandId, options = {}, runtime = {})
   return runFacadeInvocation(invocation, runtime);
 }
 
-export async function runCheckedExampleNavigationLocations(rawConfig = {}, deps = {}) {
-  const result = await runPrototypeCommand(CHECKED_EXAMPLE_NAVIGATION_COMMAND, rawConfig, {
+export async function runNavigationCommandLocations(commandId, rawConfig = {}, deps = {}) {
+  const result = await runPrototypeCommand(commandId, rawConfig, {
     runFacade: deps.runFacade,
   });
   if (result.ok) {
@@ -186,17 +209,31 @@ export async function runCheckedExampleNavigationLocations(rawConfig = {}, deps 
   return result;
 }
 
+export async function runCheckedExampleNavigationLocations(rawConfig = {}, deps = {}) {
+  return runNavigationCommandLocations(CHECKED_EXAMPLE_NAVIGATION_COMMAND, rawConfig, deps);
+}
+
 function appendCommandOutput(outputChannel, commandId, result) {
   if (!outputChannel?.appendLine) {
     return;
   }
 
   outputChannel.appendLine(`[${commandId}]`);
-  if (result.status?.status) {
+  if (result.status?.status && result.status?.kind !== "pccx-lab-backend-status") {
     outputChannel.appendLine(`AI assistant status: ${result.status.status}`);
   }
   if (result.contextSummary) {
     outputChannel.appendLine(JSON.stringify(result.contextSummary, null, 2));
+  }
+  if (result.kind === "validation-command-proposal") {
+    outputChannel.appendLine(JSON.stringify({
+      kind: result.kind,
+      proposalCount: result.proposals?.length ?? 0,
+      execution: result.execution,
+    }, null, 2));
+  }
+  if (result.status?.kind === "pccx-lab-backend-status") {
+    outputChannel.appendLine(JSON.stringify(result.status, null, 2));
   }
   if (result.action?.summary) {
     outputChannel.appendLine(result.action.summary);
@@ -297,6 +334,35 @@ function rangeIsEmpty(range) {
     );
 }
 
+function selectionCursor(selection) {
+  const active = selection?.active ?? selection?.start;
+  return {
+    line: Number.isInteger(active?.line) ? active.line : 0,
+    character: Number.isInteger(active?.character) ? active.character : 0,
+  };
+}
+
+function collectLineWindow(document, selection, options = {}) {
+  if (!document || typeof document.lineAt !== "function") {
+    return [];
+  }
+  const before = Number.isInteger(options.before) ? options.before : 80;
+  const after = Number.isInteger(options.after) ? options.after : 20;
+  const cursor = selectionCursor(selection);
+  const lineCount = Number.isInteger(document.lineCount) ? document.lineCount : cursor.line + 1;
+  const start = Math.max(0, cursor.line - before);
+  const end = Math.min(Math.max(0, lineCount - 1), cursor.line + after);
+  const lines = [];
+  for (let line = start; line <= end; line += 1) {
+    const entry = document.lineAt(line);
+    lines.push({
+      line,
+      text: typeof entry === "string" ? entry : String(entry?.text ?? ""),
+    });
+  }
+  return lines;
+}
+
 function diagnosticSeverityName(vscodeApi, severity) {
   const diagnosticSeverity = vscodeApi?.DiagnosticSeverity ?? {};
   if (severity === diagnosticSeverity.Error || severity === 0) {
@@ -375,19 +441,41 @@ function collectActiveDocumentContext(vscodeApi, runtime, config) {
   const document = editor?.document;
   const workspaceRoot = workspaceRootForDocument(vscodeApi, document);
   const selectionRange = plainRange(editor?.selection);
+  const activeDiagnostics = collectActiveDiagnostics(vscodeApi, runtime, document);
+  const selectedText = (
+    document?.uri?.fsPath &&
+    editor?.selection &&
+    !rangeIsEmpty(editor.selection) &&
+    typeof document.getText === "function"
+  )
+    ? document.getText(editor.selection)
+    : "";
+  const selectedSymbolContext = buildSelectedSymbolContext({
+    workspaceRoot,
+    path: document?.uri?.fsPath,
+    language: document?.languageId ?? "systemverilog",
+    selectionRange,
+    cursorPosition: selectionCursor(editor?.selection),
+    selectionText: selectedText,
+    lines: collectLineWindow(document, editor?.selection),
+    diagnostics: activeDiagnostics,
+    navigationItems: Array.isArray(runtime.recentNavigationItems)
+      ? runtime.recentNavigationItems
+      : [],
+  }, { workspaceRoot });
   const files = [];
 
   if (
     document?.uri?.fsPath &&
     editor?.selection &&
     !rangeIsEmpty(editor.selection) &&
-    typeof document.getText === "function"
+    selectedText.length > 0
   ) {
     files.push({
       path: document.uri.fsPath,
       language: document.languageId ?? "systemverilog",
       range: selectionRange,
-      text: document.getText(editor.selection),
+      text: selectedText,
     });
   }
 
@@ -397,7 +485,16 @@ function collectActiveDocumentContext(vscodeApi, runtime, config) {
       workspaceRoot,
       selectedFilePath: document?.uri?.fsPath,
       selectedRange: selectionRange,
-      activeDiagnostics: collectActiveDiagnostics(vscodeApi, runtime, document),
+      selectedSymbol: selectedSymbolContext?.symbolText
+        ? {
+            name: selectedSymbolContext.symbolText,
+            kind: selectedSymbolContext.lexicalKind,
+            path: document?.uri?.fsPath,
+            range: selectedSymbolContext.range,
+          }
+        : null,
+      selectedSymbolContext,
+      activeDiagnostics,
       symbolContext: {
         declarations: Array.isArray(runtime.recentNavigationItems)
           ? runtime.recentNavigationItems
@@ -478,7 +575,39 @@ export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
       return result;
     }
 
-    const returnsNavigationLocations = commandId === CHECKED_EXAMPLE_NAVIGATION_COMMAND;
+    if (commandId === VALIDATION_PROPOSAL_COMMAND) {
+      let result;
+      try {
+        result = {
+          ok: true,
+          commandId,
+          ...createValidationCommandProposal(input),
+        };
+      } catch (error) {
+        result = { ok: false, commandId, error: error.message };
+        vscodeApi?.window?.showWarningMessage?.(result.error, result);
+      }
+      appendCommandOutput(runtime.outputChannel, commandId, result);
+      return result;
+    }
+
+    if (commandId === PCCX_LAB_BACKEND_STATUS_COMMAND) {
+      let result;
+      try {
+        result = {
+          ok: true,
+          commandId,
+          status: createPccxLabBackendStatus(rawConfig),
+        };
+      } catch (error) {
+        result = { ok: false, commandId, error: error.message };
+        vscodeApi?.window?.showWarningMessage?.(result.error, result);
+      }
+      appendCommandOutput(runtime.outputChannel, commandId, result);
+      return result;
+    }
+
+    const returnsNavigationLocations = NAVIGATION_LOCATION_COMMAND_IDS.includes(commandId);
     const explicitPath = pathFromCommandInput(input);
     const request = (
       commandId === "pccxSystemVerilog.publishLiveWorkspaceDiagnostics" ||
@@ -498,7 +627,7 @@ export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
         : (_items, action) => presentAction(action, presenterDeps),
     };
     const result = returnsNavigationLocations
-      ? await runCheckedExampleNavigationLocations(request, {
+      ? await runNavigationCommandLocations(commandId, request, {
         ...presenterDeps,
         runFacade: deps.runFacade,
         fileRoot: runtime.navigationFileRoot ?? DEFAULT_NAVIGATION_FILE_ROOT,

--- a/editors/vscode-prototype/src/pccx-lab-status.mjs
+++ b/editors/vscode-prototype/src/pccx-lab-status.mjs
@@ -1,0 +1,31 @@
+import { normalizeConfig } from "./config.mjs";
+
+export const PCCX_LAB_BACKEND_STATUS_VERSION = "pccx.pccxLabBackendStatus.v0";
+
+export const FUTURE_PCCX_LAB_OPERATIONS = Object.freeze([
+  "diagnostics",
+  "index",
+  "locate",
+  "declarations",
+  "xsim-log analysis",
+  "validation summary",
+]);
+
+export function createPccxLabBackendStatus(rawConfig = {}) {
+  const config = normalizeConfig(rawConfig);
+  return {
+    version: PCCX_LAB_BACKEND_STATUS_VERSION,
+    kind: "pccx-lab-backend-status",
+    configuredCommand: config.pccxLab.command,
+    status: "placeholder",
+    configured: Boolean(config.pccxLab.command),
+    execution: "statusOnly",
+    executes: false,
+    providerCalls: false,
+    runtimeCalls: false,
+    backendCommandExecuted: false,
+    integration: "commandPalettePreparation",
+    futureControlledOperations: [...FUTURE_PCCX_LAB_OPERATIONS],
+    note: "pccx-lab remains the CLI-first backend; this status command does not execute it.",
+  };
+}

--- a/editors/vscode-prototype/src/selected-symbol-context.mjs
+++ b/editors/vscode-prototype/src/selected-symbol-context.mjs
@@ -1,0 +1,397 @@
+import { isAbsolute, relative } from "node:path";
+
+export const SELECTED_SYMBOL_CONTEXT_VERSION = "pccx.selectedSymbolContext.v0";
+
+export const DEFAULT_SELECTED_SYMBOL_CONTEXT_LIMITS = Object.freeze({
+  maxWindowLines: 80,
+  maxLineCharacters: 240,
+  maxSelectionPreviewLines: 4,
+  maxRelatedReferences: 6,
+  maxNearbyDiagnostics: 4,
+});
+
+const IDENTIFIER_PATTERN = /[A-Za-z_][A-Za-z0-9_$]*/g;
+const EXCLUDED_PATH_SEGMENTS = new Set([".git", ".vscode-test", "node_modules"]);
+const EXCLUDED_PATH_NAMES = new Set(["AGENTS.md", "package-lock.json"]);
+const SECRET_LIKE_PATTERN =
+  /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b/i;
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]/i;
+const PRIVATE_INSTRUCTION_PATH_PATTERN =
+  /(?:^|[/\\])(?:\.codex|private[-_ ]?worker|worker[-_ ]?instruction|subagent[-_ ]?instruction)(?:[/\\]|$)/i;
+
+function mergeLimits(limits = {}) {
+  return {
+    ...DEFAULT_SELECTED_SYMBOL_CONTEXT_LIMITS,
+    ...Object.fromEntries(
+      Object.entries(limits).filter(([, value]) => Number.isInteger(value) && value >= 0),
+    ),
+  };
+}
+
+function normalizeWorkspacePath(workspaceRoot) {
+  if (typeof workspaceRoot !== "string" || workspaceRoot.trim().length === 0) {
+    return null;
+  }
+  return workspaceRoot.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function pathHasExcludedSegment(path) {
+  const segments = path.split("/").filter(Boolean);
+  return segments.some((segment) => EXCLUDED_PATH_SEGMENTS.has(segment));
+}
+
+function pathHasExcludedName(path) {
+  const segments = path.split("/").filter(Boolean);
+  return segments.some((segment) => EXCLUDED_PATH_NAMES.has(segment));
+}
+
+function normalizePathRef(path, workspaceRoot = null) {
+  if (typeof path !== "string" || path.trim().length === 0) {
+    return null;
+  }
+  if (path.includes("\0") || path.includes("\n") || path.includes("\r")) {
+    return null;
+  }
+
+  const normalizedWorkspaceRoot = normalizeWorkspacePath(workspaceRoot);
+  let normalizedPath = path.replace(/\\/g, "/");
+  if (isAbsolute(normalizedPath)) {
+    if (!normalizedWorkspaceRoot) {
+      return null;
+    }
+    const rel = relative(normalizedWorkspaceRoot, normalizedPath).replace(/\\/g, "/");
+    if (rel.startsWith("../") || rel === ".." || isAbsolute(rel)) {
+      return null;
+    }
+    normalizedPath = rel;
+  }
+
+  normalizedPath = normalizedPath.replace(/^\.\//, "");
+  if (
+    normalizedPath === "" ||
+    normalizedPath.startsWith("../") ||
+    normalizedPath === ".." ||
+    pathHasExcludedSegment(normalizedPath) ||
+    pathHasExcludedName(normalizedPath) ||
+    SECRET_LIKE_PATTERN.test(normalizedPath) ||
+    PRIVATE_INSTRUCTION_PATH_PATTERN.test(normalizedPath)
+  ) {
+    return null;
+  }
+  return normalizedPath;
+}
+
+function clampNumber(value, fallback = 0) {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function clampLineText(text, maxLineCharacters) {
+  const singleLine = String(text ?? "").replace(/\r?\n/g, " ");
+  const redacted = SECRET_ASSIGNMENT_PATTERN.test(singleLine) ? "[redacted]" : singleLine;
+  return {
+    text: redacted.slice(0, maxLineCharacters),
+    truncated: redacted.length > maxLineCharacters,
+  };
+}
+
+function scrubText(value, maxCharacters) {
+  if (typeof value !== "string" || value.length === 0 || maxCharacters === 0) {
+    return "";
+  }
+  if (SECRET_ASSIGNMENT_PATTERN.test(value) || SECRET_LIKE_PATTERN.test(value)) {
+    return "[redacted]";
+  }
+  return value.slice(0, maxCharacters);
+}
+
+function normalizeRange(range) {
+  if (!range || typeof range !== "object") {
+    return null;
+  }
+  const normalized = {
+    start: {
+      line: Math.max(0, Math.floor(clampNumber(range.start?.line))),
+      character: Math.max(0, Math.floor(clampNumber(range.start?.character))),
+    },
+    end: {
+      line: Math.max(0, Math.floor(clampNumber(range.end?.line))),
+      character: Math.max(0, Math.floor(clampNumber(range.end?.character))),
+    },
+  };
+  if (
+    normalized.end.line < normalized.start.line ||
+    (
+      normalized.end.line === normalized.start.line &&
+      normalized.end.character < normalized.start.character
+    )
+  ) {
+    normalized.end = { ...normalized.start };
+  }
+  return normalized;
+}
+
+function rangeIsEmpty(range) {
+  return !range ||
+    (
+      range.start?.line === range.end?.line &&
+      range.start?.character === range.end?.character
+    );
+}
+
+function normalizeLineEntry(entry, index) {
+  if (typeof entry === "string") {
+    return {
+      line: index,
+      text: entry,
+    };
+  }
+  if (entry && typeof entry === "object") {
+    return {
+      line: Math.max(0, Math.floor(clampNumber(entry.line, index))),
+      text: String(entry.text ?? ""),
+    };
+  }
+  return null;
+}
+
+function normalizeLines(lines, limits) {
+  if (!Array.isArray(lines)) {
+    return [];
+  }
+  return lines
+    .map((entry, index) => normalizeLineEntry(entry, index))
+    .filter(Boolean)
+    .sort((a, b) => a.line - b.line)
+    .slice(0, limits.maxWindowLines);
+}
+
+function identifierUnderCursor(lineText, character) {
+  const cursor = Math.max(0, Math.floor(clampNumber(character)));
+  for (const match of String(lineText ?? "").matchAll(IDENTIFIER_PATTERN)) {
+    const start = match.index ?? 0;
+    const end = start + match[0].length;
+    if (cursor >= start && cursor <= end) {
+      return {
+        text: match[0],
+        range: { start, end },
+      };
+    }
+  }
+  return null;
+}
+
+function firstIdentifier(text) {
+  const match = String(text ?? "").match(IDENTIFIER_PATTERN);
+  return match?.[0] ?? "";
+}
+
+function findCurrentLine(lines, cursorLine) {
+  return lines.find((entry) => entry.line === cursorLine) ?? null;
+}
+
+function declarationFromLine(entry) {
+  const text = entry?.text ?? "";
+  const simple = text.match(
+    /^\s*(module|package|interface)\s+([A-Za-z_][A-Za-z0-9_$]*)\b/,
+  );
+  if (simple) {
+    return {
+      kind: simple[1],
+      name: simple[2],
+      column: simple.index + simple[0].lastIndexOf(simple[2]) + 1,
+    };
+  }
+
+  const typedef = text.match(/\btypedef\b[\s\S]*?\b([A-Za-z_][A-Za-z0-9_$]*)\s*;/);
+  if (typedef) {
+    return {
+      kind: "typedef",
+      name: typedef[1],
+      column: text.indexOf(typedef[1]) + 1,
+    };
+  }
+
+  const param = text.match(/^\s*(parameter|localparam)\b[\s\S]*?\b([A-Za-z_][A-Za-z0-9_$]*)\s*(?:=|;|,)/);
+  if (param) {
+    return {
+      kind: param[1],
+      name: param[2],
+      column: text.indexOf(param[2]) + 1,
+    };
+  }
+
+  const callable = text.match(/^\s*(function|task)\b[\s\S]*?\b([A-Za-z_][A-Za-z0-9_$]*)\s*(?:\(|;)/);
+  if (callable) {
+    return {
+      kind: callable[1],
+      name: callable[2],
+      column: text.indexOf(callable[2]) + 1,
+    };
+  }
+
+  return null;
+}
+
+function findEnclosingDeclaration(lines, cursorLine, path, limits) {
+  const candidates = lines
+    .filter((entry) => entry.line <= cursorLine)
+    .map((entry) => ({ entry, declaration: declarationFromLine(entry) }))
+    .filter(({ declaration }) => declaration)
+    .sort((a, b) => b.entry.line - a.entry.line);
+  const candidate = candidates[0];
+  if (!candidate) {
+    return null;
+  }
+
+  const line = candidate.entry.line;
+  const column = Math.max(1, candidate.declaration.column);
+  return {
+    kind: candidate.declaration.kind,
+    name: scrubText(candidate.declaration.name, 160),
+    path,
+    range: {
+      start: { line, character: column - 1 },
+      end: { line, character: column - 1 + candidate.declaration.name.length },
+    },
+    line: line + 1,
+    column,
+    lineText: clampLineText(candidate.entry.text, limits.maxLineCharacters),
+  };
+}
+
+function selectionSummary(selectionText, limits) {
+  if (typeof selectionText !== "string" || selectionText.length === 0) {
+    return null;
+  }
+  const redacted = SECRET_ASSIGNMENT_PATTERN.test(selectionText) ? "[redacted]" : selectionText;
+  const lines = redacted
+    .split(/\r?\n/)
+    .slice(0, limits.maxSelectionPreviewLines)
+    .map((line) => line.slice(0, limits.maxLineCharacters));
+  return {
+    lineCount: selectionText.split(/\r?\n/).length,
+    characterCount: selectionText.length,
+    previewLines: lines,
+    truncated: redacted.length > lines.join("\n").length,
+  };
+}
+
+function normalizeNavigationReference(item, workspaceRoot, limits) {
+  const path = normalizePathRef(item?.path ?? item?.file, workspaceRoot);
+  if (!path) {
+    return null;
+  }
+  const line = Math.max(1, Math.floor(clampNumber(item?.line, 1)));
+  const column = Math.max(1, Math.floor(clampNumber(item?.column, 1)));
+  return {
+    name: scrubText(item?.name ?? "", 160),
+    kind: scrubText(item?.kind ?? "any", 80),
+    path,
+    range: normalizeRange(item?.range) ?? {
+      start: { line: line - 1, character: column - 1 },
+      end: { line: line - 1, character: column },
+    },
+    source: scrubText(item?.source ?? "pccx-vscode-prototype", 120),
+  };
+}
+
+function normalizeDiagnostic(diagnostic, workspaceRoot, limits) {
+  const path = normalizePathRef(diagnostic?.path ?? diagnostic?.file, workspaceRoot);
+  if (!path) {
+    return null;
+  }
+  return {
+    path,
+    range: normalizeRange(diagnostic?.range),
+    severity: scrubText(diagnostic?.severity ?? "Information", 80),
+    message: scrubText(diagnostic?.message ?? "", 500),
+    source: scrubText(diagnostic?.source ?? "", 120),
+    code: scrubText(diagnostic?.code ?? "", 120),
+  };
+}
+
+function rangeTouchesLine(range, line) {
+  if (!range) {
+    return false;
+  }
+  return Number.isInteger(range.start?.line) &&
+    Number.isInteger(range.end?.line) &&
+    line >= range.start.line &&
+    line <= range.end.line;
+}
+
+export function buildSelectedSymbolContext(input = {}, options = {}) {
+  const limits = mergeLimits(options.limits);
+  const workspaceRoot = options.workspaceRoot ?? input.workspaceRoot ?? null;
+  const path = normalizePathRef(input.path ?? input.file, workspaceRoot);
+  if (!path) {
+    return null;
+  }
+
+  const lines = normalizeLines(input.lines, limits);
+  if (lines.length === 0) {
+    return null;
+  }
+
+  const selectedRange = normalizeRange(input.selectionRange ?? input.range);
+  const cursor = {
+    line: Math.max(0, Math.floor(clampNumber(
+      input.cursorPosition?.line ?? selectedRange?.start?.line,
+    ))),
+    character: Math.max(0, Math.floor(clampNumber(
+      input.cursorPosition?.character ?? selectedRange?.start?.character,
+    ))),
+  };
+  const current = findCurrentLine(lines, cursor.line) ?? lines[0];
+  const selectedText = typeof input.selectionText === "string" ? input.selectionText : "";
+  const symbolFromSelection = !rangeIsEmpty(selectedRange) ? firstIdentifier(selectedText) : "";
+  const symbolAtCursor = identifierUnderCursor(current.text, cursor.character);
+  const symbolText = scrubText(symbolFromSelection || symbolAtCursor?.text || "", 160);
+  const symbolRange = symbolAtCursor
+    ? {
+        start: { line: current.line, character: symbolAtCursor.range.start },
+        end: { line: current.line, character: symbolAtCursor.range.end },
+      }
+    : selectedRange;
+  const enclosingDeclaration = findEnclosingDeclaration(lines, cursor.line, path, limits);
+  const relatedNavigation = Array.isArray(input.navigationItems)
+    ? input.navigationItems
+      .map((item) => normalizeNavigationReference(item, workspaceRoot, limits))
+      .filter((item) => item && (!symbolText || item.name === symbolText))
+      .slice(0, limits.maxRelatedReferences)
+    : [];
+  const nearbyDiagnostics = Array.isArray(input.diagnostics)
+    ? input.diagnostics
+      .map((diagnostic) => normalizeDiagnostic(diagnostic, workspaceRoot, limits))
+      .filter((diagnostic) => diagnostic && (!selectedRange || rangeTouchesLine(diagnostic.range, cursor.line)))
+      .slice(0, limits.maxNearbyDiagnostics)
+    : [];
+  const currentLine = clampLineText(current.text, limits.maxLineCharacters);
+  const lexicalKind = enclosingDeclaration?.name === symbolText
+    ? enclosingDeclaration.kind
+    : "identifier";
+
+  return {
+    version: SELECTED_SYMBOL_CONTEXT_VERSION,
+    path,
+    language: scrubText(input.language ?? "systemverilog", 80),
+    symbolText,
+    lexicalKind,
+    range: normalizeRange(symbolRange),
+    cursor,
+    currentLine: {
+      number: current.line + 1,
+      ...currentLine,
+    },
+    selectionSummary: selectionSummary(selectedText, limits),
+    enclosingDeclaration,
+    relatedNavigation,
+    nearbyDiagnostics,
+    limits,
+    analysis: {
+      kind: "lexical",
+      semanticResolution: false,
+    },
+  };
+}

--- a/editors/vscode-prototype/src/validation-proposals.mjs
+++ b/editors/vscode-prototype/src/validation-proposals.mjs
@@ -1,0 +1,136 @@
+export const VALIDATION_PROPOSAL_VERSION = "pccx.validationCommandProposal.v0";
+
+export const VALIDATION_PROPOSAL_CATEGORIES = Object.freeze([
+  "vscodeAdapterSmoke",
+  "editorBridgeSmoke",
+  "exampleDriftCheck",
+  "pytestBaseline",
+  "extensionHostSmoke",
+  "futurePccxLabDiagnostics",
+  "futureXsimLogAnalysis",
+]);
+
+const PROPOSALS = Object.freeze([
+  Object.freeze({
+    category: "vscodeAdapterSmoke",
+    label: "VS Code adapter smoke",
+    command: Object.freeze({
+      cwd: "repo-root",
+      argv: Object.freeze(["bash", "scripts/vscode-adapter-smoke.sh"]),
+      env: Object.freeze({}),
+    }),
+    reason: "Checks the VS Code prototype adapter, facade, boundary, and static guard suite.",
+    riskLevel: "low",
+  }),
+  Object.freeze({
+    category: "editorBridgeSmoke",
+    label: "Editor bridge smoke",
+    command: Object.freeze({
+      cwd: "repo-root",
+      argv: Object.freeze(["bash", "scripts/editor-bridge-smoke.sh"]),
+      env: Object.freeze({}),
+    }),
+    reason: "Checks the editor bridge examples and CLI contract conversion path.",
+    riskLevel: "low",
+  }),
+  Object.freeze({
+    category: "exampleDriftCheck",
+    label: "Editor bridge example drift check",
+    command: Object.freeze({
+      cwd: "repo-root",
+      argv: Object.freeze(["bash", "scripts/check-editor-bridge-examples.sh"]),
+      env: Object.freeze({}),
+    }),
+    reason: "Verifies checked-in editor bridge examples still match the current CLI behavior.",
+    riskLevel: "low",
+  }),
+  Object.freeze({
+    category: "pytestBaseline",
+    label: "Python pytest baseline",
+    command: Object.freeze({
+      cwd: "repo-root",
+      argv: Object.freeze(["python3", "-m", "pytest", "-q"]),
+      env: Object.freeze({}),
+    }),
+    reason: "Runs the repository Python baseline used by the lightweight CI path.",
+    riskLevel: "low",
+  }),
+  Object.freeze({
+    category: "extensionHostSmoke",
+    label: "VS Code Extension Host smoke",
+    command: Object.freeze({
+      cwd: "repo-root",
+      argv: Object.freeze(["bash", "scripts/vscode-extension-host-smoke.sh"]),
+      env: Object.freeze({ PCCX_RUN_EXTENSION_HOST_SMOKE: "1" }),
+    }),
+    reason: "Runs the opt-in local Extension Host smoke against the controlled fixture workspace.",
+    riskLevel: "medium",
+  }),
+  Object.freeze({
+    category: "futurePccxLabDiagnostics",
+    label: "Future pccx-lab diagnostics validation",
+    command: null,
+    placeholder: true,
+    reason: "Reserved for a later allowlisted pccx-lab command palette integration.",
+    riskLevel: "medium",
+  }),
+  Object.freeze({
+    category: "futureXsimLogAnalysis",
+    label: "Future xsim-log analysis validation",
+    command: null,
+    placeholder: true,
+    reason: "Reserved for later controlled xsim-log analysis through the pccx-lab boundary.",
+    riskLevel: "medium",
+  }),
+]);
+
+function cloneCommand(command) {
+  if (!command) {
+    return null;
+  }
+  return {
+    cwd: command.cwd,
+    argv: [...command.argv],
+    env: { ...command.env },
+  };
+}
+
+function cloneProposal(proposal) {
+  return {
+    category: proposal.category,
+    label: proposal.label,
+    command: cloneCommand(proposal.command),
+    placeholder: proposal.placeholder === true,
+    reason: proposal.reason,
+    riskLevel: proposal.riskLevel,
+    requiresUserApproval: true,
+    executes: false,
+  };
+}
+
+export function createValidationCommandProposal(_input = {}) {
+  return {
+    version: VALIDATION_PROPOSAL_VERSION,
+    kind: "validation-command-proposal",
+    execution: "proposalOnly",
+    proposalOnly: true,
+    executes: false,
+    requiresUserApproval: true,
+    providerCalls: false,
+    runtimeCalls: false,
+    commandSource: "allowlistedTemplates",
+    proposals: PROPOSALS.map(cloneProposal),
+    disallowedActions: [
+      "executeCommand",
+      "spawnProcess",
+      "writeFile",
+      "commit",
+      "push",
+      "merge",
+      "release",
+      "tag",
+      "changeRuleset",
+      "accessSecrets",
+    ],
+  };
+}

--- a/editors/vscode-prototype/test/context-bundle.test.mjs
+++ b/editors/vscode-prototype/test/context-bundle.test.mjs
@@ -42,6 +42,50 @@ function fixtureInput() {
         end: { line: 10, character: 3 },
       },
     },
+    selectedSymbolContext: {
+      version: "pccx.selectedSymbolContext.v0",
+      path: "/repo/rtl/top.sv",
+      language: "systemverilog",
+      symbolText: "top",
+      lexicalKind: "module",
+      range: {
+        start: { line: 10, character: 0 },
+        end: { line: 10, character: 3 },
+      },
+      cursor: { line: 10, character: 1 },
+      currentLine: {
+        number: 11,
+        text: "module top;",
+        truncated: false,
+      },
+      selectionSummary: {
+        lineCount: 1,
+        characterCount: 3,
+        previewLines: ["top"],
+        truncated: false,
+      },
+      enclosingDeclaration: {
+        name: "top",
+        kind: "module",
+        path: "/repo/rtl/top.sv",
+        line: 11,
+        column: 1,
+        range: {
+          start: { line: 10, character: 0 },
+          end: { line: 10, character: 3 },
+        },
+      },
+      relatedNavigation: [
+        { name: "top", kind: "module", file: "/repo/rtl/top.sv", line: 11, column: 1 },
+      ],
+      nearbyDiagnostics: [
+        { file: "/repo/rtl/top.sv", message: "near selected symbol" },
+      ],
+      analysis: {
+        kind: "lexical",
+        semanticResolution: false,
+      },
+    },
     activeDiagnostics: [
       {
         file: "/repo/rtl/z.sv",
@@ -149,6 +193,15 @@ function testStableBoundedShape() {
   assert.equal(bundle.configuration.mode, "checkedExample");
   assert.equal(bundle.configuration.aiAssistant.backend, "none");
   assert.deepEqual(bundle.selectedFile, { path: "rtl/top.sv" });
+  assert.deepEqual(Object.keys(bundle.symbols.selected), ["name", "kind", "path", "range"]);
+  assert.equal(bundle.symbols.selected.name, "top");
+  assert.equal(bundle.symbols.selected.kind, "module");
+  assert.equal(bundle.symbols.selected.path, "rtl/top.sv");
+  assert.equal(bundle.symbols.selectedContext.symbolText, "top");
+  assert.equal(bundle.symbols.selectedContext.lexicalKind, "module");
+  assert.equal(bundle.symbols.selectedContext.analysis.semanticResolution, false);
+  assert.equal(bundle.symbols.selectedContext.relatedNavigation.length, 1);
+  assert.equal(bundle.symbols.selectedContext.nearbyDiagnostics.length, 1);
   assert.equal(bundle.diagnostics.length, 1);
   assert.equal(bundle.diagnostics[0].path, "rtl/a.sv");
   assert.equal(bundle.snippets.length, 2);
@@ -159,11 +212,16 @@ function testStableBoundedShape() {
   assert.equal(bundle.recentCommand.facade.mode, "example");
   assert.equal(bundle.pccxLab.outputs.length, 1);
   assert.deepEqual(bundle.pccxLab.outputs[0].lines, ["[redacted]"]);
-  assert.ok(bundle.excludedPathPatterns.includes("AGENTS.md"));
+  assert.ok(bundle.excludedPathPatterns.includes("agent-instruction-files"));
   assert.equal(bundle.redaction.assignmentPolicy, "secret-like-lines-redacted");
   assert.deepEqual(summarizeContextBundle(bundle), {
     version: CONTEXT_BUNDLE_VERSION,
     selectedFile: { path: "rtl/top.sv" },
+    selectedSymbol: {
+      name: "top",
+      kind: "module",
+      path: "rtl/top.sv",
+    },
     diagnosticCount: 1,
     snippetCount: 2,
     declarationCount: 2,
@@ -319,6 +377,8 @@ function testNoSecretValuesOrSecretLikeKeys() {
   assert.doesNotMatch(serialized, /abc123/);
   assert.doesNotMatch(serialized, /API_KEY=/);
   assert.doesNotMatch(serialized, /token=hidden/);
+  assert.doesNotMatch(serialized, /AGENTS\.md/);
+  assert.doesNotMatch(serialized, /package-lock\.json/);
 }
 
 function testNoAbsoluteHomePathLeakage() {

--- a/editors/vscode-prototype/test/extension-entrypoint.test.mjs
+++ b/editors/vscode-prototype/test/extension-entrypoint.test.mjs
@@ -6,6 +6,9 @@ import {
   COMMAND_IDS,
   CHECKED_EXAMPLE_NAVIGATION_COMMAND,
   FACADE_COMMAND_IDS,
+  LIVE_WORKSPACE_NAVIGATION_COMMAND,
+  PCCX_LAB_BACKEND_STATUS_COMMAND,
+  VALIDATION_PROPOSAL_COMMAND,
   activate,
   buildFacadeArgsForCommand,
   buildFacadeInvocationForCommand,
@@ -456,6 +459,120 @@ async function testCheckedExampleNavigationCommandReturnsLocations() {
   assert.equal(quickPickCalls.length, 0);
 }
 
+async function testLiveWorkspaceNavigationCommandReturnsLocationsWithoutQuickPick() {
+  const registered = new Map();
+  const quickPickCalls = [];
+  const settings = new Map([
+    ["mode", "liveWorkspace"],
+    ["liveWorkspace.enabled", true],
+    ["pccxLab.command", "pccx_ide_cli"],
+    ["aiAssistant.enabled", false],
+    ["aiAssistant.backend", "none"],
+    ["pythonPath", "python3"],
+    ["defaultSource", "ignored.sv"],
+    ["defaultLog", "ignored.log"],
+    ["defaultNavigationRoot", "/repo/live-fixture"],
+    ["defaultModule", "live_top"],
+    ["defaultDeclarationKind", "module"],
+  ]);
+  const vscodeApi = {
+    Uri: {
+      file(file) {
+        return { fsPath: file };
+      },
+    },
+    Range: class Range {
+      constructor(startLine, startCharacter, endLine, endCharacter) {
+        this.start = { line: startLine, character: startCharacter };
+        this.end = { line: endLine, character: endCharacter };
+      }
+    },
+    Location: class Location {
+      constructor(uri, range) {
+        this.uri = uri;
+        this.range = range;
+      }
+    },
+    commands: {
+      registerCommand(commandId, handler) {
+        registered.set(commandId, handler);
+        return { dispose() {} };
+      },
+    },
+    workspace: {
+      getConfiguration(section) {
+        assert.equal(section, "pccxSystemVerilog");
+        return {
+          get(key) {
+            return settings.get(key);
+          },
+        };
+      },
+    },
+    window: {
+      createOutputChannel() {
+        return { appendLine() {}, show() {}, dispose() {} };
+      },
+      showInformationMessage() {},
+      showErrorMessage() {},
+      showQuickPick(...args) {
+        quickPickCalls.push(args);
+        throw new Error("live navigation smoke must not prompt QuickPick");
+      },
+    },
+  };
+  const facadeCalls = [];
+
+  await activate(
+    { subscriptions: [] },
+    vscodeApi,
+    {
+      async runFacade(args, env) {
+        facadeCalls.push({ args, env });
+        return {
+          ok: true,
+          json: {
+            kind: "vscode-navigation",
+            items: [
+              {
+                name: "live_top",
+                kind: "module",
+                file: "/repo/live-fixture/top.sv",
+                line: 1,
+                column: 8,
+                zero_based_line: 0,
+                zero_based_column: 7,
+              },
+            ],
+          },
+        };
+      },
+    },
+  );
+
+  const result = await registered.get(LIVE_WORKSPACE_NAVIGATION_COMMAND)();
+
+  assert.equal(result.ok, true);
+  assert.equal(result.commandId, LIVE_WORKSPACE_NAVIGATION_COMMAND);
+  assert.deepEqual(facadeCalls[0].args, [
+    "navigation",
+    "--mode",
+    "live",
+    "--locate",
+    "/repo/live-fixture",
+    "live_top",
+    "--kind",
+    "module",
+  ]);
+  assert.deepEqual(facadeCalls[0].env, { PCCX_IDE_PYTHON: "python3" });
+  assert.equal(result.locations.length, 1);
+  assert.equal(result.locations[0].symbol, "live_top");
+  assert.equal(result.locations[0].targetKind, "module");
+  assert.equal(result.locations[0].uri.fsPath, "/repo/live-fixture/top.sv");
+  assert.equal(result.locations[0].range.start.character, 7);
+  assert.equal(quickPickCalls.length, 0);
+}
+
 async function testCheckedExampleDefinitionProviderReturnsLocations() {
   const location = { uri: { fsPath: "/repo/root/pkg.sv" }, range: { start: { line: 0 } } };
   const provider = checkedExampleDefinitionProvider({
@@ -650,14 +767,23 @@ async function testAIContextBundleCommandUsesActiveEditorSelectionAndDiagnostics
   const document = {
     uri: { fsPath: "/repo/rtl/top.sv" },
     languageId: "systemverilog",
+    lineCount: 2,
+    lineAt(line) {
+      return {
+        text: [
+          "module top;",
+          "endmodule",
+        ][line],
+      };
+    },
     getText(range) {
       assert.equal(range.start.line, 0);
-      return "module top;\nendmodule\n";
+      return "top";
     },
   };
   const selection = {
-    start: { line: 0, character: 0 },
-    end: { line: 1, character: 9 },
+    start: { line: 0, character: 7 },
+    end: { line: 0, character: 10 },
   };
   const vscodeApi = {
     DiagnosticSeverity: {
@@ -735,10 +861,75 @@ async function testAIContextBundleCommandUsesActiveEditorSelectionAndDiagnostics
   assert.equal(result.contextBundle.diagnostics[0].path, "rtl/top.sv");
   assert.equal(result.contextBundle.snippets.length, 1);
   assert.equal(result.contextBundle.snippets[0].path, "rtl/top.sv");
+  assert.equal(result.contextBundle.symbols.selected.name, "top");
+  assert.equal(result.contextBundle.symbols.selected.kind, "module");
+  assert.equal(result.contextBundle.symbols.selected.path, "rtl/top.sv");
+  assert.equal(result.contextBundle.symbols.selectedContext.symbolText, "top");
+  assert.equal(result.contextBundle.symbols.selectedContext.lexicalKind, "module");
+  assert.equal(result.contextBundle.symbols.selectedContext.currentLine.text, "module top;");
   assert.equal(result.contextBundle.symbols.declarations.length, 1);
   assert.equal(result.contextBundle.symbols.declarations[0].path, "rtl/top.sv");
   assert.equal(result.contextBundle.recentCommand.commandId, "pccxSystemVerilog.publishCheckedExampleDiagnostics");
   assert.doesNotMatch(JSON.stringify(result.contextBundle), /\/repo/);
+}
+
+async function testValidationProposalCommandReturnsDataOnly() {
+  const handler = createCommandHandler(VALIDATION_PROPOSAL_COMMAND, null, {});
+
+  const result = await handler({ command: "git push origin main" });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.commandId, VALIDATION_PROPOSAL_COMMAND);
+  assert.equal(result.kind, "validation-command-proposal");
+  assert.equal(result.execution, "proposalOnly");
+  assert.equal(result.executes, false);
+  assert.equal(result.providerCalls, false);
+  assert.equal(result.runtimeCalls, false);
+  assert.ok(result.proposals.some((proposal) => (
+    proposal.command?.argv?.join(" ") === "bash scripts/vscode-adapter-smoke.sh"
+  )));
+  assert.doesNotMatch(JSON.stringify(result), /git push/);
+}
+
+async function testPccxLabBackendStatusCommandReturnsStatusOnly() {
+  const settings = new Map([
+    ["mode", "checkedExample"],
+    ["liveWorkspace.enabled", false],
+    ["pccxLab.command", "custom-lab"],
+    ["aiAssistant.enabled", false],
+    ["aiAssistant.backend", "none"],
+    ["pythonPath", "python3"],
+    ["defaultSource", "fixtures/missing_endmodule.sv"],
+    ["defaultLog", "fixtures/xsim/mixed.log"],
+    ["defaultNavigationRoot", "fixtures/modules"],
+    ["defaultModule", "simple_mod"],
+    ["defaultDeclarationKind", "module"],
+  ]);
+  const handler = createCommandHandler(
+    PCCX_LAB_BACKEND_STATUS_COMMAND,
+    {
+      workspace: {
+        getConfiguration() {
+          return {
+            get(key) {
+              return settings.get(key);
+            },
+          };
+        },
+      },
+    },
+    {},
+  );
+
+  const result = await handler();
+
+  assert.equal(result.ok, true);
+  assert.equal(result.commandId, PCCX_LAB_BACKEND_STATUS_COMMAND);
+  assert.equal(result.status.kind, "pccx-lab-backend-status");
+  assert.equal(result.status.configuredCommand, "custom-lab");
+  assert.equal(result.status.executes, false);
+  assert.equal(result.status.backendCommandExecuted, false);
+  assert.ok(result.status.futureControlledOperations.includes("declarations"));
 }
 
 testKnownFacadeArgs();
@@ -751,11 +942,14 @@ testNavigationLocationMapping();
 testResolveCommandRequestUsesVsCodeSettings();
 await testEntrypointExportsAndActivation();
 await testCheckedExampleNavigationCommandReturnsLocations();
+await testLiveWorkspaceNavigationCommandReturnsLocationsWithoutQuickPick();
 await testCheckedExampleDefinitionProviderReturnsLocations();
 await testActivationRegistersCheckedExampleDefinitionProvider();
 await testNoVsCodeRuntimeIsANoop();
 await testCommandHandlerCanBeUsedWithoutRealVsCode();
 await testAIStatusCommandReturnsDisabledBackendNone();
 await testAIContextBundleCommandUsesActiveEditorSelectionAndDiagnostics();
+await testValidationProposalCommandReturnsDataOnly();
+await testPccxLabBackendStatusCommandReturnsStatusOnly();
 
 console.log("vscode extension entrypoint tests ok");

--- a/editors/vscode-prototype/test/extension-host-readiness.test.mjs
+++ b/editors/vscode-prototype/test/extension-host-readiness.test.mjs
@@ -102,7 +102,12 @@ async function testReadinessDocsAndCiPolicy() {
   assert.match(`${readme}\n${readiness}`, /controlled fixture/i);
   assert.match(`${readme}\n${readiness}`, /showAIAssistantStatus/);
   assert.match(`${readme}\n${readiness}`, /buildAIContextBundle/);
+  assert.match(`${readme}\n${readiness}`, /selected-symbol context/i);
+  assert.match(`${readme}\n${readiness}`, /proposeValidationCommand/);
+  assert.match(`${readme}\n${readiness}`, /showPccxLabBackendStatus/);
   assert.match(`${readme}\n${readiness}`, /context bundle command/i);
+  assert.match(`${readme}\n${readiness}`, /validation command proposal/i);
+  assert.match(`${readme}\n${readiness}`, /pccx-lab backend status/i);
   assert.match(`${readme}\n${readiness}`, /AI assistant .*boundary/i);
   assert.match(`${readme}\n${readiness}`, /pccx-llm-launcher .*future local LLM\/chat backend/i);
   assert.match(`${readme}\n${readiness}`, /no LSP provider/i);
@@ -143,10 +148,15 @@ async function testRuntimeRunnerIsPinnedAndBounded() {
   assert.match(suite, /showCheckedExampleNavigation/);
   assert.match(suite, /publishLiveWorkspaceDiagnostics/);
   assert.match(suite, /showLiveWorkspaceNavigation/);
+  assert.match(suite, /liveNavigationResult/);
+  assert.match(suite, /live_top/);
   assert.match(suite, /live workspace commands require/);
   assert.match(suite, /broken_missing_endmodule\.sv/);
   assert.match(suite, /showAIAssistantStatus/);
   assert.match(suite, /buildAIContextBundle/);
+  assert.match(suite, /selectedContext/);
+  assert.match(suite, /proposeValidationCommand/);
+  assert.match(suite, /showPccxLabBackendStatus/);
   assert.match(suite, /providerCallsImplemented/);
   assert.match(suite, /getDiagnostics/);
   assert.match(suite, /DiagnosticSeverity\.Error/);

--- a/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
+++ b/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
@@ -61,6 +61,8 @@ async function run() {
     "pccxSystemVerilog.runNavigationLive",
     "pccxSystemVerilog.showAIAssistantStatus",
     "pccxSystemVerilog.buildAIContextBundle",
+    "pccxSystemVerilog.proposeValidationCommand",
+    "pccxSystemVerilog.showPccxLabBackendStatus",
   ]);
 
   const manifest = readManifest();
@@ -241,6 +243,53 @@ async function run() {
   const liveDiagnostics = vscode.languages.getDiagnostics(vscode.Uri.file(liveBrokenPath));
   assert.ok(liveDiagnostics.length > 0, "live fixture diagnostics were not published");
 
+  const liveNavigationResult = await vscode.commands.executeCommand(
+    "pccxSystemVerilog.showLiveWorkspaceNavigation",
+  );
+  assert.equal(liveNavigationResult.ok, true);
+  assert.equal(liveNavigationResult.commandId, "pccxSystemVerilog.showLiveWorkspaceNavigation");
+  assert.equal(liveNavigationResult.action.kind, "navigation");
+  assert.equal(liveNavigationResult.plan.config.mode, "liveWorkspace");
+  assert.equal(liveNavigationResult.plan.config.liveWorkspace.enabled, true);
+  assert.deepEqual(liveNavigationResult.plan.facadeArgs, [
+    "navigation",
+    "--mode",
+    "live",
+    "--locate",
+    workspaceRoot,
+    "live_top",
+    "--kind",
+    "module",
+  ]);
+  assert.ok(Array.isArray(liveNavigationResult.action.items));
+  assert.equal(liveNavigationResult.action.items.length, 1);
+  assert.equal(liveNavigationResult.action.items[0].name, "live_top");
+  assert.equal(liveNavigationResult.action.items[0].kind, "module");
+  assert.equal(
+    path.resolve(liveNavigationResult.action.items[0].file),
+    path.resolve(workspaceRoot, "top.sv"),
+  );
+  assert.ok(Array.isArray(liveNavigationResult.locations));
+  assert.equal(liveNavigationResult.locations.length, 1);
+  assert.ok(liveNavigationResult.locations[0].uri instanceof vscode.Uri);
+  assert.ok(liveNavigationResult.locations[0].range instanceof vscode.Range);
+  assert.ok(liveNavigationResult.locations[0].location instanceof vscode.Location);
+  assert.equal(liveNavigationResult.locations[0].symbol, "live_top");
+  assert.equal(liveNavigationResult.locations[0].targetKind, "module");
+  assert.equal(liveNavigationResult.locations[0].source, "pccx-vscode-prototype");
+  assert.equal(
+    path.resolve(liveNavigationResult.locations[0].uri.fsPath),
+    path.resolve(workspaceRoot, "top.sv"),
+  );
+  assert.ok(
+    liveNavigationResult.action.items.every((item) => (
+      !item.file.includes("fixtures/modules") &&
+      item.name !== "simple_mod" &&
+      item.name !== "pkg_defs"
+    )),
+    "live navigation unexpectedly fell back to checked-example navigation",
+  );
+
   const aiStatus = await vscode.commands.executeCommand(
     "pccxSystemVerilog.showAIAssistantStatus",
   );
@@ -256,9 +305,11 @@ async function run() {
   assert.ok(aiStatus.status.disallowedActions.includes("writeFile"));
   assert.ok(aiStatus.status.disallowedActions.includes("release"));
 
-  const liveDocument = await vscode.workspace.openTextDocument(vscode.Uri.file(liveBrokenPath));
+  const liveDocument = await vscode.workspace.openTextDocument(vscode.Uri.file(
+    path.join(workspaceRoot, "top.sv"),
+  ));
   const liveEditor = await vscode.window.showTextDocument(liveDocument, { preview: false });
-  liveEditor.selection = new vscode.Selection(0, 0, 0, 12);
+  liveEditor.selection = new vscode.Selection(0, 7, 0, 15);
   const contextResult = await vscode.commands.executeCommand(
     "pccxSystemVerilog.buildAIContextBundle",
   );
@@ -269,22 +320,57 @@ async function run() {
   assert.equal(contextResult.providerCalls, false);
   assert.equal(contextResult.runtimeCalls, false);
   assert.deepEqual(contextResult.contextBundle.selectedFile, {
-    path: "broken_missing_endmodule.sv",
+    path: "top.sv",
   });
   assert.equal(contextResult.contextBundle.configuration.mode, "liveWorkspace");
   assert.equal(contextResult.contextBundle.configuration.aiAssistant.enabled, false);
   assert.equal(contextResult.contextBundle.configuration.aiAssistant.backend, "none");
-  assert.ok(contextResult.contextBundle.diagnostics.length > 0);
-  assert.equal(contextResult.contextBundle.diagnostics[0].path, "broken_missing_endmodule.sv");
+  assert.equal(contextResult.contextBundle.symbols.selected.name, "live_top");
+  assert.equal(contextResult.contextBundle.symbols.selected.kind, "module");
+  assert.equal(contextResult.contextBundle.symbols.selectedContext.symbolText, "live_top");
+  assert.equal(contextResult.contextBundle.symbols.selectedContext.lexicalKind, "module");
+  assert.equal(
+    contextResult.contextBundle.symbols.selectedContext.enclosingDeclaration.kind,
+    "module",
+  );
+  assert.equal(contextResult.contextBundle.symbols.selectedContext.relatedNavigation.length, 1);
   assert.equal(contextResult.contextBundle.snippets.length, 1);
-  assert.equal(contextResult.contextBundle.snippets[0].path, "broken_missing_endmodule.sv");
+  assert.equal(contextResult.contextBundle.snippets[0].path, "top.sv");
   assert.equal(
     contextResult.contextBundle.recentCommand.commandId,
-    "pccxSystemVerilog.publishLiveWorkspaceDiagnostics",
+    "pccxSystemVerilog.showLiveWorkspaceNavigation",
   );
   assert.doesNotMatch(JSON.stringify(contextResult.contextBundle), /\/home\//);
   assert.ok(contextResult.contextBundle.excludedPathPatterns.includes("node_modules/**"));
+  assert.doesNotMatch(JSON.stringify(contextResult.contextBundle), /AGENTS\.md/);
+  assert.doesNotMatch(JSON.stringify(contextResult.contextBundle), /package-lock\.json/);
   assert.equal(contextResult.contextBundle.redaction.assignmentPolicy, "secret-like-lines-redacted");
+
+  const validationProposal = await vscode.commands.executeCommand(
+    "pccxSystemVerilog.proposeValidationCommand",
+  );
+  assert.equal(validationProposal.ok, true);
+  assert.equal(validationProposal.kind, "validation-command-proposal");
+  assert.equal(validationProposal.execution, "proposalOnly");
+  assert.equal(validationProposal.executes, false);
+  assert.equal(validationProposal.providerCalls, false);
+  assert.equal(validationProposal.runtimeCalls, false);
+  assert.ok(validationProposal.proposals.some((proposal) => (
+    proposal.command?.argv?.join(" ") === "bash scripts/vscode-adapter-smoke.sh"
+  )));
+  assert.ok(validationProposal.proposals.some((proposal) => (
+    proposal.command?.env?.PCCX_RUN_EXTENSION_HOST_SMOKE === "1"
+  )));
+
+  const pccxLabStatus = await vscode.commands.executeCommand(
+    "pccxSystemVerilog.showPccxLabBackendStatus",
+  );
+  assert.equal(pccxLabStatus.ok, true);
+  assert.equal(pccxLabStatus.status.kind, "pccx-lab-backend-status");
+  assert.equal(pccxLabStatus.status.configuredCommand, "pccx_ide_cli");
+  assert.equal(pccxLabStatus.status.executes, false);
+  assert.equal(pccxLabStatus.status.backendCommandExecuted, false);
+  assert.ok(pccxLabStatus.status.futureControlledOperations.includes("diagnostics"));
 
   const extensionModule = await importExtensionEntrypoint();
   assert.equal(typeof extensionModule.deactivate, "function");

--- a/editors/vscode-prototype/test/extension-manifest.test.mjs
+++ b/editors/vscode-prototype/test/extension-manifest.test.mjs
@@ -16,6 +16,8 @@ const COMMAND_IDS = [
   "pccxSystemVerilog.runNavigationLive",
   "pccxSystemVerilog.showAIAssistantStatus",
   "pccxSystemVerilog.buildAIContextBundle",
+  "pccxSystemVerilog.proposeValidationCommand",
+  "pccxSystemVerilog.showPccxLabBackendStatus",
 ];
 
 async function readText(path) {
@@ -112,6 +114,8 @@ async function testDocsKeepExperimentalScope() {
   assert.match(combined, /boundary-only/i);
   assert.match(combined, /context bundle command/i);
   assert.match(combined, /AI assistant status command/i);
+  assert.match(combined, /validation command proposal/i);
+  assert.match(combined, /pccx-lab backend status/i);
   assert.match(combined, /no AI provider calls/i);
   assert.match(combined, /no MCP server implementation/i);
 }

--- a/editors/vscode-prototype/test/selected-symbol-context.test.mjs
+++ b/editors/vscode-prototype/test/selected-symbol-context.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+
+import {
+  SELECTED_SYMBOL_CONTEXT_VERSION,
+  buildSelectedSymbolContext,
+} from "../src/selected-symbol-context.mjs";
+
+function testLexicalModuleSymbolContext() {
+  const context = buildSelectedSymbolContext({
+    workspaceRoot: "/repo",
+    path: "/repo/rtl/top.sv",
+    language: "systemverilog",
+    selectionRange: {
+      start: { line: 0, character: 7 },
+      end: { line: 0, character: 15 },
+    },
+    cursorPosition: { line: 0, character: 10 },
+    selectionText: "live_top",
+    lines: [
+      { line: 0, text: "module live_top;" },
+      { line: 1, text: "endmodule" },
+    ],
+    diagnostics: [
+      {
+        file: "/repo/rtl/top.sv",
+        message: "near selection",
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 6 },
+        },
+      },
+    ],
+    navigationItems: [
+      { file: "/repo/rtl/top.sv", name: "live_top", kind: "module", line: 1, column: 8 },
+      { file: "/repo/rtl/other.sv", name: "other", kind: "module", line: 1, column: 8 },
+    ],
+  }, { workspaceRoot: "/repo" });
+
+  assert.equal(context.version, SELECTED_SYMBOL_CONTEXT_VERSION);
+  assert.equal(context.path, "rtl/top.sv");
+  assert.equal(context.symbolText, "live_top");
+  assert.equal(context.lexicalKind, "module");
+  assert.equal(context.range.start.line, 0);
+  assert.equal(context.range.start.character, 7);
+  assert.equal(context.currentLine.number, 1);
+  assert.equal(context.currentLine.text, "module live_top;");
+  assert.equal(context.enclosingDeclaration.kind, "module");
+  assert.equal(context.enclosingDeclaration.name, "live_top");
+  assert.equal(context.relatedNavigation.length, 1);
+  assert.equal(context.relatedNavigation[0].path, "rtl/top.sv");
+  assert.equal(context.nearbyDiagnostics.length, 1);
+  assert.equal(context.analysis.kind, "lexical");
+  assert.equal(context.analysis.semanticResolution, false);
+}
+
+function testCursorTokenFallbackAndBounds() {
+  const context = buildSelectedSymbolContext({
+    workspaceRoot: "/repo",
+    path: "/repo/rtl/pkg.sv",
+    selectionRange: {
+      start: { line: 1, character: 12 },
+      end: { line: 1, character: 12 },
+    },
+    cursorPosition: { line: 1, character: 14 },
+    lines: [
+      { line: 0, text: "package pkg_defs;" },
+      { line: 1, text: "  parameter WIDTH = 8;" },
+      { line: 2, text: "endpackage" },
+    ],
+  }, {
+    workspaceRoot: "/repo",
+    limits: {
+      maxLineCharacters: 12,
+    },
+  });
+
+  assert.equal(context.symbolText, "WIDTH");
+  assert.equal(context.lexicalKind, "parameter");
+  assert.equal(context.currentLine.text.length <= 12, true);
+  assert.equal(context.currentLine.truncated, true);
+  assert.equal(context.selectionSummary, null);
+}
+
+function testRestrictedPathsAndSecretLinesAreControlled() {
+  assert.equal(
+    buildSelectedSymbolContext({
+      workspaceRoot: "/repo",
+      path: "/repo/AGENTS.md",
+      lines: ["module ignored;"],
+    }, { workspaceRoot: "/repo" }),
+    null,
+  );
+  const context = buildSelectedSymbolContext({
+    workspaceRoot: "/repo",
+    path: "/repo/rtl/top.sv",
+    cursorPosition: { line: 0, character: 10 },
+    lines: [
+      { line: 0, text: "localparam API_KEY = 1;" },
+    ],
+    selectionText: "API_KEY = 1",
+    selectionRange: {
+      start: { line: 0, character: 11 },
+      end: { line: 0, character: 22 },
+    },
+  }, { workspaceRoot: "/repo" });
+  const serialized = JSON.stringify(context);
+
+  assert.equal(context.symbolText, "[redacted]");
+  assert.equal(context.currentLine.text, "[redacted]");
+  assert.deepEqual(context.selectionSummary.previewLines, ["[redacted]"]);
+  assert.doesNotMatch(serialized, /API_KEY/);
+  assert.doesNotMatch(serialized, /\/repo/);
+}
+
+testLexicalModuleSymbolContext();
+testCursorTokenFallbackAndBounds();
+testRestrictedPathsAndSecretLinesAreControlled();
+
+console.log("vscode selected-symbol context tests ok");

--- a/editors/vscode-prototype/test/static-boundary.test.mjs
+++ b/editors/vscode-prototype/test/static-boundary.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { readdir, readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 const EXTENSION_ROOT = resolve(ROOT, "editors/vscode-prototype");
@@ -129,6 +129,50 @@ async function testNoDirectShellInterpolation() {
   assert.doesNotMatch(source, /shell\s*=\s*True/);
 }
 
+async function testProposalAndStatusModulesAreDataOnly() {
+  const proposalAndStatusSource = await readCombined([
+    resolve(EXTENSION_ROOT, "src/validation-proposals.mjs"),
+    resolve(EXTENSION_ROOT, "src/pccx-lab-status.mjs"),
+  ]);
+
+  assert.doesNotMatch(
+    proposalAndStatusSource,
+    /node:child_process|\bexecFile\b|\bspawn\s*\(|\bexec\s*\(/,
+  );
+  assert.doesNotMatch(
+    proposalAndStatusSource,
+    /\bwriteFile\s*\(|\bappendFile\s*\(|\brm\s*\(|\bunlink\s*\(|\brename\s*\(/,
+  );
+  assert.doesNotMatch(proposalAndStatusSource, /\b(?:git|gh)\s+(?:push|commit|merge|release|tag)\b/i);
+  assert.doesNotMatch(proposalAndStatusSource, /\bgh\s+(?:secret|ruleset)\b/i);
+  assert.match(proposalAndStatusSource, /proposalOnly/);
+  assert.match(proposalAndStatusSource, /executes: false/);
+  assert.match(proposalAndStatusSource, /backendCommandExecuted: false/);
+}
+
+async function testContextBundleDoesNotSerializePrivateInstructionNames() {
+  const contextBundleModule = await import(pathToFileURL(resolve(
+    EXTENSION_ROOT,
+    "src/context-bundle.mjs",
+  )).href);
+  const bundle = contextBundleModule.buildContextBundle(
+    {
+      workspaceRoot: "/repo",
+      files: [
+        { path: "/repo/AGENTS.md", text: "private worker instruction" },
+        { path: "/repo/package-lock.json", text: "{\"packages\":{}}" },
+        { path: "/repo/rtl/top.sv", text: "module top;\nendmodule\n" },
+      ],
+    },
+    { workspaceRoot: "/repo" },
+  );
+  const serialized = JSON.stringify(bundle);
+
+  assert.deepEqual(bundle.snippets.map((snippet) => snippet.path), ["rtl/top.sv"]);
+  assert.doesNotMatch(serialized, /AGENTS\.md/);
+  assert.doesNotMatch(serialized, /package-lock\.json/);
+}
+
 async function testNoPositiveReadinessClaims() {
   const files = [
     ...await listFiles(ROOT, {
@@ -167,6 +211,8 @@ await testNoLauncherOrMcpRuntimeImplementation();
 await testNoDirectCliCallsFromUiOrProviderLayers();
 await testNoPackagingPublisherOrLspDependencies();
 await testNoDirectShellInterpolation();
+await testProposalAndStatusModulesAreDataOnly();
+await testContextBundleDoesNotSerializePrivateInstructionNames();
 await testNoPositiveReadinessClaims();
 
 console.log("vscode static boundary tests ok");

--- a/editors/vscode-prototype/test/validation-proposals.test.mjs
+++ b/editors/vscode-prototype/test/validation-proposals.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+
+import {
+  VALIDATION_PROPOSAL_CATEGORIES,
+  VALIDATION_PROPOSAL_VERSION,
+  createValidationCommandProposal,
+} from "../src/validation-proposals.mjs";
+import {
+  PCCX_LAB_BACKEND_STATUS_VERSION,
+  createPccxLabBackendStatus,
+} from "../src/pccx-lab-status.mjs";
+
+const SHELL_CONTROL_PATTERN = /(?:&&|\|\||;|`|\$\(|>|<)/;
+
+function testValidationProposalIsDataOnly() {
+  const proposal = createValidationCommandProposal({
+    userCommand: "git push origin main && rm -rf /",
+  });
+
+  assert.equal(proposal.version, VALIDATION_PROPOSAL_VERSION);
+  assert.equal(proposal.kind, "validation-command-proposal");
+  assert.equal(proposal.execution, "proposalOnly");
+  assert.equal(proposal.proposalOnly, true);
+  assert.equal(proposal.executes, false);
+  assert.equal(proposal.requiresUserApproval, true);
+  assert.equal(proposal.providerCalls, false);
+  assert.equal(proposal.runtimeCalls, false);
+  assert.deepEqual(
+    proposal.proposals.map((item) => item.category),
+    VALIDATION_PROPOSAL_CATEGORIES,
+  );
+  assert.ok(proposal.proposals.every((item) => item.requiresUserApproval === true));
+  assert.ok(proposal.proposals.every((item) => item.executes === false));
+  assert.ok(proposal.disallowedActions.includes("commit"));
+  assert.ok(proposal.disallowedActions.includes("release"));
+  assert.doesNotMatch(JSON.stringify(proposal), /git push|rm -rf/);
+}
+
+function testValidationCommandsAreAllowlistedArgumentArrays() {
+  const proposal = createValidationCommandProposal();
+  const commandProposals = proposal.proposals.filter((item) => item.command);
+  const flattened = commandProposals.flatMap((item) => item.command.argv);
+
+  assert.ok(commandProposals.length > 0);
+  assert.ok(commandProposals.every((item) => item.command.cwd === "repo-root"));
+  assert.ok(commandProposals.every((item) => Array.isArray(item.command.argv)));
+  assert.ok(commandProposals.every((item) => item.command.argv.every((arg) => typeof arg === "string")));
+  assert.ok(commandProposals.some((item) => (
+    item.command.env.PCCX_RUN_EXTENSION_HOST_SMOKE === "1"
+  )));
+  assert.doesNotMatch(flattened.join("\n"), SHELL_CONTROL_PATTERN);
+  assert.doesNotMatch(flattened.join("\n"), /\b(?:git|gh)\s+(?:push|commit|merge|release|tag)\b/i);
+}
+
+function testPccxLabStatusIsStatusOnly() {
+  const status = createPccxLabBackendStatus({
+    pccxLab: { command: "custom-pccx-lab" },
+  });
+
+  assert.equal(status.version, PCCX_LAB_BACKEND_STATUS_VERSION);
+  assert.equal(status.kind, "pccx-lab-backend-status");
+  assert.equal(status.configuredCommand, "custom-pccx-lab");
+  assert.equal(status.execution, "statusOnly");
+  assert.equal(status.executes, false);
+  assert.equal(status.providerCalls, false);
+  assert.equal(status.runtimeCalls, false);
+  assert.equal(status.backendCommandExecuted, false);
+  assert.ok(status.futureControlledOperations.includes("diagnostics"));
+  assert.ok(status.futureControlledOperations.includes("xsim-log analysis"));
+}
+
+testValidationProposalIsDataOnly();
+testValidationCommandsAreAllowlistedArgumentArrays();
+testPccxLabStatusIsStatusOnly();
+
+console.log("vscode validation proposal and pccx-lab status tests ok");

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -15,7 +15,9 @@ node editors/vscode-prototype/test/facade.test.mjs
 node editors/vscode-prototype/test/extension-manifest.test.mjs
 node editors/vscode-prototype/test/extension-config.test.mjs
 node editors/vscode-prototype/test/context-bundle.test.mjs
+node editors/vscode-prototype/test/selected-symbol-context.test.mjs
 node editors/vscode-prototype/test/ai-assistant-boundary.test.mjs
+node editors/vscode-prototype/test/validation-proposals.test.mjs
 node editors/vscode-prototype/test/static-boundary.test.mjs
 node editors/vscode-prototype/test/extension-entrypoint.test.mjs
 node editors/vscode-prototype/test/command-handlers.test.mjs


### PR DESCRIPTION
## Summary
- Adds fixture-backed live navigation smoke coverage for the controlled VS Code fixture workspace.
- Adds bounded lexical selected-symbol context to the AI context bundle command.
- Adds proposal-only validation command data and status-only pccx-lab backend command preparation.
- Strengthens static/runtime guards and docs for token-saving context and controlled tool boundaries.

## Scope
- Experimental only.
- checked-example remains default.
- live workspace remains explicit opt-in.
- Live navigation fixture status: smoke-tested against test/fixtures/live-workspace for live_top without QuickPick/UI blocking.
- Selected-symbol context is bounded/lexical, not full semantic SystemVerilog analysis.
- AI context command is local context only.
- Validation command proposal is data only and does not execute.
- pccx-lab backend status command does not execute pccx-lab.
- No AI provider calls.
- No pccx-llm-launcher runtime calls yet.
- No MCP server implementation.
- No LSP.
- No marketplace packaging.
- No stable API/ABI claim.
- No release/tag.

## Validation
- npm ci --prefix editors/vscode-prototype
- bash scripts/vscode-adapter-smoke.sh
- PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh
- bash scripts/vscode-extension-host-smoke.sh (confirmed guarded exit 2)
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- python3 -m pytest -q
- git diff --check
