### PR TITLE
feat: add approved validation runner boundary

### DIFF
--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -92,7 +92,8 @@ commands fail clearly instead of falling back to examples.  The current
 AI-assisted SystemVerilog development workflow work is boundary-only:
 AI assistant status and context bundle commands expose local status,
 bounded context, selected-symbol context, validation command proposal
-data, and proposal actions, with no AI provider calls, no
+data, disabled-by-default approved validation runner status/result data,
+and proposal actions, with no AI provider calls, no
 pccx-llm-launcher runtime calls yet, and no MCP server implementation.
 
 The same directory now includes an experimental local VS Code extension
@@ -144,9 +145,12 @@ path.  Context bundle records should carry selected file/range,
 bounded lexical selected-symbol context, diagnostics, declaration
 references, recent command status, current mode, validation summaries, and
 bounded snippets by path/range instead of whole workspaces.  Any command
-proposal or validation proposal must route through the facade or pccx-lab
-CLI/core boundary and remain a proposal until an editor/user-controlled
-executor accepts it.
+proposal or validation proposal must remain proposal-only until an
+editor/user-controlled executor accepts an allowlisted proposal ID.
+Approved validation execution must use fixed argument arrays, bounded
+output, an explicit user-approved command invocation, and no shell
+interpolation.  pccx-lab command execution remains future/prepared in
+this prototype.
 
 `problems` converts local diagnostics and log records into editor-friendly
 problem records.  `index` provides scanner-based module/package/interface

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -28,7 +28,8 @@ rather than being duplicated inside this extension scaffold.
 `pccx-llm-launcher` is a future local LLM/chat/model backend candidate.
 This prototype only adds AI assistant status and context bundle commands
 behind a controlled tool boundary, plus a validation command proposal
-surface that returns data only.  There are no AI provider calls, no
+surface that returns data only and a disabled-by-default approved
+validation runner for allowlisted proposal IDs.  There are no AI provider calls, no
 pccx-llm-launcher runtime calls, and no MCP server implementation in this
 scaffold.
 
@@ -136,6 +137,7 @@ The contributed commands are:
 - `pccxSystemVerilog.showAIAssistantStatus`
 - `pccxSystemVerilog.buildAIContextBundle`
 - `pccxSystemVerilog.proposeValidationCommand`
+- `pccxSystemVerilog.runApprovedValidationCommand`
 - `pccxSystemVerilog.showPccxLabBackendStatus`
 
 The prototype-only settings are:
@@ -145,6 +147,11 @@ The prototype-only settings are:
 - `pccxSystemVerilog.pccxLab.command`, default `pccx_ide_cli`
 - `pccxSystemVerilog.aiAssistant.enabled`, default `false`
 - `pccxSystemVerilog.aiAssistant.backend`, default `none`
+- `pccxSystemVerilog.validationRunner.enabled`, default `false`
+- `pccxSystemVerilog.validationRunner.mode`, default `disabled`
+- `pccxSystemVerilog.validationRunner.defaultWorkingDirectory`, default `repo-root`
+- `pccxSystemVerilog.validationRunner.maxOutputLines`, default `120`
+- `pccxSystemVerilog.validationRunner.timeoutMs`, default `30000`
 - `pccxSystemVerilog.pythonPath`, default `python3`
 - `pccxSystemVerilog.defaultSource`, default `fixtures/missing_endmodule.sv`
 - `pccxSystemVerilog.defaultLog`, default `fixtures/xsim/mixed.log`
@@ -182,7 +189,9 @@ status surface for future pccx-lab integration.  It returns the configured
 `pccxSystemVerilog.pccxLab.command` value, marks the integration as a
 placeholder/status-only boundary, lists future controlled operations such
 as diagnostics, index, locate, declarations, xsim-log analysis, and
-validation summary, and does not execute pccx-lab.
+validation summary, lists required future safety properties such as fixed
+args, no shell interpolation, explicit user approval, bounded output, and
+context bundle summary, and does not execute pccx-lab.
 
 `src/command-handlers.mjs` is the experimental local command-handler
 scaffold.  It maps command ID -> normalized prototype settings -> known
@@ -231,7 +240,9 @@ executes live navigation against the same fixture without QuickPick
 blocking.  It also executes the checked-example diagnostics/navigation
 command paths plus the provider smoke.  It checks the AI assistant status
 command, selected-symbol context bundle command, validation command
-proposal, and pccx-lab backend status command without provider/runtime
+proposal, disabled approved validation runner behavior, one explicit
+allowlisted validation run, validation summary handoff into the context
+bundle, and pccx-lab backend status command without provider/runtime
 calls.  It does not
 package the extension, add an LSP provider, or install through a
 marketplace flow.  Extension Host gates are
@@ -257,7 +268,10 @@ for the active editor state without calling a provider.  It prefers the
 current file path, selected range, bounded lexical selected-symbol
 context, active diagnostics near the selection, recent navigation
 references, recent command status, current mode/configuration, and small
-bounded snippets only for explicit selections.  The selected-symbol
+bounded snippets only for explicit selections.  It can also include the
+latest approved validation runner summary: proposal ID, status, command
+label, exit code, duration/timestamps, bounded stdout/stderr summaries,
+failure hints, and safety metadata.  The selected-symbol
 context extracts simple SystemVerilog-like lexical cues such as the symbol
 text, current line, and nearby module/package/interface/parameter/function
 or task declaration; it is not full semantic analysis.  The bundle
@@ -273,9 +287,26 @@ The boundary notes are tracked in
 
 `pccxSystemVerilog.proposeValidationCommand` returns allowlisted
 validation command proposals as JSON data.  The proposal includes
-argument-array templates, reasons, risk levels, and explicit user approval
-requirements.  It does not spawn a process, call pccx-lab, call an AI
-provider, write files, or run git operations.
+allowlisted proposal IDs, argument-array templates, reasons, risk levels, and
+explicit user approval requirements.  It does not spawn a process, call
+pccx-lab, call an AI provider, write files, or run git operations.
+
+`pccxSystemVerilog.runApprovedValidationCommand` is a separate approved
+validation runner boundary.  It is disabled by default; execution requires
+`pccxSystemVerilog.validationRunner.enabled=true` and
+`pccxSystemVerilog.validationRunner.mode=allowlisted`.  The command
+accepts proposal IDs only, not raw command strings, and re-resolves those
+IDs through the internal allowlist before execution.  Initial runnable IDs
+are `vscodeAdapterSmoke`, `editorBridgeSmoke`, `exampleDriftCheck`, and
+`pytestBaseline`.  `extensionHostSmokeOptIn` remains proposal-only from
+inside the runner.  The runner uses fixed executable and argument arrays
+with `shell=false`, enforces a timeout, bounds stdout/stderr summaries,
+and returns JSON with safety metadata.  The runner does not add a UI
+approval prompt in this prototype; callers should invoke it only after a
+user-approved validation proposal.  It does not execute destructive
+commands, git write operations, release/tag/settings/secrets commands,
+patch proposals, AI provider calls, pccx-llm-launcher runtime calls, MCP
+server operations, or pccx-lab commands.
 
 ## Theme-Neutral Presentation Boundary
 
@@ -305,15 +336,16 @@ Now:
 - AI assistant status command and bounded context bundle command
 - selected-symbol context
 - validation command proposal
+- disabled-by-default approved validation runner boundary
+- recent validation summary in the context bundle
 - pccx-lab backend status command
 
 Next:
 
-- pccx-lab command palette execution with allowlisted commands
 - selected-symbol to declaration context through live navigation
 - diagnostics-aware prompt builder
-- validation result cache
 - patch proposal format
+- pccx-lab command palette execution with allowlisted commands
 
 Later:
 
@@ -321,6 +353,16 @@ Later:
 - MCP controlled tool boundary
 - richer editor UI/panels
 - optional theme presets through host/user theme tokens
+
+## Prototype Daily-Driver Loop
+
+1. Inspect checked-example or explicit live workspace diagnostics and navigation.
+2. Build a selected-symbol AI context bundle for the active editor state.
+3. Propose a validation command as data with `pccxSystemVerilog.proposeValidationCommand`.
+4. User approves an allowlisted validation proposal ID.
+5. Run `pccxSystemVerilog.runApprovedValidationCommand` only after the runner is explicitly enabled.
+6. Feed the bounded validation result summary back into the context bundle.
+7. Future local coding-assistant mode can propose a patch or next validation step, but does not execute either directly.
 
 ## Local Smoke
 
@@ -334,6 +376,8 @@ node editors/vscode-prototype/test/context-bundle.test.mjs
 node editors/vscode-prototype/test/selected-symbol-context.test.mjs
 node editors/vscode-prototype/test/ai-assistant-boundary.test.mjs
 node editors/vscode-prototype/test/validation-proposals.test.mjs
+node editors/vscode-prototype/test/validation-result-summary.test.mjs
+node editors/vscode-prototype/test/approved-validation-runner.test.mjs
 node editors/vscode-prototype/test/static-boundary.test.mjs
 node editors/vscode-prototype/test/extension-entrypoint.test.mjs
 node editors/vscode-prototype/test/command-handlers.test.mjs

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -46,6 +46,10 @@ should earn CI promotion separately.
   symbol context is lexical and bounded, not full semantic analysis.
 - Validation command proposal smoke.  The command returns data only and
   does not execute validation commands.
+- Approved validation runner smoke.  The command blocks by default,
+  then runs one fast allowlisted proposal only after explicit test
+  configuration and feeds a bounded validation summary into the context
+  bundle.
 - pccx-lab backend status smoke.  The command reports the configured
   boundary and does not execute pccx-lab.
 - Guard behavior for the local-only Extension Host runtime smoke.
@@ -115,11 +119,13 @@ checked-example symbols.  It executes
 `pccxSystemVerilog.showAIAssistantStatus`,
 `pccxSystemVerilog.buildAIContextBundle`,
 `pccxSystemVerilog.proposeValidationCommand`, and
+`pccxSystemVerilog.runApprovedValidationCommand`, and
 `pccxSystemVerilog.showPccxLabBackendStatus`, verifying disabled/backend
-`none` status, proposal-only actions, bounded active-file and
-selected-symbol context, status-only pccx-lab boundary data, and no
-provider/runtime calls.  This is not LSP, and there is no LSP provider
-yet.
+`none` status, proposal-only actions, disabled runner blocking behavior,
+one explicitly enabled allowlisted validation run, bounded active-file
+and selected-symbol context, bounded validation summary handoff,
+status-only pccx-lab boundary data, and no provider/runtime calls.  This
+is not LSP, and there is no LSP provider yet.
 
 ## AI Assistant Boundary
 
@@ -138,11 +144,25 @@ smoke, example drift check, pytest baseline, and opt-in Extension Host
 smoke.  The command returns JSON data with reasons, risk levels, and a
 required user approval marker; it does not execute the command.
 
+`pccxSystemVerilog.runApprovedValidationCommand` is a separate approved
+validation runner.  It is disabled unless
+`validationRunner.enabled=true` and `validationRunner.mode=allowlisted`
+are set.  It accepts proposal IDs only and executes only fixed
+allowlisted command/argument arrays.  Output is bounded and summarized
+for token-saving context bundles.  It does not execute raw command
+strings, destructive commands, git write operations,
+release/tag/settings/secrets commands, pccx-lab commands, AI provider calls,
+pccx-llm-launcher runtime calls, or MCP server operations.  It does not
+add a UI approval prompt in this prototype; callers should invoke it only
+after a user-approved validation proposal.
+
 `pccxSystemVerilog.showPccxLabBackendStatus` is preparation for future
 command palette integration.  It reports the configured
 `pccxSystemVerilog.pccxLab.command`, lists future controlled operations
 such as diagnostics, index, locate, declarations, xsim-log analysis, and
-validation summary, and does not execute pccx-lab.
+validation summary, lists future safety requirements such as fixed args,
+no shell interpolation, explicit user approval, bounded output, and
+context bundle summary, and does not execute pccx-lab.
 
 The guarded script is not run by CI today.
 
@@ -190,3 +210,5 @@ system.
 8. Do not make live workspace mode the default.
 9. Do not add AI provider calls, pccx-llm-launcher runtime calls, or MCP
    server implementation without a separate contract review.
+10. Keep approved validation execution disabled by default and restricted
+    to allowlisted proposal IDs.

--- a/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
+++ b/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
@@ -18,6 +18,11 @@ AI assistant behavior is disabled by default:
 - `pccxSystemVerilog.aiAssistant.enabled=false`
 - `pccxSystemVerilog.aiAssistant.backend=none`
 
+Approved validation execution is disabled by default:
+
+- `pccxSystemVerilog.validationRunner.enabled=false`
+- `pccxSystemVerilog.validationRunner.mode=disabled`
+
 ## Roles
 
 ```text
@@ -79,6 +84,9 @@ proposal boundaries.  `pccxSystemVerilog.buildAIContextBundle` returns a
 bounded context bundle for the active editor state.
 `pccxSystemVerilog.proposeValidationCommand` returns allowlisted
 validation command proposals as data and does not execute them.
+`pccxSystemVerilog.runApprovedValidationCommand` is a separate approved
+validation runner command.  It only runs after explicit configuration and
+only accepts allowlisted proposal IDs, not raw command strings.
 `pccxSystemVerilog.showPccxLabBackendStatus` reports the configured
 pccx-lab command boundary and future controlled operations without
 running pccx-lab.  There are no AI provider calls, no external API keys,
@@ -117,7 +125,7 @@ The context bundle is a token-saving JSON contract.  It prefers:
 - active diagnostics around the selected range
 - current mode/configuration
 - recent command status
-- recent validation status
+- recent validation result summary
 - pccx-lab command output summaries
 - bounded snippets for explicit selections with path/range references
 - summarized logs, not full logs
@@ -151,6 +159,34 @@ and a required user approval marker.  The command returns JSON data only:
 it does not spawn a process, call pccx-lab, call an AI provider, write
 files, or run git commands.
 
+The approved validation runner re-resolves proposal IDs through an
+internal allowlist.  Runnable initial IDs are `vscodeAdapterSmoke`,
+`editorBridgeSmoke`, `exampleDriftCheck`, and `pytestBaseline`.
+`extensionHostSmokeOptIn` stays proposal-only inside the runner.  Runner
+execution uses fixed executable/argument arrays, `shell=false`, bounded
+stdout/stderr, a timeout, and JSON-serializable status.  It blocks
+unknown IDs, raw command strings, destructive command patterns, git write
+operations, release/tag/settings/secrets commands, patch proposals,
+provider calls, pccx-llm-launcher runtime calls, MCP server operations,
+and pccx-lab execution.  The runner does not add a UI approval prompt in
+this prototype; callers should invoke it only after a user-approved
+validation proposal.
+
+When a validation run is attempted, the context bundle can carry a recent
+validation summary with proposal ID, status, command label, exit code,
+duration/timestamps, bounded stdout/stderr summaries, short failure
+hints, and safety metadata.  It does not include full logs.
+
+## Prototype Daily-Driver Loop
+
+1. Inspect diagnostics and navigation.
+2. Build a selected-symbol AI context bundle.
+3. Propose a validation command.
+4. User approves an allowlisted validation command.
+5. The runner executes bounded validation after explicit enablement.
+6. The validation summary flows back into the context bundle.
+7. Future AI-assisted SystemVerilog development workflow can propose a patch or next validation, but does not execute directly.
+
 ## Daily-Driver Roadmap
 
 Now:
@@ -161,15 +197,16 @@ Now:
 - context bundle command
 - selected-symbol context
 - validation command proposal
+- approved validation runner boundary
+- validation summary in the context bundle
 - pccx-lab backend status
 
 Next:
 
-- pccx-lab command palette execution with allowlisted commands
 - selected-symbol to declaration context through live navigation
 - diagnostics-aware prompt builder
-- validation result cache
 - patch proposal format
+- pccx-lab command palette execution with allowlisted commands
 
 Later:
 

--- a/editors/vscode-prototype/package.json
+++ b/editors/vscode-prototype/package.json
@@ -24,6 +24,7 @@
     "onCommand:pccxSystemVerilog.showAIAssistantStatus",
     "onCommand:pccxSystemVerilog.buildAIContextBundle",
     "onCommand:pccxSystemVerilog.proposeValidationCommand",
+    "onCommand:pccxSystemVerilog.runApprovedValidationCommand",
     "onCommand:pccxSystemVerilog.showPccxLabBackendStatus"
   ],
   "contributes": {
@@ -73,6 +74,10 @@
         "title": "PCCX SystemVerilog: Propose Validation Command (Experimental)"
       },
       {
+        "command": "pccxSystemVerilog.runApprovedValidationCommand",
+        "title": "PCCX SystemVerilog: Run Approved Validation Command (Experimental, Opt-In)"
+      },
+      {
         "command": "pccxSystemVerilog.showPccxLabBackendStatus",
         "title": "PCCX SystemVerilog: Show pccx-lab Backend Status (Experimental)"
       }
@@ -113,6 +118,43 @@
           ],
           "default": "none",
           "description": "Experimental local prototype AI assistant backend selector for future controlled tool boundaries; no runtime calls in this scaffold and not a stable API."
+        },
+        "pccxSystemVerilog.validationRunner.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Experimental local prototype opt-in gate for approved validation runner execution; disabled by default and not a stable API."
+        },
+        "pccxSystemVerilog.validationRunner.mode": {
+          "type": "string",
+          "enum": [
+            "disabled",
+            "allowlisted"
+          ],
+          "default": "disabled",
+          "description": "Experimental local prototype validation runner mode; allowlisted mode must be explicit and is not a stable API."
+        },
+        "pccxSystemVerilog.validationRunner.defaultWorkingDirectory": {
+          "type": "string",
+          "enum": [
+            "repo-root",
+            "workspace"
+          ],
+          "default": "repo-root",
+          "description": "Experimental local prototype working-directory label for approved validation runner commands; fixed allowlisted commands may override it and this is not a stable API."
+        },
+        "pccxSystemVerilog.validationRunner.maxOutputLines": {
+          "type": "integer",
+          "default": 120,
+          "minimum": 1,
+          "maximum": 500,
+          "description": "Experimental local prototype maximum stdout/stderr lines retained in approved validation summaries; not a stable API."
+        },
+        "pccxSystemVerilog.validationRunner.timeoutMs": {
+          "type": "integer",
+          "default": 30000,
+          "minimum": 1000,
+          "maximum": 120000,
+          "description": "Experimental local prototype timeout in milliseconds for approved validation runner commands; not a stable API."
         },
         "pccxSystemVerilog.pythonPath": {
           "type": "string",

--- a/editors/vscode-prototype/src/approved-validation-runner.mjs
+++ b/editors/vscode-prototype/src/approved-validation-runner.mjs
@@ -1,0 +1,305 @@
+import { execFile } from "node:child_process";
+import { resolve } from "node:path";
+
+import { normalizeConfig } from "./config.mjs";
+import { findValidationCommandProposalById } from "./validation-proposals.mjs";
+import {
+  createValidationResultSummary,
+  summarizeOutputText,
+} from "./validation-result-summary.mjs";
+
+export const APPROVED_VALIDATION_RESULT_VERSION = "pccx.approvedValidationResult.v0";
+
+const DISALLOWED_ARG_PATTERN =
+  /(?:&&|\|\||;|`|\$\(|>|<|\brm\b|\bsudo\b|\bgit\b|\bgh\b|\bcommit\b|\bpush\b|\bmerge\b|\brelease\b|\btag\b|\bruleset\b|\bsettings\b|\bsecret\b|\bpatch\b)/i;
+const ALLOWED_EXECUTABLES = new Set(["bash", "python3"]);
+const PROPOSAL_ID_PATTERN = /^[A-Za-z][A-Za-z0-9]*$/;
+
+function nowIso(clock = Date) {
+  return new Date(clock.now()).toISOString();
+}
+
+function durationMs(startedMs, finishedMs) {
+  return Math.max(0, Math.floor(finishedMs - startedMs));
+}
+
+function safeArray(value) {
+  return Array.isArray(value) ? value.filter((item) => typeof item === "string") : [];
+}
+
+export function resolveApprovedValidationProposalId(input) {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input && typeof input === "object" && typeof input.proposalId === "string") {
+    return input.proposalId;
+  }
+  return null;
+}
+
+function safeBaseResult(proposalId, proposal = null) {
+  const argv = safeArray(proposal?.command?.argv);
+  return {
+    version: APPROVED_VALIDATION_RESULT_VERSION,
+    kind: "approved-validation-result",
+    proposalId: proposalId ?? "",
+    commandLabel: proposal?.label ?? "",
+    command: argv[0] ?? "",
+    args: argv.slice(1),
+    cwdKind: proposal?.command?.cwd ?? "",
+    cwdLabel: proposal?.command?.cwd ?? "",
+    exitCode: null,
+    status: "blocked",
+    stdoutSummary: { lines: [], lineCount: 0, truncated: false },
+    stderrSummary: { lines: [], lineCount: 0, truncated: false },
+    startedAt: "",
+    finishedAt: "",
+    durationMs: 0,
+    blockedReason: "",
+    safety: {
+      allowlisted: Boolean(proposal?.command),
+      shell: false,
+      fixedArgs: true,
+      userProvidedCommand: false,
+      writesFiles: false,
+      providerCalls: false,
+      launcherCalls: false,
+      mcpServerCalls: false,
+    },
+    ok: false,
+  };
+}
+
+function blockedResult(proposalId, proposal, reason, options = {}) {
+  const startedMs = options.startedMs ?? Date.now();
+  const finishedMs = options.finishedMs ?? startedMs;
+  const result = {
+    ...safeBaseResult(proposalId, proposal),
+    blockedReason: reason,
+    startedAt: options.startedAt ?? "",
+    finishedAt: options.finishedAt ?? "",
+    durationMs: durationMs(startedMs, finishedMs),
+    stderrSummary: summarizeOutputText(reason, {
+      maxOutputLines: options.maxOutputLines ?? 1,
+    }),
+  };
+  result.resultSummary = createValidationResultSummary(result, {
+    maxOutputLines: options.maxOutputLines,
+  });
+  return result;
+}
+
+function validateAllowlistedCommand(proposal) {
+  const argv = safeArray(proposal?.command?.argv);
+  if (!proposal?.command || argv.length === 0) {
+    throw new Error("validation proposal has no executable command");
+  }
+  const executable = argv[0];
+  if (!ALLOWED_EXECUTABLES.has(executable)) {
+    throw new Error(`validation executable is not allowlisted: ${executable}`);
+  }
+  for (const item of argv) {
+    if (DISALLOWED_ARG_PATTERN.test(item)) {
+      throw new Error(`validation command contains a blocked argument pattern: ${item}`);
+    }
+  }
+  for (const [key, value] of Object.entries(proposal.command.env ?? {})) {
+    if (DISALLOWED_ARG_PATTERN.test(key) || DISALLOWED_ARG_PATTERN.test(String(value))) {
+      throw new Error(`validation command contains a blocked environment shape: ${key}`);
+    }
+  }
+  return {
+    executable,
+    args: argv.slice(1),
+  };
+}
+
+function cwdForProposal(proposal, options = {}) {
+  const cwdKind = proposal?.command?.cwd ?? options.defaultWorkingDirectory ?? "repo-root";
+  if (cwdKind === "repo-root") {
+    return {
+      cwd: options.repoRoot ?? process.cwd(),
+      cwdKind: "repo-root",
+      cwdLabel: "repo-root",
+    };
+  }
+  if (cwdKind === "workspace") {
+    return {
+      cwd: options.workspaceRoot ?? options.repoRoot ?? process.cwd(),
+      cwdKind: "workspace",
+      cwdLabel: "workspace",
+    };
+  }
+  return {
+    cwd: options.repoRoot ?? process.cwd(),
+    cwdKind: "repo-root",
+    cwdLabel: "repo-root",
+  };
+}
+
+function envForProposal(proposal, options = {}) {
+  return {
+    ...(options.env ?? process.env),
+    ...(proposal?.command?.env ?? {}),
+  };
+}
+
+function captureExecFile(executable, args, options = {}) {
+  const execFileFn = options.execFile ?? execFile;
+  return new Promise((resolveResult) => {
+    execFileFn(
+      executable,
+      args,
+      {
+        cwd: options.cwd,
+        encoding: "utf8",
+        env: options.env,
+        maxBuffer: 128 * 1024,
+        shell: false,
+        timeout: options.timeoutMs,
+        windowsHide: true,
+      },
+      (error, stdout, stderr) => {
+        const timedOut = error?.killed === true ||
+          error?.signal === "SIGTERM" ||
+          error?.code === "ETIMEDOUT" ||
+          /timed out|timeout/i.test(error?.message ?? "");
+        const exitCode = error
+          ? (typeof error.code === "number" ? error.code : null)
+          : 0;
+        resolveResult({
+          exitCode,
+          timedOut,
+          stdout: stdout ?? "",
+          stderr: stderr ?? "",
+          error: error && typeof error.code !== "number" ? error.message : "",
+        });
+      },
+    );
+  });
+}
+
+export async function runApprovedValidationProposal(input, rawConfig = {}, options = {}) {
+  const config = normalizeConfig(rawConfig);
+  const proposalId = resolveApprovedValidationProposalId(input);
+  const maxOutputLines = config.validationRunner.maxOutputLines;
+  const startedMs = options.clock?.now?.() ?? Date.now();
+  const startedAt = nowIso(options.clock ?? Date);
+
+  if (!proposalId || !PROPOSAL_ID_PATTERN.test(proposalId)) {
+    const finishedMs = options.clock?.now?.() ?? Date.now();
+    return blockedResult("", null, "approved validation runner accepts a proposal ID only", {
+      maxOutputLines,
+      startedMs,
+      finishedMs,
+      startedAt,
+      finishedAt: nowIso(options.clock ?? Date),
+    });
+  }
+
+  const proposal = findValidationCommandProposalById(proposalId);
+  if (!proposal) {
+    const finishedMs = options.clock?.now?.() ?? Date.now();
+    return blockedResult(proposalId, null, "unknown validation proposal ID", {
+      maxOutputLines,
+      startedMs,
+      finishedMs,
+      startedAt,
+      finishedAt: nowIso(options.clock ?? Date),
+    });
+  }
+
+  if (!config.validationRunner.enabled || config.validationRunner.mode !== "allowlisted") {
+    const finishedMs = options.clock?.now?.() ?? Date.now();
+    return blockedResult(
+      proposalId,
+      proposal,
+      "approved validation runner is disabled; set validationRunner.enabled=true and validationRunner.mode=allowlisted",
+      {
+        maxOutputLines,
+        startedMs,
+        finishedMs,
+        startedAt,
+        finishedAt: nowIso(options.clock ?? Date),
+      },
+    );
+  }
+
+  if (proposal.runnerPolicy === "proposalOnly") {
+    const finishedMs = options.clock?.now?.() ?? Date.now();
+    return blockedResult(
+      proposalId,
+      proposal,
+      proposal.runnerBlockedReason || "validation proposal remains proposal-only",
+      {
+        maxOutputLines,
+        startedMs,
+        finishedMs,
+        startedAt,
+        finishedAt: nowIso(options.clock ?? Date),
+      },
+    );
+  }
+
+  let executable;
+  let args;
+  try {
+    ({ executable, args } = validateAllowlistedCommand(proposal));
+  } catch (error) {
+    const finishedMs = options.clock?.now?.() ?? Date.now();
+    return blockedResult(proposalId, proposal, error.message, {
+      maxOutputLines,
+      startedMs,
+      finishedMs,
+      startedAt,
+      finishedAt: nowIso(options.clock ?? Date),
+    });
+  }
+
+  const cwd = cwdForProposal(proposal, {
+    ...options,
+    defaultWorkingDirectory: config.validationRunner.defaultWorkingDirectory,
+  });
+  const execution = await captureExecFile(executable, args, {
+    cwd: resolve(cwd.cwd),
+    env: envForProposal(proposal, options),
+    execFile: options.execFile,
+    timeoutMs: config.validationRunner.timeoutMs,
+  });
+  const finishedMs = options.clock?.now?.() ?? Date.now();
+  const status = execution.timedOut
+    ? "timedOut"
+    : (execution.exitCode === 0 ? "passed" : "failed");
+  const result = {
+    ...safeBaseResult(proposalId, proposal),
+    command: executable,
+    args,
+    cwdKind: cwd.cwdKind,
+    cwdLabel: cwd.cwdLabel,
+    exitCode: execution.exitCode,
+    status,
+    stdoutSummary: summarizeOutputText(execution.stdout, { maxOutputLines }),
+    stderrSummary: summarizeOutputText(
+      execution.error
+        ? [execution.stderr, execution.error].filter(Boolean).join("\n")
+        : execution.stderr,
+      { maxOutputLines },
+    ),
+    startedAt,
+    finishedAt: nowIso(options.clock ?? Date),
+    durationMs: durationMs(startedMs, finishedMs),
+    ok: status === "passed",
+    safety: {
+      allowlisted: true,
+      shell: false,
+      fixedArgs: true,
+      userProvidedCommand: false,
+      writesFiles: false,
+      providerCalls: false,
+      launcherCalls: false,
+      mcpServerCalls: false,
+    },
+  };
+  result.resultSummary = createValidationResultSummary(result, { maxOutputLines });
+  return result;
+}

--- a/editors/vscode-prototype/src/config.mjs
+++ b/editors/vscode-prototype/src/config.mjs
@@ -6,6 +6,11 @@ export const CONFIG_KEYS = Object.freeze([
   "pccxLab.command",
   "aiAssistant.enabled",
   "aiAssistant.backend",
+  "validationRunner.enabled",
+  "validationRunner.mode",
+  "validationRunner.defaultWorkingDirectory",
+  "validationRunner.maxOutputLines",
+  "validationRunner.timeoutMs",
   "pythonPath",
   "defaultSource",
   "defaultLog",
@@ -29,6 +34,7 @@ export const AI_COMMAND_IDS = Object.freeze([
   "pccxSystemVerilog.showAIAssistantStatus",
   "pccxSystemVerilog.buildAIContextBundle",
   "pccxSystemVerilog.proposeValidationCommand",
+  "pccxSystemVerilog.runApprovedValidationCommand",
 ]);
 
 export const PCCX_LAB_COMMAND_IDS = Object.freeze([
@@ -44,6 +50,8 @@ export const COMMAND_IDS = Object.freeze([
 export const MODES = Object.freeze(["checkedExample", "liveWorkspace"]);
 export const AI_ASSISTANT_BACKENDS = Object.freeze(["none", "pccx-llm-launcher", "mcp"]);
 export const DECLARATION_KINDS = Object.freeze(["module", "package", "interface", "any"]);
+export const VALIDATION_RUNNER_MODES = Object.freeze(["disabled", "allowlisted"]);
+export const VALIDATION_RUNNER_CWD_KINDS = Object.freeze(["repo-root", "workspace"]);
 export const LIVE_WORKSPACE_COMMAND_IDS = Object.freeze([
   "pccxSystemVerilog.publishLiveWorkspaceDiagnostics",
   "pccxSystemVerilog.showLiveWorkspaceNavigation",
@@ -62,6 +70,13 @@ const DEFAULT_CONFIG = Object.freeze({
   aiAssistant: Object.freeze({
     enabled: false,
     backend: "none",
+  }),
+  validationRunner: Object.freeze({
+    enabled: false,
+    mode: "disabled",
+    defaultWorkingDirectory: "repo-root",
+    maxOutputLines: 120,
+    timeoutMs: 30000,
   }),
   pythonPath: "python3",
   defaultSource: "fixtures/missing_endmodule.sv",
@@ -138,12 +153,29 @@ function enumSetting(rawConfig, key, fallback, allowedValues) {
   return value;
 }
 
+function integerSetting(rawConfig, key, fallback, options = {}) {
+  const value = rawConfigValue(rawConfig, key);
+  if (value == null) {
+    return fallback;
+  }
+  if (!Number.isInteger(value)) {
+    throw new Error(`${CONFIG_SECTION}.${key} must be an integer`);
+  }
+  const min = Number.isInteger(options.min) ? options.min : Number.MIN_SAFE_INTEGER;
+  const max = Number.isInteger(options.max) ? options.max : Number.MAX_SAFE_INTEGER;
+  if (value < min || value > max) {
+    throw new Error(`${CONFIG_SECTION}.${key} must be between ${min} and ${max}`);
+  }
+  return value;
+}
+
 export function defaultConfig() {
   return {
     ...DEFAULT_CONFIG,
     liveWorkspace: { ...DEFAULT_CONFIG.liveWorkspace },
     pccxLab: { ...DEFAULT_CONFIG.pccxLab },
     aiAssistant: { ...DEFAULT_CONFIG.aiAssistant },
+    validationRunner: { ...DEFAULT_CONFIG.validationRunner },
   };
 }
 
@@ -171,6 +203,37 @@ export function normalizeConfig(rawConfig = {}) {
         "aiAssistant.backend",
         DEFAULT_CONFIG.aiAssistant.backend,
         AI_ASSISTANT_BACKENDS,
+      ),
+    },
+    validationRunner: {
+      enabled: booleanSetting(
+        rawConfig,
+        "validationRunner.enabled",
+        DEFAULT_CONFIG.validationRunner.enabled,
+      ),
+      mode: enumSetting(
+        rawConfig,
+        "validationRunner.mode",
+        DEFAULT_CONFIG.validationRunner.mode,
+        VALIDATION_RUNNER_MODES,
+      ),
+      defaultWorkingDirectory: enumSetting(
+        rawConfig,
+        "validationRunner.defaultWorkingDirectory",
+        DEFAULT_CONFIG.validationRunner.defaultWorkingDirectory,
+        VALIDATION_RUNNER_CWD_KINDS,
+      ),
+      maxOutputLines: integerSetting(
+        rawConfig,
+        "validationRunner.maxOutputLines",
+        DEFAULT_CONFIG.validationRunner.maxOutputLines,
+        { min: 1, max: 500 },
+      ),
+      timeoutMs: integerSetting(
+        rawConfig,
+        "validationRunner.timeoutMs",
+        DEFAULT_CONFIG.validationRunner.timeoutMs,
+        { min: 1000, max: 120000 },
       ),
     },
     pythonPath: stringSetting(rawConfig, "pythonPath", DEFAULT_CONFIG.pythonPath),

--- a/editors/vscode-prototype/src/context-bundle.mjs
+++ b/editors/vscode-prototype/src/context-bundle.mjs
@@ -284,10 +284,11 @@ function normalizeConfiguration(configuration) {
     return {
       mode: "unknown",
       liveWorkspace: { enabled: false },
-      aiAssistant: { enabled: false, backend: "none" },
-      pccxLab: { commandBoundary: "pccx_ide_cli" },
-    };
-  }
+    aiAssistant: { enabled: false, backend: "none" },
+    pccxLab: { commandBoundary: "pccx_ide_cli" },
+    validationRunner: { enabled: false, mode: "disabled" },
+  };
+}
   return {
     mode: scrubText(configuration.mode ?? "unknown", 80),
     liveWorkspace: {
@@ -299,6 +300,18 @@ function normalizeConfiguration(configuration) {
     },
     pccxLab: {
       commandBoundary: scrubText(configuration.pccxLab?.commandBoundary ?? "pccx_ide_cli", 120),
+    },
+    validationRunner: {
+      enabled: configuration.validationRunner?.enabled === true,
+      mode: scrubText(configuration.validationRunner?.mode ?? "disabled", 80),
+      defaultWorkingDirectory: scrubText(
+        configuration.validationRunner?.defaultWorkingDirectory ?? "repo-root",
+        80,
+      ),
+      maxOutputLines: Math.max(0, Math.floor(clampNumber(
+        configuration.validationRunner?.maxOutputLines,
+      ))),
+      timeoutMs: Math.max(0, Math.floor(clampNumber(configuration.validationRunner?.timeoutMs))),
     },
   };
 }
@@ -416,6 +429,67 @@ function normalizeRecentCommandStatus(status, limits) {
   };
 }
 
+function normalizeOutputSummary(summary, limits) {
+  const lines = Array.isArray(summary?.lines)
+    ? summary.lines
+      .map((line) => scrubText(String(line ?? ""), limits.maxTextCharacters))
+      .slice(0, limits.maxLogSummaryLines)
+    : [];
+  return {
+    lines,
+    lineCount: Math.max(0, Math.floor(clampNumber(summary?.lineCount, lines.length))),
+    truncated: summary?.truncated === true || (
+      Array.isArray(summary?.lines) && summary.lines.length > lines.length
+    ),
+  };
+}
+
+function normalizeRecentValidation(validation, limits) {
+  if (!validation || typeof validation !== "object") {
+    return null;
+  }
+  return {
+    version: scrubText(validation.version ?? "", 80),
+    proposalId: scrubText(validation.proposalId ?? "", 120),
+    commandLabel: scrubText(validation.commandLabel ?? "", 160),
+    status: scrubText(validation.status ?? "unknown", 80),
+    summary: scrubText(validation.summary ?? "", 800),
+    exitCode: validation.exitCode == null
+      ? null
+      : Math.floor(clampNumber(validation.exitCode)),
+    durationMs: validation.durationMs == null
+      ? null
+      : Math.max(0, Math.floor(clampNumber(validation.durationMs))),
+    startedAt: scrubText(validation.startedAt ?? "", 80),
+    finishedAt: scrubText(validation.finishedAt ?? "", 80),
+    command: scrubText(validation.command ?? "", 120),
+    args: Array.isArray(validation.args)
+      ? validation.args
+        .map((arg) => scrubText(String(arg ?? ""), 300))
+        .slice(0, 12)
+      : [],
+    cwdKind: scrubText(validation.cwdKind ?? "", 80),
+    cwdLabel: scrubText(validation.cwdLabel ?? "", 80),
+    stdoutSummary: normalizeOutputSummary(validation.stdoutSummary, limits),
+    stderrSummary: normalizeOutputSummary(validation.stderrSummary, limits),
+    failureHints: Array.isArray(validation.failureHints)
+      ? validation.failureHints
+        .map((hint) => scrubText(String(hint ?? ""), 500))
+        .slice(0, 3)
+      : [],
+    safety: {
+      allowlisted: validation.safety?.allowlisted === true,
+      shell: validation.safety?.shell === true,
+      fixedArgs: validation.safety?.fixedArgs === true,
+      userProvidedCommand: validation.safety?.userProvidedCommand === true,
+      writesFiles: validation.safety?.writesFiles === true,
+      providerCalls: validation.safety?.providerCalls === true,
+      launcherCalls: validation.safety?.launcherCalls === true,
+      mcpServerCalls: validation.safety?.mcpServerCalls === true,
+    },
+  };
+}
+
 export function buildContextBundle(input = {}, options = {}) {
   const limits = mergeLimits(options.limits);
   const workspaceRoot = options.workspaceRoot ?? input.workspaceRoot ?? null;
@@ -461,15 +535,7 @@ export function buildContextBundle(input = {}, options = {}) {
     },
     snippets,
     validation: {
-      recent: input.recentValidation
-        ? {
-            status: scrubText(input.recentValidation.status ?? "unknown", 80),
-            summary: scrubText(input.recentValidation.summary ?? "", 800),
-            exitCode: input.recentValidation.exitCode == null
-              ? null
-              : Math.floor(clampNumber(input.recentValidation.exitCode)),
-          }
-        : null,
+      recent: normalizeRecentValidation(input.recentValidation, limits),
     },
     recentCommand: normalizeRecentCommandStatus(input.recentCommandStatus, limits),
     pccxLab: {
@@ -507,5 +573,12 @@ export function summarizeContextBundle(bundle) {
     pccxLabOutputCount: Array.isArray(bundle?.pccxLab?.outputs)
       ? bundle.pccxLab.outputs.length
       : 0,
+    validation: bundle?.validation?.recent
+      ? {
+          proposalId: bundle.validation.recent.proposalId,
+          status: bundle.validation.recent.status,
+          commandLabel: bundle.validation.recent.commandLabel,
+        }
+      : null,
   };
 }

--- a/editors/vscode-prototype/src/extension.mjs
+++ b/editors/vscode-prototype/src/extension.mjs
@@ -38,6 +38,9 @@ import {
   createValidationCommandProposal,
 } from "./validation-proposals.mjs";
 import {
+  runApprovedValidationProposal,
+} from "./approved-validation-runner.mjs";
+import {
   createPccxLabBackendStatus,
 } from "./pccx-lab-status.mjs";
 
@@ -58,6 +61,8 @@ export const AI_CONTEXT_BUNDLE_COMMAND =
   "pccxSystemVerilog.buildAIContextBundle";
 export const VALIDATION_PROPOSAL_COMMAND =
   "pccxSystemVerilog.proposeValidationCommand";
+export const APPROVED_VALIDATION_RUNNER_COMMAND =
+  "pccxSystemVerilog.runApprovedValidationCommand";
 export const PCCX_LAB_BACKEND_STATUS_COMMAND =
   "pccxSystemVerilog.showPccxLabBackendStatus";
 
@@ -230,6 +235,15 @@ function appendCommandOutput(outputChannel, commandId, result) {
       kind: result.kind,
       proposalCount: result.proposals?.length ?? 0,
       execution: result.execution,
+    }, null, 2));
+  }
+  if (result.kind === "approved-validation-result") {
+    outputChannel.appendLine(JSON.stringify({
+      kind: result.kind,
+      proposalId: result.proposalId,
+      status: result.status,
+      exitCode: result.exitCode,
+      durationMs: result.durationMs,
     }, null, 2));
   }
   if (result.status?.kind === "pccx-lab-backend-status") {
@@ -413,6 +427,13 @@ function contextConfiguration(config) {
         ? defaultPccxLabCommand
         : "custom",
     },
+    validationRunner: {
+      enabled: config.validationRunner.enabled,
+      mode: config.validationRunner.mode,
+      defaultWorkingDirectory: config.validationRunner.defaultWorkingDirectory,
+      maxOutputLines: config.validationRunner.maxOutputLines,
+      timeoutMs: config.validationRunner.timeoutMs,
+    },
   };
 }
 
@@ -503,6 +524,7 @@ function collectActiveDocumentContext(vscodeApi, runtime, config) {
       files,
       configuration: contextConfiguration(config),
       recentCommandStatus: runtime.recentCommandStatus ?? null,
+      recentValidation: runtime.recentValidationSummary ?? null,
     },
   };
 }
@@ -587,6 +609,30 @@ export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
         result = { ok: false, commandId, error: error.message };
         vscodeApi?.window?.showWarningMessage?.(result.error, result);
       }
+      appendCommandOutput(runtime.outputChannel, commandId, result);
+      return result;
+    }
+
+    if (commandId === APPROVED_VALIDATION_RUNNER_COMMAND) {
+      let result;
+      try {
+        const workspaceRoot = vscodeApi?.workspace?.workspaceFolders?.[0]?.uri?.fsPath ?? null;
+        result = await runApprovedValidationProposal(
+          input,
+          rawConfig,
+          {
+            repoRoot: runtime.repoRoot ?? DEFAULT_DIAGNOSTIC_FILE_ROOT,
+            workspaceRoot,
+            execFile: runtime.validationExecFile,
+            env: runtime.env,
+          },
+        );
+        runtime.recentValidationSummary = result.resultSummary ?? null;
+      } catch (error) {
+        result = { ok: false, commandId, error: error.message };
+        vscodeApi?.window?.showWarningMessage?.(result.error, result);
+      }
+      result.commandId = commandId;
       appendCommandOutput(runtime.outputChannel, commandId, result);
       return result;
     }

--- a/editors/vscode-prototype/src/pccx-lab-status.mjs
+++ b/editors/vscode-prototype/src/pccx-lab-status.mjs
@@ -26,6 +26,13 @@ export function createPccxLabBackendStatus(rawConfig = {}) {
     backendCommandExecuted: false,
     integration: "commandPalettePreparation",
     futureControlledOperations: [...FUTURE_PCCX_LAB_OPERATIONS],
+    futureSafetyRequirements: [
+      "fixed args",
+      "no shell interpolation",
+      "explicit user approval",
+      "bounded output",
+      "context bundle summary",
+    ],
     note: "pccx-lab remains the CLI-first backend; this status command does not execute it.",
   };
 }

--- a/editors/vscode-prototype/src/validation-proposals.mjs
+++ b/editors/vscode-prototype/src/validation-proposals.mjs
@@ -12,6 +12,7 @@ export const VALIDATION_PROPOSAL_CATEGORIES = Object.freeze([
 
 const PROPOSALS = Object.freeze([
   Object.freeze({
+    id: "vscodeAdapterSmoke",
     category: "vscodeAdapterSmoke",
     label: "VS Code adapter smoke",
     command: Object.freeze({
@@ -23,6 +24,7 @@ const PROPOSALS = Object.freeze([
     riskLevel: "low",
   }),
   Object.freeze({
+    id: "editorBridgeSmoke",
     category: "editorBridgeSmoke",
     label: "Editor bridge smoke",
     command: Object.freeze({
@@ -34,6 +36,7 @@ const PROPOSALS = Object.freeze([
     riskLevel: "low",
   }),
   Object.freeze({
+    id: "exampleDriftCheck",
     category: "exampleDriftCheck",
     label: "Editor bridge example drift check",
     command: Object.freeze({
@@ -45,17 +48,22 @@ const PROPOSALS = Object.freeze([
     riskLevel: "low",
   }),
   Object.freeze({
+    id: "pytestBaseline",
     category: "pytestBaseline",
     label: "Python pytest baseline",
     command: Object.freeze({
       cwd: "repo-root",
       argv: Object.freeze(["python3", "-m", "pytest", "-q"]),
-      env: Object.freeze({}),
+      env: Object.freeze({
+        PYTHONDONTWRITEBYTECODE: "1",
+        PYTEST_ADDOPTS: "-p no:cacheprovider",
+      }),
     }),
     reason: "Runs the repository Python baseline used by the lightweight CI path.",
     riskLevel: "low",
   }),
   Object.freeze({
+    id: "extensionHostSmokeOptIn",
     category: "extensionHostSmoke",
     label: "VS Code Extension Host smoke",
     command: Object.freeze({
@@ -65,8 +73,11 @@ const PROPOSALS = Object.freeze([
     }),
     reason: "Runs the opt-in local Extension Host smoke against the controlled fixture workspace.",
     riskLevel: "medium",
+    runnerPolicy: "proposalOnly",
+    runnerBlockedReason: "Extension Host smoke remains opt-in local-only and is not executed from inside the approved validation runner.",
   }),
   Object.freeze({
+    id: "futurePccxLabDiagnostics",
     category: "futurePccxLabDiagnostics",
     label: "Future pccx-lab diagnostics validation",
     command: null,
@@ -75,6 +86,7 @@ const PROPOSALS = Object.freeze([
     riskLevel: "medium",
   }),
   Object.freeze({
+    id: "futureXsimLogAnalysis",
     category: "futureXsimLogAnalysis",
     label: "Future xsim-log analysis validation",
     command: null,
@@ -97,15 +109,30 @@ function cloneCommand(command) {
 
 function cloneProposal(proposal) {
   return {
+    id: proposal.id,
     category: proposal.category,
     label: proposal.label,
     command: cloneCommand(proposal.command),
     placeholder: proposal.placeholder === true,
     reason: proposal.reason,
     riskLevel: proposal.riskLevel,
+    runnerPolicy: proposal.runnerPolicy ?? "allowlisted",
+    runnerBlockedReason: proposal.runnerBlockedReason ?? "",
     requiresUserApproval: true,
     executes: false,
   };
+}
+
+export function listValidationCommandProposals() {
+  return PROPOSALS.map(cloneProposal);
+}
+
+export function findValidationCommandProposalById(proposalId) {
+  if (typeof proposalId !== "string" || proposalId.trim().length === 0) {
+    return null;
+  }
+  const proposal = PROPOSALS.find((item) => item.id === proposalId);
+  return proposal ? cloneProposal(proposal) : null;
 }
 
 export function createValidationCommandProposal(_input = {}) {
@@ -119,7 +146,7 @@ export function createValidationCommandProposal(_input = {}) {
     providerCalls: false,
     runtimeCalls: false,
     commandSource: "allowlistedTemplates",
-    proposals: PROPOSALS.map(cloneProposal),
+    proposals: listValidationCommandProposals(),
     disallowedActions: [
       "executeCommand",
       "spawnProcess",

--- a/editors/vscode-prototype/src/validation-result-summary.mjs
+++ b/editors/vscode-prototype/src/validation-result-summary.mjs
@@ -1,0 +1,173 @@
+export const VALIDATION_RESULT_SUMMARY_VERSION = "pccx.validationResultSummary.v0";
+
+export const DEFAULT_VALIDATION_SUMMARY_LIMITS = Object.freeze({
+  maxOutputLines: 120,
+  maxLineCharacters: 500,
+  maxTextCharacters: 8000,
+});
+
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]/i;
+const HOME_PATH_PATTERN = /(?:\/home\/[^/\s]+|\/Users\/[^/\s]+)/g;
+
+function clampInteger(value, fallback, min, max) {
+  if (!Number.isInteger(value)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, value));
+}
+
+function finiteNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function summaryLimits(options = {}) {
+  return {
+    maxOutputLines: clampInteger(
+      options.maxOutputLines,
+      DEFAULT_VALIDATION_SUMMARY_LIMITS.maxOutputLines,
+      1,
+      500,
+    ),
+    maxLineCharacters: clampInteger(
+      options.maxLineCharacters,
+      DEFAULT_VALIDATION_SUMMARY_LIMITS.maxLineCharacters,
+      80,
+      2000,
+    ),
+    maxTextCharacters: clampInteger(
+      options.maxTextCharacters,
+      DEFAULT_VALIDATION_SUMMARY_LIMITS.maxTextCharacters,
+      500,
+      50000,
+    ),
+  };
+}
+
+function redactLine(line, maxLineCharacters) {
+  const text = String(line ?? "");
+  if (SECRET_ASSIGNMENT_PATTERN.test(text)) {
+    return "[redacted]";
+  }
+  return text
+    .replace(HOME_PATH_PATTERN, "[home]")
+    .slice(0, maxLineCharacters);
+}
+
+export function summarizeOutputText(value, options = {}) {
+  const limits = summaryLimits(options);
+  if (typeof value !== "string" || value.length === 0) {
+    return {
+      lines: [],
+      lineCount: 0,
+      truncated: false,
+    };
+  }
+
+  const text = value.slice(0, limits.maxTextCharacters);
+  const allLines = text.split(/\r?\n/);
+  if (allLines.at(-1) === "") {
+    allLines.pop();
+  }
+  const lines = allLines
+    .slice(0, limits.maxOutputLines)
+    .map((line) => redactLine(line, limits.maxLineCharacters));
+
+  return {
+    lines,
+    lineCount: allLines.length,
+    truncated: value.length > text.length || allLines.length > lines.length,
+  };
+}
+
+function compactFailureHints(result, stdoutSummary, stderrSummary) {
+  if (result?.status === "passed") {
+    return [];
+  }
+  const lines = [
+    ...stderrSummary.lines,
+    ...stdoutSummary.lines,
+  ];
+  const hints = [];
+  for (const line of lines) {
+    if (/error|failed|failure|traceback|timed out|timeout|blocked/i.test(line)) {
+      hints.push(line);
+    }
+    if (hints.length >= 3) {
+      break;
+    }
+  }
+  if (hints.length === 0 && typeof result?.blockedReason === "string" && result.blockedReason) {
+    hints.push(redactLine(result.blockedReason, 500));
+  }
+  return hints;
+}
+
+export function createValidationResultSummary(result = {}, options = {}) {
+  const limits = summaryLimits(options);
+  const stdoutSummary = result.stdoutSummary?.lines
+    ? {
+        lines: result.stdoutSummary.lines.map((line) => redactLine(line, limits.maxLineCharacters)),
+        lineCount: Math.max(0, Math.floor(finiteNumber(
+          result.stdoutSummary.lineCount,
+          result.stdoutSummary.lines.length,
+        ))),
+        truncated: result.stdoutSummary.truncated === true,
+      }
+    : summarizeOutputText(result.stdout ?? "", limits);
+  const stderrSummary = result.stderrSummary?.lines
+    ? {
+        lines: result.stderrSummary.lines.map((line) => redactLine(line, limits.maxLineCharacters)),
+        lineCount: Math.max(0, Math.floor(finiteNumber(
+          result.stderrSummary.lineCount,
+          result.stderrSummary.lines.length,
+        ))),
+        truncated: result.stderrSummary.truncated === true,
+      }
+    : summarizeOutputText(result.stderr ?? "", limits);
+  const status = typeof result.status === "string" && result.status
+    ? result.status
+    : "blocked";
+  const commandLabel = typeof result.commandLabel === "string" ? result.commandLabel : "";
+  const proposalId = typeof result.proposalId === "string" ? result.proposalId : "";
+  const exitCode = result.exitCode == null ? null : Math.floor(finiteNumber(result.exitCode));
+  const summary = [
+    commandLabel || proposalId || "validation",
+    status,
+    exitCode == null ? "" : `(exit ${exitCode})`,
+  ].filter(Boolean).join(" ");
+
+  return {
+    version: VALIDATION_RESULT_SUMMARY_VERSION,
+    proposalId,
+    commandLabel,
+    status,
+    summary,
+    exitCode,
+    durationMs: Number.isFinite(result.durationMs)
+      ? Math.max(0, Math.floor(result.durationMs))
+      : null,
+    startedAt: typeof result.startedAt === "string" ? result.startedAt : "",
+    finishedAt: typeof result.finishedAt === "string" ? result.finishedAt : "",
+    command: typeof result.command === "string" ? result.command : "",
+    args: Array.isArray(result.args)
+      ? result.args.filter((arg) => typeof arg === "string").map((arg) => redactLine(arg, 500))
+      : [],
+    cwdKind: typeof result.cwdKind === "string" ? result.cwdKind : "",
+    cwdLabel: typeof result.cwdLabel === "string" ? result.cwdLabel : "",
+    stdoutSummary,
+    stderrSummary,
+    failureHints: compactFailureHints(result, stdoutSummary, stderrSummary),
+    safety: {
+      allowlisted: result.safety?.allowlisted === true,
+      shell: result.safety?.shell === true,
+      fixedArgs: result.safety?.fixedArgs === true,
+      userProvidedCommand: result.safety?.userProvidedCommand === true,
+      writesFiles: result.safety?.writesFiles === true,
+      providerCalls: result.safety?.providerCalls === true,
+      launcherCalls: result.safety?.launcherCalls === true,
+      mcpServerCalls: result.safety?.mcpServerCalls === true,
+    },
+  };
+}

--- a/editors/vscode-prototype/test/approved-validation-runner.test.mjs
+++ b/editors/vscode-prototype/test/approved-validation-runner.test.mjs
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+
+import {
+  APPROVED_VALIDATION_RESULT_VERSION,
+  resolveApprovedValidationProposalId,
+  runApprovedValidationProposal,
+} from "../src/approved-validation-runner.mjs";
+
+const ENABLED_CONFIG = {
+  validationRunner: {
+    enabled: true,
+    mode: "allowlisted",
+    defaultWorkingDirectory: "repo-root",
+    maxOutputLines: 2,
+    timeoutMs: 5000,
+  },
+};
+
+function fakeClock() {
+  let value = Date.parse("2026-01-01T00:00:00.000Z");
+  return {
+    now() {
+      value += 25;
+      return value;
+    },
+  };
+}
+
+function execFileStub(callback) {
+  const calls = [];
+  return {
+    calls,
+    execFile(executable, args, options, done) {
+      calls.push({ executable, args, options });
+      callback(executable, args, options, done);
+    },
+  };
+}
+
+function testProposalIdResolutionAcceptsIdsOnly() {
+  assert.equal(resolveApprovedValidationProposalId(null), null);
+  assert.equal(resolveApprovedValidationProposalId("vscodeAdapterSmoke"), "vscodeAdapterSmoke");
+  assert.equal(
+    resolveApprovedValidationProposalId({ proposalId: "editorBridgeSmoke" }),
+    "editorBridgeSmoke",
+  );
+  assert.equal(resolveApprovedValidationProposalId({ command: "bash scripts/a.sh" }), null);
+}
+
+async function testMissingProposalIdBlocksEvenWhenEnabled() {
+  const stub = execFileStub(() => {
+    throw new Error("missing proposal ID must not execute");
+  });
+
+  const result = await runApprovedValidationProposal(undefined, ENABLED_CONFIG, {
+    repoRoot: "/repo",
+    execFile: stub.execFile,
+    clock: fakeClock(),
+  });
+
+  assert.equal(result.status, "blocked");
+  assert.match(result.blockedReason, /proposal ID only/);
+  assert.equal(stub.calls.length, 0);
+}
+
+async function testDisabledByDefaultBlocksWithoutExecution() {
+  const stub = execFileStub(() => {
+    throw new Error("disabled runner must not execute");
+  });
+
+  const result = await runApprovedValidationProposal("vscodeAdapterSmoke", {}, {
+    repoRoot: "/repo",
+    execFile: stub.execFile,
+    clock: fakeClock(),
+  });
+
+  assert.equal(result.version, APPROVED_VALIDATION_RESULT_VERSION);
+  assert.equal(result.kind, "approved-validation-result");
+  assert.equal(result.proposalId, "vscodeAdapterSmoke");
+  assert.equal(result.commandLabel, "VS Code adapter smoke");
+  assert.equal(result.status, "blocked");
+  assert.match(result.blockedReason, /runner is disabled/);
+  assert.equal(result.ok, false);
+  assert.equal(result.safety.allowlisted, true);
+  assert.equal(result.safety.shell, false);
+  assert.equal(result.safety.userProvidedCommand, false);
+  assert.equal(stub.calls.length, 0);
+}
+
+async function testUnknownAndRawCommandInputBlocks() {
+  const stub = execFileStub(() => {
+    throw new Error("unknown proposal must not execute");
+  });
+
+  const unknown = await runApprovedValidationProposal("missingProposalId", ENABLED_CONFIG, {
+    repoRoot: "/repo",
+    execFile: stub.execFile,
+    clock: fakeClock(),
+  });
+  const rawString = await runApprovedValidationProposal("git push origin main", ENABLED_CONFIG, {
+    repoRoot: "/repo",
+    execFile: stub.execFile,
+    clock: fakeClock(),
+  });
+  const rawObject = await runApprovedValidationProposal(
+    { command: "bash scripts/vscode-adapter-smoke.sh" },
+    ENABLED_CONFIG,
+    {
+      repoRoot: "/repo",
+      execFile: stub.execFile,
+      clock: fakeClock(),
+    },
+  );
+
+  assert.equal(unknown.status, "blocked");
+  assert.match(unknown.blockedReason, /unknown validation proposal ID/);
+  assert.equal(rawString.status, "blocked");
+  assert.match(rawString.blockedReason, /proposal ID only/);
+  assert.doesNotMatch(JSON.stringify(rawString), /origin main/);
+  assert.equal(rawObject.status, "blocked");
+  assert.match(rawObject.blockedReason, /proposal ID only/);
+  assert.equal(stub.calls.length, 0);
+}
+
+async function testAllowlistedExecutionUsesExecFileArgumentArray() {
+  const stub = execFileStub((_executable, _args, _options, done) => {
+    done(null, "adapter ok\nAPI_KEY=hidden\nthird line\n", "");
+  });
+
+  const result = await runApprovedValidationProposal("vscodeAdapterSmoke", ENABLED_CONFIG, {
+    repoRoot: "/repo",
+    execFile: stub.execFile,
+    env: { PATH: "/bin" },
+    clock: fakeClock(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.status, "passed");
+  assert.equal(result.command, "bash");
+  assert.deepEqual(result.args, ["scripts/vscode-adapter-smoke.sh"]);
+  assert.equal(result.cwdKind, "repo-root");
+  assert.equal(result.cwdLabel, "repo-root");
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(result.stdoutSummary.lines, ["adapter ok", "[redacted]"]);
+  assert.equal(result.stdoutSummary.truncated, true);
+  assert.equal(result.resultSummary.proposalId, "vscodeAdapterSmoke");
+  assert.equal(result.resultSummary.safety.fixedArgs, true);
+  assert.equal(result.safety.allowlisted, true);
+  assert.equal(result.safety.providerCalls, false);
+  assert.equal(result.safety.launcherCalls, false);
+  assert.equal(result.safety.mcpServerCalls, false);
+  assert.equal(stub.calls.length, 1);
+  assert.equal(stub.calls[0].executable, "bash");
+  assert.deepEqual(stub.calls[0].args, ["scripts/vscode-adapter-smoke.sh"]);
+  assert.equal(stub.calls[0].options.cwd, "/repo");
+  assert.equal(stub.calls[0].options.shell, false);
+  assert.equal(stub.calls[0].options.timeout, 5000);
+}
+
+async function testFailureTimeoutAndProposalOnlyBlocks() {
+  const failingStub = execFileStub((_executable, _args, _options, done) => {
+    const error = new Error("failed");
+    error.code = 7;
+    done(error, "", "failure: bad\n");
+  });
+  const timeoutStub = execFileStub((_executable, _args, _options, done) => {
+    const error = new Error("timed out");
+    error.killed = true;
+    done(error, "", "");
+  });
+
+  const failed = await runApprovedValidationProposal("editorBridgeSmoke", ENABLED_CONFIG, {
+    repoRoot: "/repo",
+    execFile: failingStub.execFile,
+    clock: fakeClock(),
+  });
+  const timedOut = await runApprovedValidationProposal("pytestBaseline", ENABLED_CONFIG, {
+    repoRoot: "/repo",
+    execFile: timeoutStub.execFile,
+    clock: fakeClock(),
+  });
+  const blocked = await runApprovedValidationProposal("extensionHostSmokeOptIn", ENABLED_CONFIG, {
+    repoRoot: "/repo",
+    execFile: timeoutStub.execFile,
+    clock: fakeClock(),
+  });
+
+  assert.equal(failed.status, "failed");
+  assert.equal(failed.exitCode, 7);
+  assert.deepEqual(failed.stderrSummary.lines, ["failure: bad"]);
+  assert.equal(timedOut.status, "timedOut");
+  assert.equal(timedOut.exitCode, null);
+  assert.equal(blocked.status, "blocked");
+  assert.match(blocked.blockedReason, /Extension Host smoke remains opt-in/);
+  assert.equal(timeoutStub.calls.length, 1);
+}
+
+testProposalIdResolutionAcceptsIdsOnly();
+await testMissingProposalIdBlocksEvenWhenEnabled();
+await testDisabledByDefaultBlocksWithoutExecution();
+await testUnknownAndRawCommandInputBlocks();
+await testAllowlistedExecutionUsesExecFileArgumentArray();
+await testFailureTimeoutAndProposalOnlyBlocks();
+
+console.log("vscode approved validation runner tests ok");

--- a/editors/vscode-prototype/test/context-bundle.test.mjs
+++ b/editors/vscode-prototype/test/context-bundle.test.mjs
@@ -151,6 +151,13 @@ function fixtureInput() {
       liveWorkspace: { enabled: false },
       aiAssistant: { enabled: false, backend: "none" },
       pccxLab: { commandBoundary: "pccx_ide_cli" },
+      validationRunner: {
+        enabled: false,
+        mode: "disabled",
+        defaultWorkingDirectory: "repo-root",
+        maxOutputLines: 120,
+        timeoutMs: 30000,
+      },
     },
     recentCommandStatus: {
       commandId: "pccxSystemVerilog.publishCheckedExampleDiagnostics",
@@ -162,9 +169,40 @@ function fixtureInput() {
       navigationItemCount: 0,
     },
     recentValidation: {
+      version: "pccx.validationResultSummary.v0",
+      proposalId: "vscodeAdapterSmoke",
+      commandLabel: "VS Code adapter smoke",
       status: "failed",
-      summary: "1 diagnostic",
+      summary: "VS Code adapter smoke failed (exit 1)",
       exitCode: 1,
+      durationMs: 55,
+      startedAt: "2026-01-01T00:00:00.000Z",
+      finishedAt: "2026-01-01T00:00:00.055Z",
+      command: "bash",
+      args: ["scripts/vscode-adapter-smoke.sh"],
+      cwdKind: "repo-root",
+      cwdLabel: "repo-root",
+      stdoutSummary: {
+        lines: ["adapter ok", "API_KEY=abc123", "extra"],
+        lineCount: 3,
+        truncated: true,
+      },
+      stderrSummary: {
+        lines: ["failure: missing endmodule"],
+        lineCount: 1,
+        truncated: false,
+      },
+      failureHints: ["failure: missing endmodule"],
+      safety: {
+        allowlisted: true,
+        shell: false,
+        fixedArgs: true,
+        userProvidedCommand: false,
+        writesFiles: false,
+        providerCalls: false,
+        launcherCalls: false,
+        mcpServerCalls: false,
+      },
     },
     pccxLabOutputs: [
       {
@@ -208,6 +246,13 @@ function testStableBoundedShape() {
   assert.deepEqual(bundle.snippets.map((snippet) => snippet.path), ["rtl/a.sv", "rtl/z.sv"]);
   assert.ok(bundle.snippets.every((snippet) => snippet.lines.length <= 2));
   assert.equal(bundle.validation.recent.status, "failed");
+  assert.equal(bundle.validation.recent.proposalId, "vscodeAdapterSmoke");
+  assert.equal(bundle.validation.recent.commandLabel, "VS Code adapter smoke");
+  assert.equal(bundle.validation.recent.stdoutSummary.lines.length, 1);
+  assert.deepEqual(bundle.validation.recent.stdoutSummary.lines, ["adapter ok"]);
+  assert.deepEqual(bundle.validation.recent.stderrSummary.lines, ["failure: missing endmodule"]);
+  assert.equal(bundle.validation.recent.safety.allowlisted, true);
+  assert.equal(bundle.validation.recent.safety.shell, false);
   assert.equal(bundle.recentCommand.commandId, "pccxSystemVerilog.publishCheckedExampleDiagnostics");
   assert.equal(bundle.recentCommand.facade.mode, "example");
   assert.equal(bundle.pccxLab.outputs.length, 1);
@@ -226,6 +271,11 @@ function testStableBoundedShape() {
     snippetCount: 2,
     declarationCount: 2,
     pccxLabOutputCount: 1,
+    validation: {
+      proposalId: "vscodeAdapterSmoke",
+      status: "failed",
+      commandLabel: "VS Code adapter smoke",
+    },
   });
 }
 
@@ -351,10 +401,17 @@ function testNoHugeFileOrRestrictedPathInclusion() {
         { path: "/repo/.vscode-test/ignored.sv", text: hugeText },
         { path: "/repo/AGENTS.md", text: hugeText },
         { path: "/repo/package-lock.json", text: hugeText },
+        { path: "/repo/.git/config", text: hugeText },
+        { path: "/repo/.codex/notes.md", text: hugeText },
+        { path: "/repo/private-worker/notes.md", text: hugeText },
+        { path: "/repo/worker-instruction/notes.md", text: hugeText },
+        { path: "/repo/subagent-instruction/notes.md", text: hugeText },
+        { path: "/repo/rtl/api-token.sv", text: hugeText },
       ],
       activeDiagnostics: [
         { file: "/repo/node_modules/pkg/ignored.sv", message: "ignored" },
         { file: "/repo/.vscode-test/ignored.sv", message: "ignored" },
+        { file: "/repo/rtl/client_secret.sv", message: "ignored" },
       ],
     },
     {
@@ -377,6 +434,7 @@ function testNoSecretValuesOrSecretLikeKeys() {
   assert.doesNotMatch(serialized, /abc123/);
   assert.doesNotMatch(serialized, /API_KEY=/);
   assert.doesNotMatch(serialized, /token=hidden/);
+  assert.doesNotMatch(serialized, /API_KEY=abc123/);
   assert.doesNotMatch(serialized, /AGENTS\.md/);
   assert.doesNotMatch(serialized, /package-lock\.json/);
 }

--- a/editors/vscode-prototype/test/extension-config.test.mjs
+++ b/editors/vscode-prototype/test/extension-config.test.mjs
@@ -8,6 +8,8 @@ import {
   DECLARATION_KINDS,
   FACADE_COMMAND_IDS,
   MODES,
+  VALIDATION_RUNNER_CWD_KINDS,
+  VALIDATION_RUNNER_MODES,
   buildFacadeArgsForCommand,
   defaultConfig,
   normalizeConfig,
@@ -22,6 +24,11 @@ const REQUIRED_SETTINGS = new Map([
   ["pccxSystemVerilog.pccxLab.command", { type: "string", default: "pccx_ide_cli" }],
   ["pccxSystemVerilog.aiAssistant.enabled", { type: "boolean", default: false }],
   ["pccxSystemVerilog.aiAssistant.backend", { type: "string", default: "none" }],
+  ["pccxSystemVerilog.validationRunner.enabled", { type: "boolean", default: false }],
+  ["pccxSystemVerilog.validationRunner.mode", { type: "string", default: "disabled" }],
+  ["pccxSystemVerilog.validationRunner.defaultWorkingDirectory", { type: "string", default: "repo-root" }],
+  ["pccxSystemVerilog.validationRunner.maxOutputLines", { type: "integer", default: 120 }],
+  ["pccxSystemVerilog.validationRunner.timeoutMs", { type: "integer", default: 30000 }],
   ["pccxSystemVerilog.pythonPath", { type: "string", default: "python3" }],
   ["pccxSystemVerilog.defaultSource", { type: "string", default: "fixtures/missing_endmodule.sv" }],
   ["pccxSystemVerilog.defaultLog", { type: "string", default: "fixtures/xsim/mixed.log" }],
@@ -68,6 +75,14 @@ async function testPackageConfigurationSchema() {
     configuration.properties["pccxSystemVerilog.defaultDeclarationKind"].enum,
     DECLARATION_KINDS,
   );
+  assert.deepEqual(
+    configuration.properties["pccxSystemVerilog.validationRunner.mode"].enum,
+    VALIDATION_RUNNER_MODES,
+  );
+  assert.deepEqual(
+    configuration.properties["pccxSystemVerilog.validationRunner.defaultWorkingDirectory"].enum,
+    VALIDATION_RUNNER_CWD_KINDS,
+  );
 }
 
 function testDefaultConfig() {
@@ -82,6 +97,13 @@ function testDefaultConfig() {
     aiAssistant: {
       enabled: false,
       backend: "none",
+    },
+    validationRunner: {
+      enabled: false,
+      mode: "disabled",
+      defaultWorkingDirectory: "repo-root",
+      maxOutputLines: 120,
+      timeoutMs: 30000,
     },
     pythonPath: "python3",
     defaultSource: "fixtures/missing_endmodule.sv",
@@ -108,6 +130,26 @@ function testNormalizeConfigRejectsInvalidSettings() {
   assert.throws(
     () => normalizeConfig({ aiAssistant: { backend: "openai" } }),
     /pccxSystemVerilog\.aiAssistant\.backend must be one of: none, pccx-llm-launcher, mcp/,
+  );
+  assert.throws(
+    () => normalizeConfig({ validationRunner: { enabled: "yes" } }),
+    /pccxSystemVerilog\.validationRunner\.enabled must be a boolean/,
+  );
+  assert.throws(
+    () => normalizeConfig({ validationRunner: { mode: "shell" } }),
+    /pccxSystemVerilog\.validationRunner\.mode must be one of: disabled, allowlisted/,
+  );
+  assert.throws(
+    () => normalizeConfig({ validationRunner: { defaultWorkingDirectory: "tmp" } }),
+    /pccxSystemVerilog\.validationRunner\.defaultWorkingDirectory must be one of: repo-root, workspace/,
+  );
+  assert.throws(
+    () => normalizeConfig({ validationRunner: { maxOutputLines: 0 } }),
+    /pccxSystemVerilog\.validationRunner\.maxOutputLines must be between 1 and 500/,
+  );
+  assert.throws(
+    () => normalizeConfig({ validationRunner: { timeoutMs: 999 } }),
+    /pccxSystemVerilog\.validationRunner\.timeoutMs must be between 1000 and 120000/,
   );
   assert.throws(
     () => normalizeConfig({ defaultDeclarationKind: "class" }),

--- a/editors/vscode-prototype/test/extension-entrypoint.test.mjs
+++ b/editors/vscode-prototype/test/extension-entrypoint.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   AI_CONTEXT_BUNDLE_COMMAND,
   AI_ASSISTANT_STATUS_COMMAND,
+  APPROVED_VALIDATION_RUNNER_COMMAND,
   COMMAND_IDS,
   CHECKED_EXAMPLE_NAVIGATION_COMMAND,
   FACADE_COMMAND_IDS,
@@ -218,6 +219,11 @@ function testResolveCommandRequestUsesVsCodeSettings() {
     ["pccxLab.command", "pccx_ide_cli"],
     ["aiAssistant.enabled", false],
     ["aiAssistant.backend", "none"],
+    ["validationRunner.enabled", false],
+    ["validationRunner.mode", "disabled"],
+    ["validationRunner.defaultWorkingDirectory", "repo-root"],
+    ["validationRunner.maxOutputLines", 120],
+    ["validationRunner.timeoutMs", 30000],
     ["pythonPath", "python-custom"],
     ["defaultSource", "configured.sv"],
     ["defaultLog", "configured.log"],
@@ -250,6 +256,13 @@ function testResolveCommandRequestUsesVsCodeSettings() {
       enabled: false,
       backend: "none",
     },
+    validationRunner: {
+      enabled: false,
+      mode: "disabled",
+      defaultWorkingDirectory: "repo-root",
+      maxOutputLines: 120,
+      timeoutMs: 30000,
+    },
     pythonPath: "python-custom",
     defaultSource: "configured.sv",
     defaultLog: "configured.log",
@@ -270,6 +283,13 @@ function testResolveCommandRequestUsesVsCodeSettings() {
       aiAssistant: {
         enabled: false,
         backend: "none",
+      },
+      validationRunner: {
+        enabled: false,
+        mode: "disabled",
+        defaultWorkingDirectory: "repo-root",
+        maxOutputLines: 120,
+        timeoutMs: 30000,
       },
       pythonPath: "python-custom",
       defaultSource: "configured.sv",
@@ -293,6 +313,13 @@ function testResolveCommandRequestUsesVsCodeSettings() {
         enabled: false,
         backend: "none",
       },
+      validationRunner: {
+        enabled: false,
+        mode: "disabled",
+        defaultWorkingDirectory: "repo-root",
+        maxOutputLines: 120,
+        timeoutMs: 30000,
+      },
       pythonPath: "python-custom",
       defaultSource: "configured.sv",
       defaultLog: "configured.log",
@@ -314,6 +341,13 @@ function testResolveCommandRequestUsesVsCodeSettings() {
       aiAssistant: {
         enabled: false,
         backend: "none",
+      },
+      validationRunner: {
+        enabled: false,
+        mode: "disabled",
+        defaultWorkingDirectory: "repo-root",
+        maxOutputLines: 120,
+        timeoutMs: 30000,
       },
       pythonPath: "python-custom",
       defaultSource: "explicit.sv",
@@ -468,6 +502,11 @@ async function testLiveWorkspaceNavigationCommandReturnsLocationsWithoutQuickPic
     ["pccxLab.command", "pccx_ide_cli"],
     ["aiAssistant.enabled", false],
     ["aiAssistant.backend", "none"],
+    ["validationRunner.enabled", false],
+    ["validationRunner.mode", "disabled"],
+    ["validationRunner.defaultWorkingDirectory", "repo-root"],
+    ["validationRunner.maxOutputLines", 120],
+    ["validationRunner.timeoutMs", 30000],
     ["pythonPath", "python3"],
     ["defaultSource", "ignored.sv"],
     ["defaultLog", "ignored.log"],
@@ -857,6 +896,8 @@ async function testAIContextBundleCommandUsesActiveEditorSelectionAndDiagnostics
   assert.equal(result.contextBundle.selectedRange.start.line, 0);
   assert.equal(result.contextBundle.configuration.mode, "checkedExample");
   assert.equal(result.contextBundle.configuration.aiAssistant.enabled, false);
+  assert.equal(result.contextBundle.configuration.validationRunner.enabled, false);
+  assert.equal(result.contextBundle.configuration.validationRunner.mode, "disabled");
   assert.equal(result.contextBundle.diagnostics.length, 1);
   assert.equal(result.contextBundle.diagnostics[0].path, "rtl/top.sv");
   assert.equal(result.contextBundle.snippets.length, 1);
@@ -891,6 +932,158 @@ async function testValidationProposalCommandReturnsDataOnly() {
   assert.doesNotMatch(JSON.stringify(result), /git push/);
 }
 
+async function testApprovedValidationRunnerBlocksByDefaultAndUpdatesContext() {
+  const settings = new Map([
+    ["mode", "checkedExample"],
+    ["liveWorkspace.enabled", false],
+    ["pccxLab.command", "pccx_ide_cli"],
+    ["aiAssistant.enabled", false],
+    ["aiAssistant.backend", "none"],
+    ["validationRunner.enabled", false],
+    ["validationRunner.mode", "disabled"],
+    ["validationRunner.defaultWorkingDirectory", "repo-root"],
+    ["validationRunner.maxOutputLines", 2],
+    ["validationRunner.timeoutMs", 30000],
+    ["pythonPath", "python3"],
+    ["defaultSource", "fixtures/missing_endmodule.sv"],
+    ["defaultLog", "fixtures/xsim/mixed.log"],
+    ["defaultNavigationRoot", "fixtures/modules"],
+    ["defaultModule", "simple_mod"],
+    ["defaultDeclarationKind", "module"],
+  ]);
+  const runtime = {};
+  const vscodeApi = {
+    workspace: {
+      workspaceFolders: [{ uri: { fsPath: "/repo" } }],
+      getConfiguration() {
+        return {
+          get(key) {
+            return settings.get(key);
+          },
+        };
+      },
+    },
+  };
+  const handler = createCommandHandler(APPROVED_VALIDATION_RUNNER_COMMAND, vscodeApi, runtime);
+
+  const result = await handler("vscodeAdapterSmoke");
+
+  assert.equal(result.ok, false);
+  assert.equal(result.commandId, APPROVED_VALIDATION_RUNNER_COMMAND);
+  assert.equal(result.kind, "approved-validation-result");
+  assert.equal(result.proposalId, "vscodeAdapterSmoke");
+  assert.equal(result.status, "blocked");
+  assert.match(result.blockedReason, /runner is disabled/);
+  assert.equal(result.safety.allowlisted, true);
+  assert.equal(result.safety.shell, false);
+  assert.equal(runtime.recentValidationSummary.proposalId, "vscodeAdapterSmoke");
+  assert.equal(runtime.recentValidationSummary.status, "blocked");
+}
+
+async function testApprovedValidationRunnerRequiresProposalIdWhenEnabled() {
+  const settings = new Map([
+    ["mode", "checkedExample"],
+    ["liveWorkspace.enabled", false],
+    ["pccxLab.command", "pccx_ide_cli"],
+    ["aiAssistant.enabled", false],
+    ["aiAssistant.backend", "none"],
+    ["validationRunner.enabled", true],
+    ["validationRunner.mode", "allowlisted"],
+    ["validationRunner.defaultWorkingDirectory", "repo-root"],
+    ["validationRunner.maxOutputLines", 2],
+    ["validationRunner.timeoutMs", 30000],
+    ["pythonPath", "python3"],
+    ["defaultSource", "fixtures/missing_endmodule.sv"],
+    ["defaultLog", "fixtures/xsim/mixed.log"],
+    ["defaultNavigationRoot", "fixtures/modules"],
+    ["defaultModule", "simple_mod"],
+    ["defaultDeclarationKind", "module"],
+  ]);
+  const calls = [];
+  const handler = createCommandHandler(
+    APPROVED_VALIDATION_RUNNER_COMMAND,
+    {
+      workspace: {
+        workspaceFolders: [{ uri: { fsPath: "/repo/workspace" } }],
+        getConfiguration() {
+          return {
+            get(key) {
+              return settings.get(key);
+            },
+          };
+        },
+      },
+    },
+    {
+      repoRoot: "/repo",
+      validationExecFile(...args) {
+        calls.push(args);
+      },
+    },
+  );
+
+  const result = await handler();
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, "blocked");
+  assert.match(result.blockedReason, /proposal ID only/);
+  assert.equal(calls.length, 0);
+}
+
+async function testApprovedValidationRunnerExecutesAllowlistedProposalWhenEnabled() {
+  const settings = new Map([
+    ["mode", "checkedExample"],
+    ["liveWorkspace.enabled", false],
+    ["pccxLab.command", "pccx_ide_cli"],
+    ["aiAssistant.enabled", false],
+    ["aiAssistant.backend", "none"],
+    ["validationRunner.enabled", true],
+    ["validationRunner.mode", "allowlisted"],
+    ["validationRunner.defaultWorkingDirectory", "repo-root"],
+    ["validationRunner.maxOutputLines", 2],
+    ["validationRunner.timeoutMs", 30000],
+    ["pythonPath", "python3"],
+    ["defaultSource", "fixtures/missing_endmodule.sv"],
+    ["defaultLog", "fixtures/xsim/mixed.log"],
+    ["defaultNavigationRoot", "fixtures/modules"],
+    ["defaultModule", "simple_mod"],
+    ["defaultDeclarationKind", "module"],
+  ]);
+  const calls = [];
+  const vscodeApi = {
+    workspace: {
+      workspaceFolders: [{ uri: { fsPath: "/repo/workspace" } }],
+      getConfiguration() {
+        return {
+          get(key) {
+            return settings.get(key);
+          },
+        };
+      },
+    },
+  };
+  const handler = createCommandHandler(APPROVED_VALIDATION_RUNNER_COMMAND, vscodeApi, {
+    repoRoot: "/repo",
+    validationExecFile(executable, args, options, done) {
+      calls.push({ executable, args, options });
+      done(null, "ok\n", "");
+    },
+  });
+
+  const result = await handler({ proposalId: "vscodeAdapterSmoke" });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.status, "passed");
+  assert.equal(result.command, "bash");
+  assert.deepEqual(result.args, ["scripts/vscode-adapter-smoke.sh"]);
+  assert.equal(result.stdoutSummary.lines[0], "ok");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].executable, "bash");
+  assert.deepEqual(calls[0].args, ["scripts/vscode-adapter-smoke.sh"]);
+  assert.equal(calls[0].options.shell, false);
+  assert.equal(calls[0].options.cwd, "/repo");
+}
+
 async function testPccxLabBackendStatusCommandReturnsStatusOnly() {
   const settings = new Map([
     ["mode", "checkedExample"],
@@ -898,6 +1091,11 @@ async function testPccxLabBackendStatusCommandReturnsStatusOnly() {
     ["pccxLab.command", "custom-lab"],
     ["aiAssistant.enabled", false],
     ["aiAssistant.backend", "none"],
+    ["validationRunner.enabled", false],
+    ["validationRunner.mode", "disabled"],
+    ["validationRunner.defaultWorkingDirectory", "repo-root"],
+    ["validationRunner.maxOutputLines", 120],
+    ["validationRunner.timeoutMs", 30000],
     ["pythonPath", "python3"],
     ["defaultSource", "fixtures/missing_endmodule.sv"],
     ["defaultLog", "fixtures/xsim/mixed.log"],
@@ -930,6 +1128,8 @@ async function testPccxLabBackendStatusCommandReturnsStatusOnly() {
   assert.equal(result.status.executes, false);
   assert.equal(result.status.backendCommandExecuted, false);
   assert.ok(result.status.futureControlledOperations.includes("declarations"));
+  assert.ok(result.status.futureControlledOperations.includes("validation summary"));
+  assert.ok(result.status.futureSafetyRequirements.includes("fixed args"));
 }
 
 testKnownFacadeArgs();
@@ -950,6 +1150,9 @@ await testCommandHandlerCanBeUsedWithoutRealVsCode();
 await testAIStatusCommandReturnsDisabledBackendNone();
 await testAIContextBundleCommandUsesActiveEditorSelectionAndDiagnostics();
 await testValidationProposalCommandReturnsDataOnly();
+await testApprovedValidationRunnerBlocksByDefaultAndUpdatesContext();
+await testApprovedValidationRunnerRequiresProposalIdWhenEnabled();
+await testApprovedValidationRunnerExecutesAllowlistedProposalWhenEnabled();
 await testPccxLabBackendStatusCommandReturnsStatusOnly();
 
 console.log("vscode extension entrypoint tests ok");

--- a/editors/vscode-prototype/test/extension-host-readiness.test.mjs
+++ b/editors/vscode-prototype/test/extension-host-readiness.test.mjs
@@ -104,6 +104,7 @@ async function testReadinessDocsAndCiPolicy() {
   assert.match(`${readme}\n${readiness}`, /buildAIContextBundle/);
   assert.match(`${readme}\n${readiness}`, /selected-symbol context/i);
   assert.match(`${readme}\n${readiness}`, /proposeValidationCommand/);
+  assert.match(`${readme}\n${readiness}`, /runApprovedValidationCommand/);
   assert.match(`${readme}\n${readiness}`, /showPccxLabBackendStatus/);
   assert.match(`${readme}\n${readiness}`, /context bundle command/i);
   assert.match(`${readme}\n${readiness}`, /validation command proposal/i);
@@ -156,6 +157,9 @@ async function testRuntimeRunnerIsPinnedAndBounded() {
   assert.match(suite, /buildAIContextBundle/);
   assert.match(suite, /selectedContext/);
   assert.match(suite, /proposeValidationCommand/);
+  assert.match(suite, /runApprovedValidationCommand/);
+  assert.match(suite, /validationRunner\.enabled/);
+  assert.match(suite, /vscodeAdapterSmoke/);
   assert.match(suite, /showPccxLabBackendStatus/);
   assert.match(suite, /providerCallsImplemented/);
   assert.match(suite, /getDiagnostics/);

--- a/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
+++ b/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
@@ -37,6 +37,11 @@ async function resetPrototypeConfig() {
   await updatePrototypeConfig("liveWorkspace.enabled", false);
   await updatePrototypeConfig("aiAssistant.enabled", false);
   await updatePrototypeConfig("aiAssistant.backend", "none");
+  await updatePrototypeConfig("validationRunner.enabled", false);
+  await updatePrototypeConfig("validationRunner.mode", "disabled");
+  await updatePrototypeConfig("validationRunner.defaultWorkingDirectory", "repo-root");
+  await updatePrototypeConfig("validationRunner.maxOutputLines", 120);
+  await updatePrototypeConfig("validationRunner.timeoutMs", 30000);
   await updatePrototypeConfig("pythonPath", "python3");
   await updatePrototypeConfig("pccxLab.command", "pccx_ide_cli");
   await updatePrototypeConfig("defaultSource", "fixtures/missing_endmodule.sv");
@@ -62,6 +67,7 @@ async function run() {
     "pccxSystemVerilog.showAIAssistantStatus",
     "pccxSystemVerilog.buildAIContextBundle",
     "pccxSystemVerilog.proposeValidationCommand",
+    "pccxSystemVerilog.runApprovedValidationCommand",
     "pccxSystemVerilog.showPccxLabBackendStatus",
   ]);
 
@@ -356,11 +362,65 @@ async function run() {
   assert.equal(validationProposal.providerCalls, false);
   assert.equal(validationProposal.runtimeCalls, false);
   assert.ok(validationProposal.proposals.some((proposal) => (
+    proposal.id === "vscodeAdapterSmoke"
+  )));
+  assert.ok(validationProposal.proposals.some((proposal) => (
     proposal.command?.argv?.join(" ") === "bash scripts/vscode-adapter-smoke.sh"
   )));
   assert.ok(validationProposal.proposals.some((proposal) => (
     proposal.command?.env?.PCCX_RUN_EXTENSION_HOST_SMOKE === "1"
   )));
+
+  const disabledValidationRun = await vscode.commands.executeCommand(
+    "pccxSystemVerilog.runApprovedValidationCommand",
+    "vscodeAdapterSmoke",
+  );
+  assert.equal(disabledValidationRun.ok, false);
+  assert.equal(disabledValidationRun.kind, "approved-validation-result");
+  assert.equal(disabledValidationRun.status, "blocked");
+  assert.match(disabledValidationRun.blockedReason, /runner is disabled/);
+  assert.equal(disabledValidationRun.safety.allowlisted, true);
+  assert.equal(disabledValidationRun.safety.shell, false);
+
+  await updatePrototypeConfig("validationRunner.enabled", true);
+  await updatePrototypeConfig("validationRunner.mode", "allowlisted");
+  await updatePrototypeConfig("validationRunner.maxOutputLines", 20);
+  try {
+    const approvedValidationRun = await vscode.commands.executeCommand(
+      "pccxSystemVerilog.runApprovedValidationCommand",
+      { proposalId: "vscodeAdapterSmoke" },
+    );
+    assert.equal(approvedValidationRun.ok, true);
+    assert.equal(approvedValidationRun.status, "passed");
+    assert.equal(approvedValidationRun.command, "bash");
+    assert.deepEqual(approvedValidationRun.args, ["scripts/vscode-adapter-smoke.sh"]);
+    assert.equal(approvedValidationRun.safety.allowlisted, true);
+    assert.equal(approvedValidationRun.safety.shell, false);
+    assert.ok(approvedValidationRun.stdoutSummary.lines.length <= 20);
+    assert.equal(approvedValidationRun.resultSummary.proposalId, "vscodeAdapterSmoke");
+
+    const postValidationContext = await vscode.commands.executeCommand(
+      "pccxSystemVerilog.buildAIContextBundle",
+    );
+    assert.equal(postValidationContext.ok, true);
+    assert.equal(postValidationContext.contextBundle.validation.recent.proposalId, "vscodeAdapterSmoke");
+    assert.equal(postValidationContext.contextBundle.validation.recent.status, "passed");
+    assert.equal(
+      postValidationContext.contextBundle.validation.recent.commandLabel,
+      "VS Code adapter smoke",
+    );
+    assert.ok(
+      postValidationContext.contextBundle.validation.recent.stdoutSummary.lines.length <= 20,
+    );
+    assert.equal(
+      postValidationContext.contextBundle.validation.recent.safety.allowlisted,
+      true,
+    );
+  } finally {
+    await updatePrototypeConfig("validationRunner.enabled", false);
+    await updatePrototypeConfig("validationRunner.mode", "disabled");
+    await updatePrototypeConfig("validationRunner.maxOutputLines", 120);
+  }
 
   const pccxLabStatus = await vscode.commands.executeCommand(
     "pccxSystemVerilog.showPccxLabBackendStatus",

--- a/editors/vscode-prototype/test/extension-manifest.test.mjs
+++ b/editors/vscode-prototype/test/extension-manifest.test.mjs
@@ -17,6 +17,7 @@ const COMMAND_IDS = [
   "pccxSystemVerilog.showAIAssistantStatus",
   "pccxSystemVerilog.buildAIContextBundle",
   "pccxSystemVerilog.proposeValidationCommand",
+  "pccxSystemVerilog.runApprovedValidationCommand",
   "pccxSystemVerilog.showPccxLabBackendStatus",
 ];
 
@@ -115,6 +116,8 @@ async function testDocsKeepExperimentalScope() {
   assert.match(combined, /context bundle command/i);
   assert.match(combined, /AI assistant status command/i);
   assert.match(combined, /validation command proposal/i);
+  assert.match(combined, /approved validation runner/i);
+  assert.match(combined, /allowlisted proposal IDs/i);
   assert.match(combined, /pccx-lab backend status/i);
   assert.match(combined, /no AI provider calls/i);
   assert.match(combined, /no MCP server implementation/i);

--- a/editors/vscode-prototype/test/static-boundary.test.mjs
+++ b/editors/vscode-prototype/test/static-boundary.test.mjs
@@ -150,6 +150,42 @@ async function testProposalAndStatusModulesAreDataOnly() {
   assert.match(proposalAndStatusSource, /backendCommandExecuted: false/);
 }
 
+async function testApprovedValidationRunnerUsesOnlyAllowlistedExecution() {
+  const runnerSource = await readText(resolve(EXTENSION_ROOT, "src/approved-validation-runner.mjs"));
+  const proposalModule = await import(pathToFileURL(resolve(
+    EXTENSION_ROOT,
+    "src/validation-proposals.mjs",
+  )).href);
+  const proposals = proposalModule.listValidationCommandProposals();
+  const runnable = proposals.filter((proposal) => (
+    proposal.command && proposal.runnerPolicy !== "proposalOnly"
+  ));
+  const flattened = runnable.flatMap((proposal) => proposal.command.argv);
+
+  assert.match(runnerSource, /execFile/);
+  assert.match(runnerSource, /shell:\s*false/);
+  assert.match(runnerSource, /PROPOSAL_ID_PATTERN/);
+  assert.doesNotMatch(runnerSource, /\bexec\s*\(/);
+  assert.doesNotMatch(runnerSource, /shell\s*:\s*true/);
+  assert.ok(runnable.length >= 4);
+  assert.deepEqual(
+    runnable.map((proposal) => proposal.id),
+    ["vscodeAdapterSmoke", "editorBridgeSmoke", "exampleDriftCheck", "pytestBaseline"],
+  );
+  assert.ok(runnable.every((proposal) => proposal.command.cwd === "repo-root"));
+  assert.ok(runnable.every((proposal) => Array.isArray(proposal.command.argv)));
+  assert.ok(runnable.every((proposal) => ["bash", "python3"].includes(proposal.command.argv[0])));
+  assert.doesNotMatch(flattened.join("\n"), /(?:&&|\|\||;|`|\$\(|>|<)/);
+  assert.doesNotMatch(
+    flattened.join("\n"),
+    /\b(?:git|gh)\s+(?:push|commit|merge|release|tag|secret|ruleset|api)\b/i,
+  );
+  assert.equal(
+    proposals.find((proposal) => proposal.id === "extensionHostSmokeOptIn").runnerPolicy,
+    "proposalOnly",
+  );
+}
+
 async function testContextBundleDoesNotSerializePrivateInstructionNames() {
   const contextBundleModule = await import(pathToFileURL(resolve(
     EXTENSION_ROOT,
@@ -184,7 +220,7 @@ async function testNoPositiveReadinessClaims() {
     !path.endsWith("/editors/vscode-prototype/test/static-boundary.test.mjs")
   ));
   const positiveClaim =
-    /\b(?:production[- ]ready|(?<!pre-)stable API|(?<!pre-)stable ABI|(?<!pre-)stable diagnostics envelope|marketplace-ready|complete AI integration)\b/i;
+    /\b(?:production[- ]ready|(?<!pre-)stable API|(?<!pre-)stable ABI|(?<!pre-)stable diagnostics envelope|marketplace-ready|complete AI integration|fully validated|CI-covered|approved runner proves)\b/i;
   const negation = /\b(?:no|not|never|without|does not|is not|are not|avoid|do not)\b/i;
   const violations = [];
 
@@ -212,6 +248,7 @@ await testNoDirectCliCallsFromUiOrProviderLayers();
 await testNoPackagingPublisherOrLspDependencies();
 await testNoDirectShellInterpolation();
 await testProposalAndStatusModulesAreDataOnly();
+await testApprovedValidationRunnerUsesOnlyAllowlistedExecution();
 await testContextBundleDoesNotSerializePrivateInstructionNames();
 await testNoPositiveReadinessClaims();
 

--- a/editors/vscode-prototype/test/validation-proposals.test.mjs
+++ b/editors/vscode-prototype/test/validation-proposals.test.mjs
@@ -4,6 +4,8 @@ import {
   VALIDATION_PROPOSAL_CATEGORIES,
   VALIDATION_PROPOSAL_VERSION,
   createValidationCommandProposal,
+  findValidationCommandProposalById,
+  listValidationCommandProposals,
 } from "../src/validation-proposals.mjs";
 import {
   PCCX_LAB_BACKEND_STATUS_VERSION,
@@ -29,6 +31,18 @@ function testValidationProposalIsDataOnly() {
     proposal.proposals.map((item) => item.category),
     VALIDATION_PROPOSAL_CATEGORIES,
   );
+  assert.deepEqual(
+    proposal.proposals.map((item) => item.id),
+    [
+      "vscodeAdapterSmoke",
+      "editorBridgeSmoke",
+      "exampleDriftCheck",
+      "pytestBaseline",
+      "extensionHostSmokeOptIn",
+      "futurePccxLabDiagnostics",
+      "futureXsimLogAnalysis",
+    ],
+  );
   assert.ok(proposal.proposals.every((item) => item.requiresUserApproval === true));
   assert.ok(proposal.proposals.every((item) => item.executes === false));
   assert.ok(proposal.disallowedActions.includes("commit"));
@@ -48,8 +62,23 @@ function testValidationCommandsAreAllowlistedArgumentArrays() {
   assert.ok(commandProposals.some((item) => (
     item.command.env.PCCX_RUN_EXTENSION_HOST_SMOKE === "1"
   )));
+  assert.equal(
+    commandProposals.find((item) => item.id === "extensionHostSmokeOptIn").runnerPolicy,
+    "proposalOnly",
+  );
   assert.doesNotMatch(flattened.join("\n"), SHELL_CONTROL_PATTERN);
   assert.doesNotMatch(flattened.join("\n"), /\b(?:git|gh)\s+(?:push|commit|merge|release|tag)\b/i);
+}
+
+function testValidationProposalsCanBeResolvedByStableId() {
+  const proposals = listValidationCommandProposals();
+  const adapter = findValidationCommandProposalById("vscodeAdapterSmoke");
+
+  assert.ok(proposals.some((item) => item.id === "vscodeAdapterSmoke"));
+  assert.equal(adapter.id, "vscodeAdapterSmoke");
+  assert.equal(adapter.command.argv[0], "bash");
+  assert.equal(adapter.command.argv[1], "scripts/vscode-adapter-smoke.sh");
+  assert.equal(findValidationCommandProposalById("bash scripts/vscode-adapter-smoke.sh"), null);
 }
 
 function testPccxLabStatusIsStatusOnly() {
@@ -67,10 +96,14 @@ function testPccxLabStatusIsStatusOnly() {
   assert.equal(status.backendCommandExecuted, false);
   assert.ok(status.futureControlledOperations.includes("diagnostics"));
   assert.ok(status.futureControlledOperations.includes("xsim-log analysis"));
+  assert.ok(status.futureControlledOperations.includes("validation summary"));
+  assert.ok(status.futureSafetyRequirements.includes("fixed args"));
+  assert.ok(status.futureSafetyRequirements.includes("bounded output"));
 }
 
 testValidationProposalIsDataOnly();
 testValidationCommandsAreAllowlistedArgumentArrays();
+testValidationProposalsCanBeResolvedByStableId();
 testPccxLabStatusIsStatusOnly();
 
 console.log("vscode validation proposal and pccx-lab status tests ok");

--- a/editors/vscode-prototype/test/validation-result-summary.test.mjs
+++ b/editors/vscode-prototype/test/validation-result-summary.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+
+import {
+  VALIDATION_RESULT_SUMMARY_VERSION,
+  createValidationResultSummary,
+  summarizeOutputText,
+} from "../src/validation-result-summary.mjs";
+
+function testSummariesAreBoundedAndRedacted() {
+  const summary = summarizeOutputText(
+    [
+      "API_KEY=abc123",
+      "/home/dev/repo/rtl/top.sv:1: error: bad",
+      "line 3",
+      "line 4",
+    ].join("\n"),
+    { maxOutputLines: 2, maxLineCharacters: 80 },
+  );
+
+  assert.deepEqual(summary.lines, [
+    "[redacted]",
+    "[home]/repo/rtl/top.sv:1: error: bad",
+  ]);
+  assert.equal(summary.lineCount, 4);
+  assert.equal(summary.truncated, true);
+}
+
+function testValidationResultSummaryShape() {
+  const result = createValidationResultSummary(
+    {
+      proposalId: "vscodeAdapterSmoke",
+      commandLabel: "VS Code adapter smoke",
+      status: "failed",
+      exitCode: 1,
+      durationMs: 42,
+      command: "bash",
+      args: ["scripts/vscode-adapter-smoke.sh"],
+      cwdKind: "repo-root",
+      cwdLabel: "repo-root",
+      stdout: "ok\n",
+      stderr: "test failed\nTOKEN=hidden\n",
+      safety: {
+        allowlisted: true,
+        shell: false,
+        fixedArgs: true,
+        userProvidedCommand: false,
+        writesFiles: false,
+        providerCalls: false,
+        launcherCalls: false,
+        mcpServerCalls: false,
+      },
+    },
+    { maxOutputLines: 2 },
+  );
+
+  assert.equal(result.version, VALIDATION_RESULT_SUMMARY_VERSION);
+  assert.equal(result.proposalId, "vscodeAdapterSmoke");
+  assert.equal(result.commandLabel, "VS Code adapter smoke");
+  assert.equal(result.status, "failed");
+  assert.equal(result.exitCode, 1);
+  assert.deepEqual(result.stderrSummary.lines, ["test failed", "[redacted]"]);
+  assert.deepEqual(result.failureHints, ["test failed"]);
+  assert.equal(result.safety.allowlisted, true);
+  assert.equal(result.safety.shell, false);
+  assert.equal(result.safety.userProvidedCommand, false);
+}
+
+testSummariesAreBoundedAndRedacted();
+testValidationResultSummaryShape();
+
+console.log("vscode validation result summary tests ok");

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -18,6 +18,8 @@ node editors/vscode-prototype/test/context-bundle.test.mjs
 node editors/vscode-prototype/test/selected-symbol-context.test.mjs
 node editors/vscode-prototype/test/ai-assistant-boundary.test.mjs
 node editors/vscode-prototype/test/validation-proposals.test.mjs
+node editors/vscode-prototype/test/validation-result-summary.test.mjs
+node editors/vscode-prototype/test/approved-validation-runner.test.mjs
 node editors/vscode-prototype/test/static-boundary.test.mjs
 node editors/vscode-prototype/test/extension-entrypoint.test.mjs
 node editors/vscode-prototype/test/command-handlers.test.mjs


### PR DESCRIPTION
## Summary
- Adds an experimental approved validation runner boundary for the VS Code prototype.
- Keeps checked-example mode as the default and live workspace as explicit opt-in.
- Keeps `pccxSystemVerilog.proposeValidationCommand` data-only; it does not execute validation commands.
- Adds `pccxSystemVerilog.runApprovedValidationCommand`, disabled by default, for allowlisted command execution by proposal ID only.
- Adds bounded/redacted validation result summaries and feeds the latest summary into the token-saving context bundle.
- Prepares pccx-lab status wording for future fixed-args command boundaries while keeping pccx-lab execution future/prepared only.

## Safety
- Experimental only; no stable API/ABI claim.
- Approved runner executes only allowlisted proposal IDs after explicit enablement.
- No raw command strings or user-provided shell passthrough.
- No destructive, git write, release, tag, settings, secrets, or ruleset commands.
- No AI provider calls.
- No pccx-llm-launcher runtime calls yet.
- No MCP server implementation.
- No LSP.
- No marketplace packaging, publisher, vsce flow, release, or tag.

## Validation
- `npm ci --prefix editors/vscode-prototype`
- `bash scripts/vscode-adapter-smoke.sh`
- `PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh`
- `bash scripts/vscode-extension-host-smoke.sh` exited 2 intentionally by default
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `python3 -m pytest -q`
- `git diff --check`