### PR TITLE
Add VS Code validation result cache boundary

### DIFF
--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -138,6 +138,8 @@ The contributed commands are:
 - `pccxSystemVerilog.buildAIContextBundle`
 - `pccxSystemVerilog.proposeValidationCommand`
 - `pccxSystemVerilog.runApprovedValidationCommand`
+- `pccxSystemVerilog.showRecentValidationResults`
+- `pccxSystemVerilog.clearValidationResultCache`
 - `pccxSystemVerilog.showPccxLabBackendStatus`
 
 The prototype-only settings are:
@@ -242,8 +244,8 @@ command paths plus the provider smoke.  It checks the AI assistant status
 command, selected-symbol context bundle command, validation command
 proposal, disabled approved validation runner behavior, one explicit
 allowlisted validation run, validation summary handoff into the context
-bundle, and pccx-lab backend status command without provider/runtime
-calls.  It does not
+bundle, local validation-result cache command registration, and pccx-lab
+backend status command without provider/runtime calls.  It does not
 package the extension, add an LSP provider, or install through a
 marketplace flow.  Extension Host gates are
 tracked in
@@ -269,9 +271,13 @@ current file path, selected range, bounded lexical selected-symbol
 context, active diagnostics near the selection, recent navigation
 references, recent command status, current mode/configuration, and small
 bounded snippets only for explicit selections.  It can also include the
-latest approved validation runner summary: proposal ID, status, command
-label, exit code, duration/timestamps, bounded stdout/stderr summaries,
-failure hints, and safety metadata.  The selected-symbol
+latest approved validation runner cache summary and a small bounded
+recent validation history: proposal ID, status, allowlist label, exit
+code, duration/timestamps, working-directory kind, command kind, bounded
+stdout/stderr summaries, truncation/redaction flags, failure hints, and
+safety metadata.  It does not include full logs, raw shell command
+strings, raw absolute private paths, generated artifacts, or bulk file
+content.  The selected-symbol
 context extracts simple SystemVerilog-like lexical cues such as the symbol
 text, current line, and nearby module/package/interface/parameter/function
 or task declaration; it is not full semantic analysis.  The bundle
@@ -307,6 +313,17 @@ user-approved validation proposal.  It does not execute destructive
 commands, git write operations, release/tag/settings/secrets commands,
 patch proposals, AI provider calls, pccx-llm-launcher runtime calls, MCP
 server operations, or pccx-lab commands.
+
+Approved validation summaries are cached in memory only and kept brief.
+The cache stores summary-only, redacted entries for recent runner results;
+it does not persist to disk and does not store full stdout/stderr logs,
+secrets, tokens, private home paths, raw command strings, generated blobs,
+model paths, or pccx-lab outputs.  `pccxSystemVerilog.showRecentValidationResults`
+shows the small recent cache through VS Code-native surfaces, and
+`pccxSystemVerilog.clearValidationResultCache` clears the in-memory cache.
+This cache boundary does not add AI provider calls, MCP, LSP, marketplace
+packaging, pccx-llm-launcher calls, real pccx-lab execution, releases, or
+tags.
 
 ## Theme-Neutral Presentation Boundary
 
@@ -361,7 +378,7 @@ Later:
 3. Propose a validation command as data with `pccxSystemVerilog.proposeValidationCommand`.
 4. User approves an allowlisted validation proposal ID.
 5. Run `pccxSystemVerilog.runApprovedValidationCommand` only after the runner is explicitly enabled.
-6. Feed the bounded validation result summary back into the context bundle.
+6. Feed the bounded validation result cache summary back into the context bundle.
 7. Future local coding-assistant mode can propose a patch or next validation step, but does not execute either directly.
 
 ## Local Smoke
@@ -377,6 +394,7 @@ node editors/vscode-prototype/test/selected-symbol-context.test.mjs
 node editors/vscode-prototype/test/ai-assistant-boundary.test.mjs
 node editors/vscode-prototype/test/validation-proposals.test.mjs
 node editors/vscode-prototype/test/validation-result-summary.test.mjs
+node editors/vscode-prototype/test/validation-result-cache.test.mjs
 node editors/vscode-prototype/test/approved-validation-runner.test.mjs
 node editors/vscode-prototype/test/static-boundary.test.mjs
 node editors/vscode-prototype/test/extension-entrypoint.test.mjs

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -119,13 +119,15 @@ checked-example symbols.  It executes
 `pccxSystemVerilog.showAIAssistantStatus`,
 `pccxSystemVerilog.buildAIContextBundle`,
 `pccxSystemVerilog.proposeValidationCommand`, and
-`pccxSystemVerilog.runApprovedValidationCommand`, and
+`pccxSystemVerilog.runApprovedValidationCommand`,
+`pccxSystemVerilog.showRecentValidationResults`,
+`pccxSystemVerilog.clearValidationResultCache`, and
 `pccxSystemVerilog.showPccxLabBackendStatus`, verifying disabled/backend
 `none` status, proposal-only actions, disabled runner blocking behavior,
 one explicitly enabled allowlisted validation run, bounded active-file
-and selected-symbol context, bounded validation summary handoff,
-status-only pccx-lab boundary data, and no provider/runtime calls.  This
-is not LSP, and there is no LSP provider yet.
+and selected-symbol context, bounded validation-result cache summary
+handoff, status-only pccx-lab boundary data, and no provider/runtime
+calls.  This is not LSP, and there is no LSP provider yet.
 
 ## AI Assistant Boundary
 
@@ -149,12 +151,19 @@ validation runner.  It is disabled unless
 `validationRunner.enabled=true` and `validationRunner.mode=allowlisted`
 are set.  It accepts proposal IDs only and executes only fixed
 allowlisted command/argument arrays.  Output is bounded and summarized
-for token-saving context bundles.  It does not execute raw command
+for a small in-memory validation-result cache and token-saving context
+bundles.  `pccxSystemVerilog.showRecentValidationResults` shows cached
+summary-only entries through VS Code-native surfaces, and
+`pccxSystemVerilog.clearValidationResultCache` clears that local cache.
+The cache does not persist to disk and does not store full logs, raw
+shell command strings, secrets, tokens, private home paths, generated
+blobs, model paths, or pccx-lab outputs.  It does not execute raw command
 strings, destructive commands, git write operations,
 release/tag/settings/secrets commands, pccx-lab commands, AI provider calls,
-pccx-llm-launcher runtime calls, or MCP server operations.  It does not
-add a UI approval prompt in this prototype; callers should invoke it only
-after a user-approved validation proposal.
+pccx-llm-launcher runtime calls, MCP server operations, LSP, marketplace
+packaging, releases, or tags.  It does not add a UI approval prompt in
+this prototype; callers should invoke it only after a user-approved
+validation proposal.
 
 `pccxSystemVerilog.showPccxLabBackendStatus` is preparation for future
 command palette integration.  It reports the configured

--- a/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
+++ b/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
@@ -172,10 +172,21 @@ and pccx-lab execution.  The runner does not add a UI approval prompt in
 this prototype; callers should invoke it only after a user-approved
 validation proposal.
 
-When a validation run is attempted, the context bundle can carry a recent
-validation summary with proposal ID, status, command label, exit code,
-duration/timestamps, bounded stdout/stderr summaries, short failure
-hints, and safety metadata.  It does not include full logs.
+When a validation run is attempted, the extension keeps a small
+in-memory validation-result cache.  The cache is local-only,
+summary-only, and newest-first; it stores bounded/redacted summaries with
+proposal ID, status, allowlist label, exit code, duration/timestamps,
+working-directory kind, command kind, bounded stdout/stderr summaries,
+truncation/redaction flags, and safety metadata.  It does not persist to
+disk and does not store full logs, raw shell command strings, secrets,
+tokens, private home paths, generated blobs, model paths, or pccx-lab
+outputs.
+
+The context bundle can carry the latest cached validation summary and a
+small bounded recent validation history.  It does not include full logs,
+raw absolute private paths, generated artifacts, launcher calls, AI
+provider calls, MCP, LSP, marketplace packaging, release/tag flow, or
+real pccx-lab execution.
 
 ## Prototype Daily-Driver Loop
 
@@ -184,7 +195,7 @@ hints, and safety metadata.  It does not include full logs.
 3. Propose a validation command.
 4. User approves an allowlisted validation command.
 5. The runner executes bounded validation after explicit enablement.
-6. The validation summary flows back into the context bundle.
+6. The validation-result cache summary flows back into the context bundle.
 7. Future AI-assisted SystemVerilog development workflow can propose a patch or next validation, but does not execute directly.
 
 ## Daily-Driver Roadmap

--- a/editors/vscode-prototype/package.json
+++ b/editors/vscode-prototype/package.json
@@ -25,6 +25,8 @@
     "onCommand:pccxSystemVerilog.buildAIContextBundle",
     "onCommand:pccxSystemVerilog.proposeValidationCommand",
     "onCommand:pccxSystemVerilog.runApprovedValidationCommand",
+    "onCommand:pccxSystemVerilog.showRecentValidationResults",
+    "onCommand:pccxSystemVerilog.clearValidationResultCache",
     "onCommand:pccxSystemVerilog.showPccxLabBackendStatus"
   ],
   "contributes": {
@@ -76,6 +78,14 @@
       {
         "command": "pccxSystemVerilog.runApprovedValidationCommand",
         "title": "PCCX SystemVerilog: Run Approved Validation Command (Experimental, Opt-In)"
+      },
+      {
+        "command": "pccxSystemVerilog.showRecentValidationResults",
+        "title": "PCCX SystemVerilog: Show Recent Validation Results (Experimental)"
+      },
+      {
+        "command": "pccxSystemVerilog.clearValidationResultCache",
+        "title": "PCCX SystemVerilog: Clear Validation Result Cache (Experimental)"
       },
       {
         "command": "pccxSystemVerilog.showPccxLabBackendStatus",

--- a/editors/vscode-prototype/src/config.mjs
+++ b/editors/vscode-prototype/src/config.mjs
@@ -35,6 +35,8 @@ export const AI_COMMAND_IDS = Object.freeze([
   "pccxSystemVerilog.buildAIContextBundle",
   "pccxSystemVerilog.proposeValidationCommand",
   "pccxSystemVerilog.runApprovedValidationCommand",
+  "pccxSystemVerilog.showRecentValidationResults",
+  "pccxSystemVerilog.clearValidationResultCache",
 ]);
 
 export const PCCX_LAB_COMMAND_IDS = Object.freeze([

--- a/editors/vscode-prototype/src/context-bundle.mjs
+++ b/editors/vscode-prototype/src/context-bundle.mjs
@@ -9,6 +9,7 @@ export const DEFAULT_CONTEXT_BUNDLE_LIMITS = Object.freeze({
   maxDeclarations: 12,
   maxSnippetLines: 40,
   maxLogSummaryLines: 20,
+  maxRecentValidationResults: 5,
   maxTextCharacters: 4000,
 });
 
@@ -39,6 +40,7 @@ const SECRET_LIKE_PATTERN =
   /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b/i;
 const SECRET_ASSIGNMENT_PATTERN =
   /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]/i;
+const HOME_PATH_PATTERN = /(?:\/home\/[^/\s]+|\/Users\/[^/\s]+)/g;
 const PRIVATE_INSTRUCTION_PATH_PATTERN =
   /(?:^|[/\\])(?:\.codex|private[-_ ]?worker|worker[-_ ]?instruction|subagent[-_ ]?instruction)(?:[/\\]|$)/i;
 
@@ -146,7 +148,9 @@ function scrubText(value, maxCharacters) {
   if (typeof value !== "string" || value.length === 0 || maxCharacters === 0) {
     return "";
   }
-  return redactSecretAssignments(value).slice(0, maxCharacters);
+  return redactSecretAssignments(value)
+    .replace(HOME_PATH_PATTERN, "[home]")
+    .slice(0, maxCharacters);
 }
 
 function isBinaryLike(text) {
@@ -448,12 +452,17 @@ function normalizeRecentValidation(validation, limits) {
   if (!validation || typeof validation !== "object") {
     return null;
   }
+  const stdoutSummary = normalizeOutputSummary(validation.stdoutSummary, limits);
+  const stderrSummary = normalizeOutputSummary(validation.stderrSummary, limits);
+  const label = scrubText(validation.label ?? validation.commandLabel ?? "", 160);
+  const summaryText = scrubText(validation.summaryText ?? validation.summary ?? "", 800);
   return {
     version: scrubText(validation.version ?? "", 80),
     proposalId: scrubText(validation.proposalId ?? "", 120),
-    commandLabel: scrubText(validation.commandLabel ?? "", 160),
+    label,
+    commandLabel: scrubText(validation.commandLabel ?? label, 160),
     status: scrubText(validation.status ?? "unknown", 80),
-    summary: scrubText(validation.summary ?? "", 800),
+    summaryText,
     exitCode: validation.exitCode == null
       ? null
       : Math.floor(clampNumber(validation.exitCode)),
@@ -462,16 +471,19 @@ function normalizeRecentValidation(validation, limits) {
       : Math.max(0, Math.floor(clampNumber(validation.durationMs))),
     startedAt: scrubText(validation.startedAt ?? "", 80),
     finishedAt: scrubText(validation.finishedAt ?? "", 80),
-    command: scrubText(validation.command ?? "", 120),
-    args: Array.isArray(validation.args)
-      ? validation.args
-        .map((arg) => scrubText(String(arg ?? ""), 300))
-        .slice(0, 12)
-      : [],
-    cwdKind: scrubText(validation.cwdKind ?? "", 80),
-    cwdLabel: scrubText(validation.cwdLabel ?? "", 80),
-    stdoutSummary: normalizeOutputSummary(validation.stdoutSummary, limits),
-    stderrSummary: normalizeOutputSummary(validation.stderrSummary, limits),
+    commandKind: scrubText(validation.commandKind ?? "", 120),
+    workingDirectoryKind: scrubText(
+      validation.workingDirectoryKind ?? validation.cwdKind ?? "",
+      80,
+    ),
+    stdoutSummary,
+    stderrSummary,
+    truncated: validation.truncated === true ||
+      stdoutSummary.truncated === true ||
+      stderrSummary.truncated === true,
+    redactionApplied: validation.redactionApplied === true ||
+      stdoutSummary.lines.some((line) => line.includes("[redacted]") || line.includes("[home]")) ||
+      stderrSummary.lines.some((line) => line.includes("[redacted]") || line.includes("[home]")),
     failureHints: Array.isArray(validation.failureHints)
       ? validation.failureHints
         .map((hint) => scrubText(String(hint ?? ""), 500))
@@ -490,6 +502,16 @@ function normalizeRecentValidation(validation, limits) {
   };
 }
 
+function normalizeRecentValidationHistory(history, limits) {
+  if (!Array.isArray(history)) {
+    return [];
+  }
+  return history
+    .map((entry) => normalizeRecentValidation(entry, limits))
+    .filter(Boolean)
+    .slice(0, limits.maxRecentValidationResults);
+}
+
 export function buildContextBundle(input = {}, options = {}) {
   const limits = mergeLimits(options.limits);
   const workspaceRoot = options.workspaceRoot ?? input.workspaceRoot ?? null;
@@ -501,6 +523,13 @@ export function buildContextBundle(input = {}, options = {}) {
   const pccxLabOutputs = Array.isArray(input.pccxLabOutputs) ? input.pccxLabOutputs : [];
   const selectedPath = normalizePathRef(input.selectedFilePath, workspaceRoot);
   const selectedRange = normalizeRange(input.selectedRange);
+  const recentValidationHistory = normalizeRecentValidationHistory(
+    input.recentValidationHistory,
+    limits,
+  );
+  const recentValidation = normalizeRecentValidation(input.recentValidation, limits) ??
+    recentValidationHistory[0] ??
+    null;
 
   const snippets = sortedSnippets(
     files
@@ -535,7 +564,8 @@ export function buildContextBundle(input = {}, options = {}) {
     },
     snippets,
     validation: {
-      recent: normalizeRecentValidation(input.recentValidation, limits),
+      recent: recentValidation,
+      recentHistory: recentValidationHistory,
     },
     recentCommand: normalizeRecentCommandStatus(input.recentCommandStatus, limits),
     pccxLab: {
@@ -577,7 +607,10 @@ export function summarizeContextBundle(bundle) {
       ? {
           proposalId: bundle.validation.recent.proposalId,
           status: bundle.validation.recent.status,
-          commandLabel: bundle.validation.recent.commandLabel,
+          label: bundle.validation.recent.label,
+          recentHistoryCount: Array.isArray(bundle.validation.recentHistory)
+            ? bundle.validation.recentHistory.length
+            : 0,
         }
       : null,
   };

--- a/editors/vscode-prototype/src/extension.mjs
+++ b/editors/vscode-prototype/src/extension.mjs
@@ -41,6 +41,9 @@ import {
   runApprovedValidationProposal,
 } from "./approved-validation-runner.mjs";
 import {
+  createValidationResultCache,
+} from "./validation-result-cache.mjs";
+import {
   createPccxLabBackendStatus,
 } from "./pccx-lab-status.mjs";
 
@@ -63,6 +66,10 @@ export const VALIDATION_PROPOSAL_COMMAND =
   "pccxSystemVerilog.proposeValidationCommand";
 export const APPROVED_VALIDATION_RUNNER_COMMAND =
   "pccxSystemVerilog.runApprovedValidationCommand";
+export const SHOW_RECENT_VALIDATION_RESULTS_COMMAND =
+  "pccxSystemVerilog.showRecentValidationResults";
+export const CLEAR_VALIDATION_RESULT_CACHE_COMMAND =
+  "pccxSystemVerilog.clearValidationResultCache";
 export const PCCX_LAB_BACKEND_STATUS_COMMAND =
   "pccxSystemVerilog.showPccxLabBackendStatus";
 
@@ -218,6 +225,31 @@ export async function runCheckedExampleNavigationLocations(rawConfig = {}, deps 
   return runNavigationCommandLocations(CHECKED_EXAMPLE_NAVIGATION_COMMAND, rawConfig, deps);
 }
 
+function validationResultCacheFromRuntime(runtime = {}) {
+  if (!runtime.validationResultCache) {
+    runtime.validationResultCache = createValidationResultCache(runtime.validationResultCacheOptions);
+  }
+  return runtime.validationResultCache;
+}
+
+function shortValidationEntryLabel(entry) {
+  const label = entry?.label || entry?.proposalId || "validation";
+  const status = entry?.status || "unknown";
+  const exitText = entry?.exitCode == null ? "" : ` exit ${entry.exitCode}`;
+  return `${label}: ${status}${exitText}`;
+}
+
+function validationEntryQuickPickItems(entries) {
+  return entries.map((entry) => ({
+    label: entry.status === "passed" ? "$(check) " + entry.label : "$(warning) " + entry.label,
+    description: [entry.status, entry.exitCode == null ? "" : `exit ${entry.exitCode}`]
+      .filter(Boolean)
+      .join(" "),
+    detail: entry.summaryText,
+    entry,
+  }));
+}
+
 function appendCommandOutput(outputChannel, commandId, result) {
   if (!outputChannel?.appendLine) {
     return;
@@ -244,6 +276,29 @@ function appendCommandOutput(outputChannel, commandId, result) {
       status: result.status,
       exitCode: result.exitCode,
       durationMs: result.durationMs,
+    }, null, 2));
+  }
+  if (result.kind === "validation-result-cache") {
+    outputChannel.appendLine(JSON.stringify({
+      kind: result.kind,
+      count: result.entries?.length ?? 0,
+      entries: (result.entries ?? []).map((entry) => ({
+        proposalId: entry.proposalId,
+        label: entry.label,
+        status: entry.status,
+        exitCode: entry.exitCode,
+        durationMs: entry.durationMs,
+        commandKind: entry.commandKind,
+        workingDirectoryKind: entry.workingDirectoryKind,
+        truncated: entry.truncated,
+        redactionApplied: entry.redactionApplied,
+      })),
+    }, null, 2));
+  }
+  if (result.kind === "validation-result-cache-clear") {
+    outputChannel.appendLine(JSON.stringify({
+      kind: result.kind,
+      clearedCount: result.clearedCount,
     }, null, 2));
   }
   if (result.status?.kind === "pccx-lab-backend-status") {
@@ -463,6 +518,8 @@ function collectActiveDocumentContext(vscodeApi, runtime, config) {
   const workspaceRoot = workspaceRootForDocument(vscodeApi, document);
   const selectionRange = plainRange(editor?.selection);
   const activeDiagnostics = collectActiveDiagnostics(vscodeApi, runtime, document);
+  const validationCache = validationResultCacheFromRuntime(runtime);
+  const recentValidationHistory = validationCache.list();
   const selectedText = (
     document?.uri?.fsPath &&
     editor?.selection &&
@@ -524,7 +581,8 @@ function collectActiveDocumentContext(vscodeApi, runtime, config) {
       files,
       configuration: contextConfiguration(config),
       recentCommandStatus: runtime.recentCommandStatus ?? null,
-      recentValidation: runtime.recentValidationSummary ?? null,
+      recentValidation: recentValidationHistory[0] ?? runtime.recentValidationSummary ?? null,
+      recentValidationHistory,
     },
   };
 }
@@ -613,6 +671,66 @@ export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
       return result;
     }
 
+    if (commandId === SHOW_RECENT_VALIDATION_RESULTS_COMMAND) {
+      let result;
+      try {
+        const entries = validationResultCacheFromRuntime(runtime).list();
+        result = {
+          ok: true,
+          commandId,
+          kind: "validation-result-cache",
+          entries,
+          selected: null,
+        };
+        if (entries.length === 0) {
+          vscodeApi?.window?.showInformationMessage?.(
+            "No recent validation results are cached.",
+            result,
+          );
+        } else if (typeof vscodeApi?.window?.showQuickPick === "function") {
+          const selected = await vscodeApi.window.showQuickPick(
+            validationEntryQuickPickItems(entries),
+            { title: "Recent Validation Results", placeHolder: "Select a cached validation summary" },
+          );
+          result.selected = selected?.entry ?? null;
+        } else {
+          vscodeApi?.window?.showInformationMessage?.(
+            `${entries.length} recent validation result(s) cached. ${shortValidationEntryLabel(entries[0])}`,
+            result,
+          );
+        }
+      } catch (error) {
+        result = { ok: false, commandId, error: error.message };
+        vscodeApi?.window?.showWarningMessage?.(result.error, result);
+      }
+      appendCommandOutput(runtime.outputChannel, commandId, result);
+      return result;
+    }
+
+    if (commandId === CLEAR_VALIDATION_RESULT_CACHE_COMMAND) {
+      let result;
+      try {
+        const cache = validationResultCacheFromRuntime(runtime);
+        const clearedCount = cache.clear();
+        runtime.recentValidationSummary = null;
+        result = {
+          ok: true,
+          commandId,
+          kind: "validation-result-cache-clear",
+          clearedCount,
+        };
+        vscodeApi?.window?.showInformationMessage?.(
+          `Cleared ${clearedCount} cached validation result(s).`,
+          result,
+        );
+      } catch (error) {
+        result = { ok: false, commandId, error: error.message };
+        vscodeApi?.window?.showWarningMessage?.(result.error, result);
+      }
+      appendCommandOutput(runtime.outputChannel, commandId, result);
+      return result;
+    }
+
     if (commandId === APPROVED_VALIDATION_RUNNER_COMMAND) {
       let result;
       try {
@@ -627,7 +745,9 @@ export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
             env: runtime.env,
           },
         );
-        runtime.recentValidationSummary = result.resultSummary ?? null;
+        runtime.recentValidationSummary = result.resultSummary
+          ? validationResultCacheFromRuntime(runtime).add(result.resultSummary)
+          : null;
       } catch (error) {
         result = { ok: false, commandId, error: error.message };
         vscodeApi?.window?.showWarningMessage?.(result.error, result);

--- a/editors/vscode-prototype/src/validation-result-cache.mjs
+++ b/editors/vscode-prototype/src/validation-result-cache.mjs
@@ -1,0 +1,184 @@
+import { summarizeOutputText } from "./validation-result-summary.mjs";
+
+export const VALIDATION_RESULT_CACHE_ENTRY_VERSION = "pccx.validationResultCacheEntry.v0";
+export const DEFAULT_VALIDATION_RESULT_CACHE_MAX_SIZE = 5;
+export const DEFAULT_VALIDATION_RESULT_CACHE_OUTPUT_LINES = 20;
+
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]/i;
+const HOME_PATH_PATTERN = /(?:\/home\/[^/\s]+|\/Users\/[^/\s]+)/g;
+const HOME_PATH_TEST_PATTERN = /(?:\/home\/[^/\s]+|\/Users\/[^/\s]+)/;
+const WORKING_DIRECTORY_KINDS = new Set(["repo-root", "workspace"]);
+
+function clampInteger(value, fallback, min, max) {
+  if (!Number.isInteger(value)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, value));
+}
+
+function finiteNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function redactText(value) {
+  return String(value ?? "")
+    .split(/\r?\n/)
+    .map((line) => (SECRET_ASSIGNMENT_PATTERN.test(line) ? "[redacted]" : line))
+    .join("\n")
+    .replace(HOME_PATH_PATTERN, "[home]");
+}
+
+function boundedText(value, maxCharacters) {
+  if (typeof value !== "string" || value.length === 0 || maxCharacters === 0) {
+    return "";
+  }
+  return redactText(value).slice(0, maxCharacters);
+}
+
+function outputSummaryOptions(options = {}) {
+  return {
+    maxOutputLines: clampInteger(
+      options.maxOutputLines,
+      DEFAULT_VALIDATION_RESULT_CACHE_OUTPUT_LINES,
+      1,
+      120,
+    ),
+    maxLineCharacters: clampInteger(options.maxLineCharacters, 500, 80, 2000),
+    maxTextCharacters: clampInteger(options.maxTextCharacters, 4000, 500, 10000),
+  };
+}
+
+function normalizeOutputSummary(summary, options = {}) {
+  const limits = outputSummaryOptions(options);
+  const sourceLines = Array.isArray(summary?.lines)
+    ? summary.lines.map((line) => String(line ?? ""))
+    : [];
+  const rawText = sourceLines.join("\n");
+  const normalized = summarizeOutputText(rawText, limits);
+  const sourceLineCount = Math.max(
+    0,
+    Math.floor(finiteNumber(summary?.lineCount, normalized.lineCount)),
+  );
+  const redactionApplied = sourceLines.some((line) => (
+    SECRET_ASSIGNMENT_PATTERN.test(line) ||
+    HOME_PATH_TEST_PATTERN.test(line) ||
+    line.includes("[redacted]") ||
+    line.includes("[home]")
+  ));
+
+  return {
+    summary: {
+      lines: normalized.lines,
+      lineCount: Math.max(sourceLineCount, normalized.lineCount),
+      truncated: summary?.truncated === true ||
+        normalized.truncated === true ||
+        sourceLines.length > normalized.lines.length ||
+        sourceLineCount > normalized.lines.length,
+    },
+    redactionApplied,
+  };
+}
+
+function normalizedWorkingDirectoryKind(summary = {}) {
+  const kind = summary.workingDirectoryKind ?? summary.cwdKind ?? summary.cwdLabel ?? "";
+  return WORKING_DIRECTORY_KINDS.has(kind) ? kind : "";
+}
+
+function normalizedCommandKind(summary = {}) {
+  if (typeof summary.commandKind === "string" && summary.commandKind.trim()) {
+    return boundedText(summary.commandKind, 120);
+  }
+  if (summary.safety?.allowlisted === true) {
+    return "allowlisted-validation-proposal";
+  }
+  return "validation-proposal";
+}
+
+function cloneEntry(entry) {
+  return JSON.parse(JSON.stringify(entry));
+}
+
+export function createValidationResultCacheEntry(validationResult = {}, options = {}) {
+  const source = validationResult?.resultSummary &&
+    typeof validationResult.resultSummary === "object"
+    ? validationResult.resultSummary
+    : validationResult;
+  const stdout = normalizeOutputSummary(source.stdoutSummary, options);
+  const stderr = normalizeOutputSummary(source.stderrSummary, options);
+  const label = boundedText(
+    source.label ?? source.commandLabel ?? source.proposalId ?? "validation",
+    160,
+  );
+  const summaryText = boundedText(source.summaryText ?? source.summary ?? "", 800);
+
+  return {
+    version: VALIDATION_RESULT_CACHE_ENTRY_VERSION,
+    proposalId: boundedText(source.proposalId ?? "", 120),
+    label,
+    status: boundedText(source.status ?? "unknown", 80),
+    exitCode: source.exitCode == null ? null : Math.floor(finiteNumber(source.exitCode)),
+    startedAt: boundedText(source.startedAt ?? "", 80),
+    finishedAt: boundedText(source.finishedAt ?? "", 80),
+    durationMs: source.durationMs == null
+      ? null
+      : Math.max(0, Math.floor(finiteNumber(source.durationMs))),
+    summaryText,
+    workingDirectoryKind: normalizedWorkingDirectoryKind(source),
+    commandKind: normalizedCommandKind(source),
+    stdoutSummary: stdout.summary,
+    stderrSummary: stderr.summary,
+    truncated: source.truncated === true ||
+      stdout.summary.truncated === true ||
+      stderr.summary.truncated === true,
+    redactionApplied: source.redactionApplied === true ||
+      stdout.redactionApplied ||
+      stderr.redactionApplied ||
+      summaryText.includes("[redacted]") ||
+      summaryText.includes("[home]"),
+    safety: {
+      allowlisted: source.safety?.allowlisted === true,
+      shell: source.safety?.shell === true,
+      fixedArgs: source.safety?.fixedArgs === true,
+      userProvidedCommand: source.safety?.userProvidedCommand === true,
+      writesFiles: source.safety?.writesFiles === true,
+      providerCalls: source.safety?.providerCalls === true,
+      launcherCalls: source.safety?.launcherCalls === true,
+      mcpServerCalls: source.safety?.mcpServerCalls === true,
+    },
+  };
+}
+
+export function createValidationResultCache(options = {}) {
+  const maxSize = clampInteger(
+    options.maxSize,
+    DEFAULT_VALIDATION_RESULT_CACHE_MAX_SIZE,
+    1,
+    20,
+  );
+  const entryOptions = outputSummaryOptions(options);
+  let entries = [];
+
+  return {
+    add(validationResult) {
+      const entry = createValidationResultCacheEntry(validationResult, entryOptions);
+      entries = [entry, ...entries].slice(0, maxSize);
+      return cloneEntry(entry);
+    },
+    list() {
+      return entries.map((entry) => cloneEntry(entry));
+    },
+    latest() {
+      return entries[0] ? cloneEntry(entries[0]) : null;
+    },
+    clear() {
+      const count = entries.length;
+      entries = [];
+      return count;
+    },
+    size() {
+      return entries.length;
+    },
+  };
+}

--- a/editors/vscode-prototype/test/context-bundle.test.mjs
+++ b/editors/vscode-prototype/test/context-bundle.test.mjs
@@ -169,19 +169,19 @@ function fixtureInput() {
       navigationItemCount: 0,
     },
     recentValidation: {
-      version: "pccx.validationResultSummary.v0",
+      version: "pccx.validationResultCacheEntry.v0",
       proposalId: "vscodeAdapterSmoke",
-      commandLabel: "VS Code adapter smoke",
+      label: "VS Code adapter smoke",
       status: "failed",
-      summary: "VS Code adapter smoke failed (exit 1)",
+      summaryText: "VS Code adapter smoke failed (exit 1)",
       exitCode: 1,
       durationMs: 55,
       startedAt: "2026-01-01T00:00:00.000Z",
       finishedAt: "2026-01-01T00:00:00.055Z",
+      commandKind: "allowlisted-validation-proposal",
+      workingDirectoryKind: "repo-root",
       command: "bash",
       args: ["scripts/vscode-adapter-smoke.sh"],
-      cwdKind: "repo-root",
-      cwdLabel: "repo-root",
       stdoutSummary: {
         lines: ["adapter ok", "API_KEY=abc123", "extra"],
         lineCount: 3,
@@ -192,6 +192,8 @@ function fixtureInput() {
         lineCount: 1,
         truncated: false,
       },
+      truncated: true,
+      redactionApplied: true,
       failureHints: ["failure: missing endmodule"],
       safety: {
         allowlisted: true,
@@ -204,6 +206,58 @@ function fixtureInput() {
         mcpServerCalls: false,
       },
     },
+    recentValidationHistory: [
+      {
+        version: "pccx.validationResultCacheEntry.v0",
+        proposalId: "vscodeAdapterSmoke",
+        label: "VS Code adapter smoke",
+        status: "failed",
+        summaryText: "VS Code adapter smoke failed (exit 1)",
+        exitCode: 1,
+        durationMs: 55,
+        startedAt: "2026-01-01T00:00:00.000Z",
+        finishedAt: "2026-01-01T00:00:00.055Z",
+        commandKind: "allowlisted-validation-proposal",
+        workingDirectoryKind: "repo-root",
+        stdoutSummary: {
+          lines: ["adapter ok"],
+          lineCount: 1,
+          truncated: false,
+        },
+        stderrSummary: {
+          lines: ["failure: missing endmodule"],
+          lineCount: 1,
+          truncated: false,
+        },
+        truncated: false,
+        redactionApplied: false,
+      },
+      {
+        version: "pccx.validationResultCacheEntry.v0",
+        proposalId: "editorBridgeSmoke",
+        label: "Editor bridge smoke",
+        status: "passed",
+        summaryText: "Editor bridge smoke passed",
+        exitCode: 0,
+        durationMs: 12,
+        startedAt: "2026-01-01T00:01:00.000Z",
+        finishedAt: "2026-01-01T00:01:00.012Z",
+        commandKind: "allowlisted-validation-proposal",
+        workingDirectoryKind: "repo-root",
+        stdoutSummary: {
+          lines: ["bridge ok"],
+          lineCount: 1,
+          truncated: false,
+        },
+        stderrSummary: {
+          lines: [],
+          lineCount: 0,
+          truncated: false,
+        },
+        truncated: false,
+        redactionApplied: false,
+      },
+    ],
     pccxLabOutputs: [
       {
         flow: "problems from-check",
@@ -248,11 +302,21 @@ function testStableBoundedShape() {
   assert.equal(bundle.validation.recent.status, "failed");
   assert.equal(bundle.validation.recent.proposalId, "vscodeAdapterSmoke");
   assert.equal(bundle.validation.recent.commandLabel, "VS Code adapter smoke");
+  assert.equal(bundle.validation.recent.label, "VS Code adapter smoke");
+  assert.equal(bundle.validation.recent.commandKind, "allowlisted-validation-proposal");
+  assert.equal(bundle.validation.recent.workingDirectoryKind, "repo-root");
   assert.equal(bundle.validation.recent.stdoutSummary.lines.length, 1);
   assert.deepEqual(bundle.validation.recent.stdoutSummary.lines, ["adapter ok"]);
   assert.deepEqual(bundle.validation.recent.stderrSummary.lines, ["failure: missing endmodule"]);
+  assert.equal(bundle.validation.recent.truncated, true);
+  assert.equal(bundle.validation.recent.redactionApplied, true);
   assert.equal(bundle.validation.recent.safety.allowlisted, true);
   assert.equal(bundle.validation.recent.safety.shell, false);
+  assert.equal(bundle.validation.recentHistory.length, 2);
+  assert.deepEqual(
+    bundle.validation.recentHistory.map((entry) => entry.proposalId),
+    ["vscodeAdapterSmoke", "editorBridgeSmoke"],
+  );
   assert.equal(bundle.recentCommand.commandId, "pccxSystemVerilog.publishCheckedExampleDiagnostics");
   assert.equal(bundle.recentCommand.facade.mode, "example");
   assert.equal(bundle.pccxLab.outputs.length, 1);
@@ -274,7 +338,8 @@ function testStableBoundedShape() {
     validation: {
       proposalId: "vscodeAdapterSmoke",
       status: "failed",
-      commandLabel: "VS Code adapter smoke",
+      label: "VS Code adapter smoke",
+      recentHistoryCount: 2,
     },
   });
 }
@@ -426,6 +491,68 @@ function testNoHugeFileOrRestrictedPathInclusion() {
   assert.deepEqual(bundle.diagnostics, []);
 }
 
+function testValidationHistoryIsSummaryOnlyAndBounded() {
+  const bundle = buildContextBundle(
+    {
+      workspaceRoot: "/repo",
+      recentValidationHistory: [
+        {
+          proposalId: "newest",
+          label: "Newest",
+          status: "failed",
+          summaryText: "failed without full logs",
+          exitCode: 1,
+          commandKind: "allowlisted-validation-proposal",
+          workingDirectoryKind: "repo-root",
+          command: "bash",
+          args: ["scripts/private.sh"],
+          fullStdout: "full log must not flow",
+          stdoutSummary: {
+            lines: [
+              "line one",
+              "TOKEN=hidden",
+              "/home/dev/private/path.sv",
+              "line four",
+            ],
+            lineCount: 4,
+            truncated: false,
+          },
+          stderrSummary: {
+            lines: ["failure"],
+            lineCount: 1,
+            truncated: false,
+          },
+        },
+        {
+          proposalId: "older",
+          label: "Older",
+          status: "passed",
+          stdoutSummary: { lines: ["ok"], lineCount: 1, truncated: false },
+          stderrSummary: { lines: [], lineCount: 0, truncated: false },
+        },
+      ],
+    },
+    {
+      workspaceRoot: "/repo",
+      limits: {
+        maxLogSummaryLines: 2,
+        maxRecentValidationResults: 1,
+      },
+    },
+  );
+  const serialized = JSON.stringify(bundle.validation);
+
+  assert.equal(bundle.validation.recent.proposalId, "newest");
+  assert.equal(bundle.validation.recentHistory.length, 1);
+  assert.deepEqual(bundle.validation.recentHistory[0].stdoutSummary.lines, ["line one", "[redacted]"]);
+  assert.equal(bundle.validation.recentHistory[0].stdoutSummary.truncated, true);
+  assert.doesNotMatch(serialized, /full log must not flow/);
+  assert.doesNotMatch(serialized, /scripts\/private\.sh/);
+  assert.doesNotMatch(serialized, /TOKEN=hidden/);
+  assert.doesNotMatch(serialized, /\/home\/dev/);
+  assert.doesNotMatch(serialized, /line four/);
+}
+
 function testNoSecretValuesOrSecretLikeKeys() {
   const bundle = buildContextBundle(fixtureInput(), { workspaceRoot: "/repo" });
   const serialized = JSON.stringify(bundle);
@@ -435,6 +562,7 @@ function testNoSecretValuesOrSecretLikeKeys() {
   assert.doesNotMatch(serialized, /API_KEY=/);
   assert.doesNotMatch(serialized, /token=hidden/);
   assert.doesNotMatch(serialized, /API_KEY=abc123/);
+  assert.doesNotMatch(serialized, /scripts\/vscode-adapter-smoke\.sh/);
   assert.doesNotMatch(serialized, /AGENTS\.md/);
   assert.doesNotMatch(serialized, /package-lock\.json/);
 }
@@ -481,6 +609,7 @@ testSelectedFileSnippetAndDiagnosticsArePrioritized();
 testInvalidSelectedSymbolAndRangesAreControlled();
 testLongSingleLineSnippetReportsTruncation();
 testNoHugeFileOrRestrictedPathInclusion();
+testValidationHistoryIsSummaryOnlyAndBounded();
 testNoSecretValuesOrSecretLikeKeys();
 testNoAbsoluteHomePathLeakage();
 testNoActiveEditorContextShape();

--- a/editors/vscode-prototype/test/extension-entrypoint.test.mjs
+++ b/editors/vscode-prototype/test/extension-entrypoint.test.mjs
@@ -4,11 +4,13 @@ import {
   AI_CONTEXT_BUNDLE_COMMAND,
   AI_ASSISTANT_STATUS_COMMAND,
   APPROVED_VALIDATION_RUNNER_COMMAND,
+  CLEAR_VALIDATION_RESULT_CACHE_COMMAND,
   COMMAND_IDS,
   CHECKED_EXAMPLE_NAVIGATION_COMMAND,
   FACADE_COMMAND_IDS,
   LIVE_WORKSPACE_NAVIGATION_COMMAND,
   PCCX_LAB_BACKEND_STATUS_COMMAND,
+  SHOW_RECENT_VALIDATION_RESULTS_COMMAND,
   VALIDATION_PROPOSAL_COMMAND,
   activate,
   buildFacadeArgsForCommand,
@@ -978,6 +980,9 @@ async function testApprovedValidationRunnerBlocksByDefaultAndUpdatesContext() {
   assert.equal(result.safety.shell, false);
   assert.equal(runtime.recentValidationSummary.proposalId, "vscodeAdapterSmoke");
   assert.equal(runtime.recentValidationSummary.status, "blocked");
+  assert.equal(runtime.recentValidationSummary.commandKind, "allowlisted-validation-proposal");
+  assert.equal(runtime.validationResultCache.size(), 1);
+  assert.equal(runtime.validationResultCache.latest().proposalId, "vscodeAdapterSmoke");
 }
 
 async function testApprovedValidationRunnerRequiresProposalIdWhenEnabled() {
@@ -1084,6 +1089,84 @@ async function testApprovedValidationRunnerExecutesAllowlistedProposalWhenEnable
   assert.equal(calls[0].options.cwd, "/repo");
 }
 
+async function testValidationResultCacheCommandsShowAndClear() {
+  const settings = new Map([
+    ["mode", "checkedExample"],
+    ["liveWorkspace.enabled", false],
+    ["pccxLab.command", "pccx_ide_cli"],
+    ["aiAssistant.enabled", false],
+    ["aiAssistant.backend", "none"],
+    ["validationRunner.enabled", true],
+    ["validationRunner.mode", "allowlisted"],
+    ["validationRunner.defaultWorkingDirectory", "repo-root"],
+    ["validationRunner.maxOutputLines", 3],
+    ["validationRunner.timeoutMs", 30000],
+    ["pythonPath", "python3"],
+    ["defaultSource", "fixtures/missing_endmodule.sv"],
+    ["defaultLog", "fixtures/xsim/mixed.log"],
+    ["defaultNavigationRoot", "fixtures/modules"],
+    ["defaultModule", "simple_mod"],
+    ["defaultDeclarationKind", "module"],
+  ]);
+  const quickPickCalls = [];
+  const informationMessages = [];
+  const vscodeApi = {
+    workspace: {
+      workspaceFolders: [{ uri: { fsPath: "/repo/workspace" } }],
+      getConfiguration() {
+        return {
+          get(key) {
+            return settings.get(key);
+          },
+        };
+      },
+    },
+    window: {
+      showInformationMessage(...args) {
+        informationMessages.push(args);
+      },
+      showQuickPick(items, options) {
+        quickPickCalls.push({ items, options });
+        return items[0];
+      },
+    },
+  };
+  const runtime = {
+    repoRoot: "/repo",
+    validationExecFile(_executable, _args, _options, done) {
+      done(null, "ok\nTOKEN=hidden\n/home/dev/repo/file.sv\n", "");
+    },
+  };
+  const runHandler = createCommandHandler(APPROVED_VALIDATION_RUNNER_COMMAND, vscodeApi, runtime);
+  const showHandler = createCommandHandler(SHOW_RECENT_VALIDATION_RESULTS_COMMAND, vscodeApi, runtime);
+  const clearHandler = createCommandHandler(CLEAR_VALIDATION_RESULT_CACHE_COMMAND, vscodeApi, runtime);
+
+  await runHandler({ proposalId: "vscodeAdapterSmoke" });
+  const shown = await showHandler();
+
+  assert.equal(shown.ok, true);
+  assert.equal(shown.kind, "validation-result-cache");
+  assert.equal(shown.entries.length, 1);
+  assert.equal(shown.entries[0].proposalId, "vscodeAdapterSmoke");
+  assert.equal(shown.entries[0].commandKind, "allowlisted-validation-proposal");
+  assert.equal(shown.entries[0].redactionApplied, true);
+  assert.equal(shown.selected.proposalId, "vscodeAdapterSmoke");
+  assert.equal(quickPickCalls.length, 1);
+  assert.equal(quickPickCalls[0].options.title, "Recent Validation Results");
+  assert.doesNotMatch(JSON.stringify(shown.entries), /TOKEN=hidden/);
+  assert.doesNotMatch(JSON.stringify(shown.entries), /\/home\/dev/);
+  assert.doesNotMatch(JSON.stringify(shown.entries), /scripts\/vscode-adapter-smoke\.sh/);
+
+  const cleared = await clearHandler();
+
+  assert.equal(cleared.ok, true);
+  assert.equal(cleared.kind, "validation-result-cache-clear");
+  assert.equal(cleared.clearedCount, 1);
+  assert.equal(runtime.validationResultCache.size(), 0);
+  assert.equal(runtime.recentValidationSummary, null);
+  assert.match(informationMessages[0][0], /Cleared 1 cached validation result/);
+}
+
 async function testPccxLabBackendStatusCommandReturnsStatusOnly() {
   const settings = new Map([
     ["mode", "checkedExample"],
@@ -1153,6 +1236,7 @@ await testValidationProposalCommandReturnsDataOnly();
 await testApprovedValidationRunnerBlocksByDefaultAndUpdatesContext();
 await testApprovedValidationRunnerRequiresProposalIdWhenEnabled();
 await testApprovedValidationRunnerExecutesAllowlistedProposalWhenEnabled();
+await testValidationResultCacheCommandsShowAndClear();
 await testPccxLabBackendStatusCommandReturnsStatusOnly();
 
 console.log("vscode extension entrypoint tests ok");

--- a/editors/vscode-prototype/test/extension-host-readiness.test.mjs
+++ b/editors/vscode-prototype/test/extension-host-readiness.test.mjs
@@ -105,6 +105,8 @@ async function testReadinessDocsAndCiPolicy() {
   assert.match(`${readme}\n${readiness}`, /selected-symbol context/i);
   assert.match(`${readme}\n${readiness}`, /proposeValidationCommand/);
   assert.match(`${readme}\n${readiness}`, /runApprovedValidationCommand/);
+  assert.match(`${readme}\n${readiness}`, /showRecentValidationResults/);
+  assert.match(`${readme}\n${readiness}`, /clearValidationResultCache/);
   assert.match(`${readme}\n${readiness}`, /showPccxLabBackendStatus/);
   assert.match(`${readme}\n${readiness}`, /context bundle command/i);
   assert.match(`${readme}\n${readiness}`, /validation command proposal/i);
@@ -158,6 +160,8 @@ async function testRuntimeRunnerIsPinnedAndBounded() {
   assert.match(suite, /selectedContext/);
   assert.match(suite, /proposeValidationCommand/);
   assert.match(suite, /runApprovedValidationCommand/);
+  assert.match(suite, /showRecentValidationResults/);
+  assert.match(suite, /clearValidationResultCache/);
   assert.match(suite, /validationRunner\.enabled/);
   assert.match(suite, /vscodeAdapterSmoke/);
   assert.match(suite, /showPccxLabBackendStatus/);

--- a/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
+++ b/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
@@ -68,6 +68,8 @@ async function run() {
     "pccxSystemVerilog.buildAIContextBundle",
     "pccxSystemVerilog.proposeValidationCommand",
     "pccxSystemVerilog.runApprovedValidationCommand",
+    "pccxSystemVerilog.showRecentValidationResults",
+    "pccxSystemVerilog.clearValidationResultCache",
     "pccxSystemVerilog.showPccxLabBackendStatus",
   ]);
 

--- a/editors/vscode-prototype/test/extension-manifest.test.mjs
+++ b/editors/vscode-prototype/test/extension-manifest.test.mjs
@@ -18,6 +18,8 @@ const COMMAND_IDS = [
   "pccxSystemVerilog.buildAIContextBundle",
   "pccxSystemVerilog.proposeValidationCommand",
   "pccxSystemVerilog.runApprovedValidationCommand",
+  "pccxSystemVerilog.showRecentValidationResults",
+  "pccxSystemVerilog.clearValidationResultCache",
   "pccxSystemVerilog.showPccxLabBackendStatus",
 ];
 

--- a/editors/vscode-prototype/test/validation-result-cache.test.mjs
+++ b/editors/vscode-prototype/test/validation-result-cache.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+
+import {
+  VALIDATION_RESULT_CACHE_ENTRY_VERSION,
+  createValidationResultCache,
+  createValidationResultCacheEntry,
+} from "../src/validation-result-cache.mjs";
+
+function summary(proposalId, options = {}) {
+  return {
+    version: "pccx.validationResultSummary.v0",
+    proposalId,
+    commandLabel: options.commandLabel ?? `Validation ${proposalId}`,
+    status: options.status ?? "passed",
+    summary: options.summary ?? `Validation ${proposalId} passed`,
+    exitCode: options.exitCode ?? 0,
+    durationMs: options.durationMs ?? 25,
+    startedAt: options.startedAt ?? "2026-01-01T00:00:00.000Z",
+    finishedAt: options.finishedAt ?? "2026-01-01T00:00:00.025Z",
+    command: "bash",
+    args: ["scripts/vscode-adapter-smoke.sh"],
+    cwdKind: options.cwdKind ?? "repo-root",
+    stdoutSummary: options.stdoutSummary ?? {
+      lines: ["ok"],
+      lineCount: 1,
+      truncated: false,
+    },
+    stderrSummary: options.stderrSummary ?? {
+      lines: [],
+      lineCount: 0,
+      truncated: false,
+    },
+    safety: {
+      allowlisted: true,
+      shell: false,
+      fixedArgs: true,
+      userProvidedCommand: false,
+      writesFiles: false,
+      providerCalls: false,
+      launcherCalls: false,
+      mcpServerCalls: false,
+    },
+  };
+}
+
+function testCacheKeepsNewestFirstWithinMaxSize() {
+  const cache = createValidationResultCache({ maxSize: 3 });
+
+  cache.add(summary("one"));
+  cache.add(summary("two"));
+  cache.add(summary("three"));
+  cache.add(summary("four"));
+
+  assert.deepEqual(
+    cache.list().map((entry) => entry.proposalId),
+    ["four", "three", "two"],
+  );
+  assert.equal(cache.latest().proposalId, "four");
+  assert.equal(cache.size(), 3);
+}
+
+function testCacheEntriesAreSummaryOnlyRedactedAndBounded() {
+  const entry = createValidationResultCacheEntry(
+    summary("vscodeAdapterSmoke", {
+      stdoutSummary: {
+        lines: [
+          "adapter ok",
+          "TOKEN=hidden",
+          "/home/dev/repo/rtl/top.sv:1: note",
+          "tail",
+        ],
+        lineCount: 4,
+        truncated: false,
+      },
+      stderrSummary: {
+        lines: ["/Users/dev/project/error.sv:2: error"],
+        lineCount: 1,
+        truncated: false,
+      },
+    }),
+    { maxOutputLines: 2 },
+  );
+  const serialized = JSON.stringify(entry);
+
+  assert.equal(entry.version, VALIDATION_RESULT_CACHE_ENTRY_VERSION);
+  assert.equal(entry.proposalId, "vscodeAdapterSmoke");
+  assert.equal(entry.label, "Validation vscodeAdapterSmoke");
+  assert.equal(entry.workingDirectoryKind, "repo-root");
+  assert.equal(entry.commandKind, "allowlisted-validation-proposal");
+  assert.deepEqual(entry.stdoutSummary.lines, ["adapter ok", "[redacted]"]);
+  assert.deepEqual(entry.stderrSummary.lines, ["[home]/project/error.sv:2: error"]);
+  assert.equal(entry.stdoutSummary.truncated, true);
+  assert.equal(entry.truncated, true);
+  assert.equal(entry.redactionApplied, true);
+  assert.equal(Object.hasOwn(entry, "command"), false);
+  assert.equal(Object.hasOwn(entry, "args"), false);
+  assert.doesNotMatch(serialized, /TOKEN=hidden/);
+  assert.doesNotMatch(serialized, /\/home\/dev/);
+  assert.doesNotMatch(serialized, /\/Users\/dev/);
+  assert.doesNotMatch(serialized, /scripts\/vscode-adapter-smoke\.sh/);
+}
+
+function testCacheClearReturnsCountAndEmptiesEntries() {
+  const cache = createValidationResultCache({ maxSize: 2 });
+
+  cache.add(summary("one"));
+  cache.add(summary("two"));
+
+  assert.equal(cache.clear(), 2);
+  assert.deepEqual(cache.list(), []);
+  assert.equal(cache.latest(), null);
+  assert.equal(cache.size(), 0);
+}
+
+testCacheKeepsNewestFirstWithinMaxSize();
+testCacheEntriesAreSummaryOnlyRedactedAndBounded();
+testCacheClearReturnsCountAndEmptiesEntries();
+
+console.log("vscode validation result cache tests ok");

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -19,6 +19,7 @@ node editors/vscode-prototype/test/selected-symbol-context.test.mjs
 node editors/vscode-prototype/test/ai-assistant-boundary.test.mjs
 node editors/vscode-prototype/test/validation-proposals.test.mjs
 node editors/vscode-prototype/test/validation-result-summary.test.mjs
+node editors/vscode-prototype/test/validation-result-cache.test.mjs
 node editors/vscode-prototype/test/approved-validation-runner.test.mjs
 node editors/vscode-prototype/test/static-boundary.test.mjs
 node editors/vscode-prototype/test/extension-entrypoint.test.mjs


### PR DESCRIPTION
## Summary
- Add a small in-memory validation-result cache for summary-only approved validation runner results.
- Add VS Code commands to show and clear recent cached validation summaries.
- Feed latest and bounded recent validation summaries into the local context bundle without full logs, raw commands, or private paths.
- Update docs and smoke coverage for the experimental local-only boundary.

## Validation
- npm ci --prefix editors/vscode-prototype
- bash scripts/vscode-adapter-smoke.sh
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- python3 -m pytest -q
- bash scripts/vscode-extension-host-smoke.sh exits 2 by default as expected
- PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh
- git diff --check

## Scope Notes
- No real pccx-lab execution, pccx-llm-launcher calls, AI provider calls, MCP, LSP, marketplace packaging, release, or tag.
- No FPGA repo changes.