### PR TITLE
feat(vscode): polish validation result cache UX

### DIFF
--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -93,8 +93,9 @@ AI-assisted SystemVerilog development workflow work is boundary-only:
 AI assistant status and context bundle commands expose local status,
 bounded context, selected-symbol context, validation command proposal
 data, disabled-by-default approved validation runner status/result data,
-and proposal actions, with no AI provider calls, no
-pccx-llm-launcher runtime calls yet, and no MCP server implementation.
+summary-only validation cache status, and proposal actions, with no AI
+provider calls, no pccx-llm-launcher runtime calls yet, and no MCP server
+implementation.
 
 The same directory now includes an experimental local VS Code extension
 scaffold.  Its command handlers are thin wrappers around the local facade:

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -139,6 +139,7 @@ The contributed commands are:
 - `pccxSystemVerilog.proposeValidationCommand`
 - `pccxSystemVerilog.runApprovedValidationCommand`
 - `pccxSystemVerilog.showRecentValidationResults`
+- `pccxSystemVerilog.showValidationCacheStatus`
 - `pccxSystemVerilog.clearValidationResultCache`
 - `pccxSystemVerilog.showPccxLabBackendStatus`
 
@@ -244,7 +245,7 @@ command paths plus the provider smoke.  It checks the AI assistant status
 command, selected-symbol context bundle command, validation command
 proposal, disabled approved validation runner behavior, one explicit
 allowlisted validation run, validation summary handoff into the context
-bundle, local validation-result cache command registration, and pccx-lab
+bundle, local validation-result cache commands, and pccx-lab
 backend status command without provider/runtime calls.  It does not
 package the extension, add an LSP provider, or install through a
 marketplace flow.  Extension Host gates are
@@ -320,6 +321,9 @@ it does not persist to disk and does not store full stdout/stderr logs,
 secrets, tokens, private home paths, raw command strings, generated blobs,
 model paths, or pccx-lab outputs.  `pccxSystemVerilog.showRecentValidationResults`
 shows the small recent cache through VS Code-native surfaces, and
+`pccxSystemVerilog.showValidationCacheStatus` reports the cache count,
+max size, latest status, and redaction/truncation flags through a
+summary-only validation output channel.
 `pccxSystemVerilog.clearValidationResultCache` clears the in-memory cache.
 This cache boundary does not add AI provider calls, MCP, LSP, marketplace
 packaging, pccx-llm-launcher calls, real pccx-lab execution, releases, or
@@ -354,7 +358,7 @@ Now:
 - selected-symbol context
 - validation command proposal
 - disabled-by-default approved validation runner boundary
-- recent validation summary in the context bundle
+- recent validation summary and cache status command
 - pccx-lab backend status command
 
 Next:
@@ -378,7 +382,7 @@ Later:
 3. Propose a validation command as data with `pccxSystemVerilog.proposeValidationCommand`.
 4. User approves an allowlisted validation proposal ID.
 5. Run `pccxSystemVerilog.runApprovedValidationCommand` only after the runner is explicitly enabled.
-6. Feed the bounded validation result cache summary back into the context bundle.
+6. Inspect the bounded validation cache status and feed the summary back into the context bundle.
 7. Future local coding-assistant mode can propose a patch or next validation step, but does not execute either directly.
 
 ## Local Smoke

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -121,6 +121,7 @@ checked-example symbols.  It executes
 `pccxSystemVerilog.proposeValidationCommand`, and
 `pccxSystemVerilog.runApprovedValidationCommand`,
 `pccxSystemVerilog.showRecentValidationResults`,
+`pccxSystemVerilog.showValidationCacheStatus`,
 `pccxSystemVerilog.clearValidationResultCache`, and
 `pccxSystemVerilog.showPccxLabBackendStatus`, verifying disabled/backend
 `none` status, proposal-only actions, disabled runner blocking behavior,
@@ -154,6 +155,8 @@ allowlisted command/argument arrays.  Output is bounded and summarized
 for a small in-memory validation-result cache and token-saving context
 bundles.  `pccxSystemVerilog.showRecentValidationResults` shows cached
 summary-only entries through VS Code-native surfaces, and
+`pccxSystemVerilog.showValidationCacheStatus` reports summary-only cache
+count, max size, latest status, and redaction/truncation flags.
 `pccxSystemVerilog.clearValidationResultCache` clears that local cache.
 The cache does not persist to disk and does not store full logs, raw
 shell command strings, secrets, tokens, private home paths, generated

--- a/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
+++ b/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
@@ -180,7 +180,8 @@ working-directory kind, command kind, bounded stdout/stderr summaries,
 truncation/redaction flags, and safety metadata.  It does not persist to
 disk and does not store full logs, raw shell command strings, secrets,
 tokens, private home paths, generated blobs, model paths, or pccx-lab
-outputs.
+outputs.  The cache UX exposes recent entries and cache status through
+VS Code-native surfaces and a summary-only validation output channel.
 
 The context bundle can carry the latest cached validation summary and a
 small bounded recent validation history.  It does not include full logs,
@@ -210,6 +211,7 @@ Now:
 - validation command proposal
 - approved validation runner boundary
 - validation summary in the context bundle
+- validation cache status command
 - pccx-lab backend status
 
 Next:

--- a/editors/vscode-prototype/package.json
+++ b/editors/vscode-prototype/package.json
@@ -26,6 +26,7 @@
     "onCommand:pccxSystemVerilog.proposeValidationCommand",
     "onCommand:pccxSystemVerilog.runApprovedValidationCommand",
     "onCommand:pccxSystemVerilog.showRecentValidationResults",
+    "onCommand:pccxSystemVerilog.showValidationCacheStatus",
     "onCommand:pccxSystemVerilog.clearValidationResultCache",
     "onCommand:pccxSystemVerilog.showPccxLabBackendStatus"
   ],
@@ -82,6 +83,10 @@
       {
         "command": "pccxSystemVerilog.showRecentValidationResults",
         "title": "PCCX SystemVerilog: Show Recent Validation Results (Experimental)"
+      },
+      {
+        "command": "pccxSystemVerilog.showValidationCacheStatus",
+        "title": "PCCX SystemVerilog: Show Validation Cache Status (Experimental)"
       },
       {
         "command": "pccxSystemVerilog.clearValidationResultCache",

--- a/editors/vscode-prototype/src/config.mjs
+++ b/editors/vscode-prototype/src/config.mjs
@@ -36,6 +36,7 @@ export const AI_COMMAND_IDS = Object.freeze([
   "pccxSystemVerilog.proposeValidationCommand",
   "pccxSystemVerilog.runApprovedValidationCommand",
   "pccxSystemVerilog.showRecentValidationResults",
+  "pccxSystemVerilog.showValidationCacheStatus",
   "pccxSystemVerilog.clearValidationResultCache",
 ]);
 

--- a/editors/vscode-prototype/src/context-bundle.mjs
+++ b/editors/vscode-prototype/src/context-bundle.mjs
@@ -566,6 +566,11 @@ export function buildContextBundle(input = {}, options = {}) {
     validation: {
       recent: recentValidation,
       recentHistory: recentValidationHistory,
+      historyPolicy: {
+        maxResults: limits.maxRecentValidationResults,
+        summaryOnly: true,
+        fullLogsExcluded: true,
+      },
     },
     recentCommand: normalizeRecentCommandStatus(input.recentCommandStatus, limits),
     pccxLab: {

--- a/editors/vscode-prototype/src/extension.mjs
+++ b/editors/vscode-prototype/src/extension.mjs
@@ -42,6 +42,8 @@ import {
 } from "./approved-validation-runner.mjs";
 import {
   createValidationResultCache,
+  formatValidationResultCacheEntry,
+  formatValidationResultCacheStatus,
 } from "./validation-result-cache.mjs";
 import {
   createPccxLabBackendStatus,
@@ -52,6 +54,7 @@ const DEFAULT_DIAGNOSTIC_FILE_ROOT = resolve(EXTENSION_ROOT, "../..");
 const DEFAULT_NAVIGATION_FILE_ROOT = DEFAULT_DIAGNOSTIC_FILE_ROOT;
 const DEFAULT_FACADE_PATH = resolve(EXTENSION_ROOT, "bin/pccx-vscode-prototype.mjs");
 const OUTPUT_CHANNEL_NAME = "PCCX SystemVerilog IDE Prototype";
+const VALIDATION_OUTPUT_CHANNEL_NAME = "PCCX SystemVerilog Validation Results";
 export const CHECKED_EXAMPLE_NAVIGATION_COMMAND =
   "pccxSystemVerilog.showCheckedExampleNavigation";
 export const LIVE_WORKSPACE_NAVIGATION_COMMAND =
@@ -68,6 +71,8 @@ export const APPROVED_VALIDATION_RUNNER_COMMAND =
   "pccxSystemVerilog.runApprovedValidationCommand";
 export const SHOW_RECENT_VALIDATION_RESULTS_COMMAND =
   "pccxSystemVerilog.showRecentValidationResults";
+export const SHOW_VALIDATION_CACHE_STATUS_COMMAND =
+  "pccxSystemVerilog.showValidationCacheStatus";
 export const CLEAR_VALIDATION_RESULT_CACHE_COMMAND =
   "pccxSystemVerilog.clearValidationResultCache";
 export const PCCX_LAB_BACKEND_STATUS_COMMAND =
@@ -245,9 +250,49 @@ function validationEntryQuickPickItems(entries) {
     description: [entry.status, entry.exitCode == null ? "" : `exit ${entry.exitCode}`]
       .filter(Boolean)
       .join(" "),
-    detail: entry.summaryText,
+    detail: [
+      entry.proposalId ? `proposal ${entry.proposalId}` : "",
+      entry.durationMs == null ? "" : `${entry.durationMs}ms`,
+      entry.redactionApplied ? "redacted" : "",
+      entry.truncated ? "truncated" : "",
+    ].filter(Boolean).join(" | "),
     entry,
   }));
+}
+
+function validationOutputChannelFromRuntime(runtime = {}) {
+  return runtime.validationOutputChannel ?? runtime.outputChannel;
+}
+
+function appendValidationOutput(outputChannel, commandId, result) {
+  if (!outputChannel?.appendLine) {
+    return;
+  }
+
+  outputChannel.appendLine(`[${commandId}]`);
+  if (result.kind === "validation-result-cache") {
+    outputChannel.appendLine(`cachedResultCount: ${result.entries?.length ?? 0}`);
+    if (result.selected) {
+      outputChannel.appendLine(formatValidationResultCacheEntry(result.selected));
+    } else {
+      for (const entry of result.entries ?? []) {
+        outputChannel.appendLine(formatValidationResultCacheEntry(entry, { maxDisplayLines: 0 }));
+      }
+    }
+  }
+  if (result.kind === "validation-result-cache-status") {
+    outputChannel.appendLine(formatValidationResultCacheStatus(result.status));
+  }
+  if (result.kind === "validation-result-cache-clear") {
+    outputChannel.appendLine(`clearedCount: ${result.clearedCount}`);
+  }
+  if (result.kind === "approved-validation-result" && result.resultSummary) {
+    outputChannel.appendLine(formatValidationResultCacheEntry(result.resultSummary));
+  }
+  if (result.error) {
+    outputChannel.appendLine(result.error);
+  }
+  outputChannel.show?.(true);
 }
 
 function appendCommandOutput(outputChannel, commandId, result) {
@@ -293,6 +338,12 @@ function appendCommandOutput(outputChannel, commandId, result) {
         truncated: entry.truncated,
         redactionApplied: entry.redactionApplied,
       })),
+    }, null, 2));
+  }
+  if (result.kind === "validation-result-cache-status") {
+    outputChannel.appendLine(JSON.stringify({
+      kind: result.kind,
+      status: result.status,
     }, null, 2));
   }
   if (result.kind === "validation-result-cache-clear") {
@@ -693,6 +744,12 @@ export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
             { title: "Recent Validation Results", placeHolder: "Select a cached validation summary" },
           );
           result.selected = selected?.entry ?? null;
+          if (result.selected) {
+            vscodeApi?.window?.showInformationMessage?.(
+              `Validation summary: ${shortValidationEntryLabel(result.selected)}`,
+              result,
+            );
+          }
         } else {
           vscodeApi?.window?.showInformationMessage?.(
             `${entries.length} recent validation result(s) cached. ${shortValidationEntryLabel(entries[0])}`,
@@ -703,6 +760,34 @@ export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
         result = { ok: false, commandId, error: error.message };
         vscodeApi?.window?.showWarningMessage?.(result.error, result);
       }
+      appendValidationOutput(validationOutputChannelFromRuntime(runtime), commandId, result);
+      appendCommandOutput(runtime.outputChannel, commandId, result);
+      return result;
+    }
+
+    if (commandId === SHOW_VALIDATION_CACHE_STATUS_COMMAND) {
+      let result;
+      try {
+        const cache = validationResultCacheFromRuntime(runtime);
+        const status = cache.status();
+        result = {
+          ok: true,
+          commandId,
+          kind: "validation-result-cache-status",
+          status,
+        };
+        const latestText = status.latest
+          ? ` Latest: ${status.latest.label || status.latest.proposalId} ${status.latest.status}.`
+          : "";
+        vscodeApi?.window?.showInformationMessage?.(
+          `Validation cache: ${status.count}/${status.maxSize} result(s).${latestText}`,
+          result,
+        );
+      } catch (error) {
+        result = { ok: false, commandId, error: error.message };
+        vscodeApi?.window?.showWarningMessage?.(result.error, result);
+      }
+      appendValidationOutput(validationOutputChannelFromRuntime(runtime), commandId, result);
       appendCommandOutput(runtime.outputChannel, commandId, result);
       return result;
     }
@@ -727,6 +812,7 @@ export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
         result = { ok: false, commandId, error: error.message };
         vscodeApi?.window?.showWarningMessage?.(result.error, result);
       }
+      appendValidationOutput(validationOutputChannelFromRuntime(runtime), commandId, result);
       appendCommandOutput(runtime.outputChannel, commandId, result);
       return result;
     }
@@ -753,6 +839,17 @@ export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
         vscodeApi?.window?.showWarningMessage?.(result.error, result);
       }
       result.commandId = commandId;
+      if (runtime.recentValidationSummary) {
+        appendValidationOutput(
+          validationOutputChannelFromRuntime(runtime),
+          commandId,
+          {
+            kind: "validation-result-cache",
+            entries: [runtime.recentValidationSummary],
+            selected: runtime.recentValidationSummary,
+          },
+        );
+      }
       appendCommandOutput(runtime.outputChannel, commandId, result);
       return result;
     }
@@ -823,9 +920,16 @@ export async function activate(context, injectedVscodeApi = null, runtime = {}) 
   }
 
   const outputChannel = vscodeApi.window?.createOutputChannel?.(OUTPUT_CHANNEL_NAME);
+  const validationOutputChannel =
+    vscodeApi.window?.createOutputChannel?.(VALIDATION_OUTPUT_CHANNEL_NAME);
   const diagnosticsCollection = runtime.diagnosticsCollection
     ?? vscodeApi.languages?.createDiagnosticCollection?.(OUTPUT_CHANNEL_NAME);
-  const commandRuntime = { ...runtime, diagnosticsCollection, outputChannel };
+  const commandRuntime = {
+    ...runtime,
+    diagnosticsCollection,
+    outputChannel,
+    validationOutputChannel,
+  };
   const registered = [];
   const definitionProviders = [];
 
@@ -855,6 +959,9 @@ export async function activate(context, injectedVscodeApi = null, runtime = {}) 
 
   if (outputChannel) {
     context?.subscriptions?.push?.(outputChannel);
+  }
+  if (validationOutputChannel) {
+    context?.subscriptions?.push?.(validationOutputChannel);
   }
   if (diagnosticsCollection && diagnosticsCollection !== runtime.diagnosticsCollection) {
     context?.subscriptions?.push?.(diagnosticsCollection);

--- a/editors/vscode-prototype/src/validation-result-cache.mjs
+++ b/editors/vscode-prototype/src/validation-result-cache.mjs
@@ -1,8 +1,10 @@
 import { summarizeOutputText } from "./validation-result-summary.mjs";
 
 export const VALIDATION_RESULT_CACHE_ENTRY_VERSION = "pccx.validationResultCacheEntry.v0";
+export const VALIDATION_RESULT_CACHE_STATUS_VERSION = "pccx.validationResultCacheStatus.v0";
 export const DEFAULT_VALIDATION_RESULT_CACHE_MAX_SIZE = 5;
 export const DEFAULT_VALIDATION_RESULT_CACHE_OUTPUT_LINES = 20;
+export const DEFAULT_VALIDATION_RESULT_CACHE_DISPLAY_LINES = 8;
 
 const SECRET_ASSIGNMENT_PATTERN =
   /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]/i;
@@ -100,6 +102,100 @@ function cloneEntry(entry) {
   return JSON.parse(JSON.stringify(entry));
 }
 
+function lineCount(summary) {
+  return Math.max(0, Math.floor(finiteNumber(summary?.lineCount)));
+}
+
+function outputLines(summary, maxLines = DEFAULT_VALIDATION_RESULT_CACHE_DISPLAY_LINES) {
+  return Array.isArray(summary?.lines)
+    ? summary.lines
+      .map((line) => boundedText(String(line ?? ""), 500))
+      .slice(0, Math.max(0, maxLines))
+    : [];
+}
+
+function yesNo(value) {
+  return value === true ? "yes" : "no";
+}
+
+function latestStatus(entry) {
+  if (!entry) {
+    return null;
+  }
+  return {
+    proposalId: boundedText(entry.proposalId ?? "", 120),
+    label: boundedText(entry.label ?? "", 160),
+    status: boundedText(entry.status ?? "unknown", 80),
+    exitCode: entry.exitCode == null ? null : Math.floor(finiteNumber(entry.exitCode)),
+    durationMs: entry.durationMs == null
+      ? null
+      : Math.max(0, Math.floor(finiteNumber(entry.durationMs))),
+    truncated: entry.truncated === true,
+    redactionApplied: entry.redactionApplied === true,
+  };
+}
+
+export function createValidationResultCacheStatus(entries = [], maxSize = DEFAULT_VALIDATION_RESULT_CACHE_MAX_SIZE) {
+  const safeEntries = Array.isArray(entries) ? entries : [];
+  return {
+    version: VALIDATION_RESULT_CACHE_STATUS_VERSION,
+    count: safeEntries.length,
+    maxSize: Math.max(0, Math.floor(finiteNumber(maxSize))),
+    latest: latestStatus(safeEntries[0]),
+    truncated: safeEntries.some((entry) => entry?.truncated === true),
+    redactionApplied: safeEntries.some((entry) => entry?.redactionApplied === true),
+    summaryOnly: true,
+    fullLogsExcluded: true,
+  };
+}
+
+export function formatValidationResultCacheEntry(entry = {}, options = {}) {
+  const maxLines = clampInteger(
+    options.maxDisplayLines,
+    DEFAULT_VALIDATION_RESULT_CACHE_DISPLAY_LINES,
+    0,
+    40,
+  );
+  const stdoutLines = outputLines(entry.stdoutSummary, maxLines);
+  const stderrLines = outputLines(entry.stderrSummary, maxLines);
+  const lines = [
+    "Validation Result Summary",
+    `proposalId: ${boundedText(entry.proposalId ?? "", 120) || "(none)"}`,
+    `label: ${boundedText(entry.label ?? "", 160) || "validation"}`,
+    `status: ${boundedText(entry.status ?? "unknown", 80)}`,
+    `exitCode: ${entry.exitCode == null ? "none" : Math.floor(finiteNumber(entry.exitCode))}`,
+    `durationMs: ${entry.durationMs == null ? "none" : Math.max(0, Math.floor(finiteNumber(entry.durationMs)))}`,
+    `workingDirectoryKind: ${boundedText(entry.workingDirectoryKind ?? "", 80) || "unknown"}`,
+    `commandKind: ${boundedText(entry.commandKind ?? "", 120) || "validation-proposal"}`,
+    `redactionApplied: ${yesNo(entry.redactionApplied === true)}`,
+    `truncated: ${yesNo(entry.truncated === true)}`,
+    `summary: ${boundedText(entry.summaryText ?? "", 800) || "(none)"}`,
+    `stdoutSummary: ${lineCount(entry.stdoutSummary)} line(s), shown ${stdoutLines.length}, truncated=${yesNo(entry.stdoutSummary?.truncated === true)}`,
+    ...stdoutLines.map((line) => `  ${line}`),
+    `stderrSummary: ${lineCount(entry.stderrSummary)} line(s), shown ${stderrLines.length}, truncated=${yesNo(entry.stderrSummary?.truncated === true)}`,
+    ...stderrLines.map((line) => `  ${line}`),
+  ];
+  return lines.join("\n");
+}
+
+export function formatValidationResultCacheStatus(status = {}) {
+  const latest = status.latest;
+  return [
+    "Validation Cache Status",
+    `count: ${Math.max(0, Math.floor(finiteNumber(status.count)))}`,
+    `maxSize: ${Math.max(0, Math.floor(finiteNumber(status.maxSize)))}`,
+    `latestProposalId: ${latest?.proposalId || "(none)"}`,
+    `latestLabel: ${latest?.label || "(none)"}`,
+    `latestStatus: ${latest?.status || "(none)"}`,
+    `latestExitCode: ${latest?.exitCode == null ? "none" : latest.exitCode}`,
+    `latestDurationMs: ${latest?.durationMs == null ? "none" : latest.durationMs}`,
+    `redactionApplied: ${yesNo(status.redactionApplied === true)}`,
+    `truncated: ${yesNo(status.truncated === true)}`,
+    `summaryOnly: ${yesNo(status.summaryOnly === true)}`,
+    `fullLogsExcluded: ${yesNo(status.fullLogsExcluded === true)}`,
+  ].join("\n");
+}
+
 export function createValidationResultCacheEntry(validationResult = {}, options = {}) {
   const source = validationResult?.resultSummary &&
     typeof validationResult.resultSummary === "object"
@@ -171,6 +267,12 @@ export function createValidationResultCache(options = {}) {
     },
     latest() {
       return entries[0] ? cloneEntry(entries[0]) : null;
+    },
+    status() {
+      return createValidationResultCacheStatus(entries, maxSize);
+    },
+    maxSize() {
+      return maxSize;
     },
     clear() {
       const count = entries.length;

--- a/editors/vscode-prototype/test/context-bundle.test.mjs
+++ b/editors/vscode-prototype/test/context-bundle.test.mjs
@@ -313,6 +313,11 @@ function testStableBoundedShape() {
   assert.equal(bundle.validation.recent.safety.allowlisted, true);
   assert.equal(bundle.validation.recent.safety.shell, false);
   assert.equal(bundle.validation.recentHistory.length, 2);
+  assert.deepEqual(bundle.validation.historyPolicy, {
+    maxResults: 5,
+    summaryOnly: true,
+    fullLogsExcluded: true,
+  });
   assert.deepEqual(
     bundle.validation.recentHistory.map((entry) => entry.proposalId),
     ["vscodeAdapterSmoke", "editorBridgeSmoke"],

--- a/editors/vscode-prototype/test/extension-entrypoint.test.mjs
+++ b/editors/vscode-prototype/test/extension-entrypoint.test.mjs
@@ -11,6 +11,7 @@ import {
   LIVE_WORKSPACE_NAVIGATION_COMMAND,
   PCCX_LAB_BACKEND_STATUS_COMMAND,
   SHOW_RECENT_VALIDATION_RESULTS_COMMAND,
+  SHOW_VALIDATION_CACHE_STATUS_COMMAND,
   VALIDATION_PROPOSAL_COMMAND,
   activate,
   buildFacadeArgsForCommand,
@@ -408,7 +409,7 @@ async function testEntrypointExportsAndActivation() {
   assert.equal(activation.definitionProviders[0].id, CHECKED_EXAMPLE_DEFINITION_PROVIDER_ID);
   assert.equal(activation.definitionProviders[0].registered, false);
   assert.equal(registered.size, COMMAND_IDS.length);
-  assert.equal(subscriptions.length, COMMAND_IDS.length + 1);
+  assert.equal(subscriptions.length, COMMAND_IDS.length + 2);
 
   const result = await registered.get("pccxSystemVerilog.showDiagnosticsExample")();
   assert.equal(result.ok, true);
@@ -725,7 +726,7 @@ async function testActivationRegistersCheckedExampleDefinitionProvider() {
   assert.ok(
     CHECKED_EXAMPLE_DEFINITION_SELECTOR.some((selector) => selector.pattern === "**/*.sv"),
   );
-  assert.equal(subscriptions.length, COMMAND_IDS.length + 2);
+  assert.equal(subscriptions.length, COMMAND_IDS.length + 3);
 
   const definitions = await definitionRegistrations[0].provider.provideDefinition(
     { uri: { fsPath: "/workspace/smoke.sv" } },
@@ -1110,6 +1111,7 @@ async function testValidationResultCacheCommandsShowAndClear() {
   ]);
   const quickPickCalls = [];
   const informationMessages = [];
+  const validationOutputLines = [];
   const vscodeApi = {
     workspace: {
       workspaceFolders: [{ uri: { fsPath: "/repo/workspace" } }],
@@ -1133,16 +1135,24 @@ async function testValidationResultCacheCommandsShowAndClear() {
   };
   const runtime = {
     repoRoot: "/repo",
+    validationOutputChannel: {
+      appendLine(line) {
+        validationOutputLines.push(line);
+      },
+      show() {},
+    },
     validationExecFile(_executable, _args, _options, done) {
       done(null, "ok\nTOKEN=hidden\n/home/dev/repo/file.sv\n", "");
     },
   };
   const runHandler = createCommandHandler(APPROVED_VALIDATION_RUNNER_COMMAND, vscodeApi, runtime);
   const showHandler = createCommandHandler(SHOW_RECENT_VALIDATION_RESULTS_COMMAND, vscodeApi, runtime);
+  const statusHandler = createCommandHandler(SHOW_VALIDATION_CACHE_STATUS_COMMAND, vscodeApi, runtime);
   const clearHandler = createCommandHandler(CLEAR_VALIDATION_RESULT_CACHE_COMMAND, vscodeApi, runtime);
 
   await runHandler({ proposalId: "vscodeAdapterSmoke" });
   const shown = await showHandler();
+  const status = await statusHandler();
 
   assert.equal(shown.ok, true);
   assert.equal(shown.kind, "validation-result-cache");
@@ -1153,9 +1163,26 @@ async function testValidationResultCacheCommandsShowAndClear() {
   assert.equal(shown.selected.proposalId, "vscodeAdapterSmoke");
   assert.equal(quickPickCalls.length, 1);
   assert.equal(quickPickCalls[0].options.title, "Recent Validation Results");
+  assert.match(quickPickCalls[0].items[0].detail, /proposal vscodeAdapterSmoke/);
+  assert.match(quickPickCalls[0].items[0].detail, /redacted/);
+  assert.equal(status.ok, true);
+  assert.equal(status.kind, "validation-result-cache-status");
+  assert.equal(status.status.count, 1);
+  assert.equal(status.status.maxSize, 5);
+  assert.equal(status.status.latest.proposalId, "vscodeAdapterSmoke");
+  assert.equal(status.status.latest.status, "passed");
+  assert.equal(status.status.summaryOnly, true);
+  assert.equal(status.status.fullLogsExcluded, true);
   assert.doesNotMatch(JSON.stringify(shown.entries), /TOKEN=hidden/);
   assert.doesNotMatch(JSON.stringify(shown.entries), /\/home\/dev/);
   assert.doesNotMatch(JSON.stringify(shown.entries), /scripts\/vscode-adapter-smoke\.sh/);
+  assert.ok(validationOutputLines.some((line) => line.includes("Validation Result Summary")));
+  assert.ok(validationOutputLines.some((line) => line.includes("proposalId: vscodeAdapterSmoke")));
+  assert.ok(validationOutputLines.some((line) => line.includes("Validation Cache Status")));
+  assert.ok(validationOutputLines.some((line) => line.includes("fullLogsExcluded: yes")));
+  assert.doesNotMatch(validationOutputLines.join("\n"), /TOKEN=hidden/);
+  assert.doesNotMatch(validationOutputLines.join("\n"), /\/home\/dev/);
+  assert.doesNotMatch(validationOutputLines.join("\n"), /scripts\/vscode-adapter-smoke\.sh/);
 
   const cleared = await clearHandler();
 
@@ -1164,7 +1191,7 @@ async function testValidationResultCacheCommandsShowAndClear() {
   assert.equal(cleared.clearedCount, 1);
   assert.equal(runtime.validationResultCache.size(), 0);
   assert.equal(runtime.recentValidationSummary, null);
-  assert.match(informationMessages[0][0], /Cleared 1 cached validation result/);
+  assert.ok(informationMessages.some(([message]) => /Cleared 1 cached validation result/.test(message)));
 }
 
 async function testPccxLabBackendStatusCommandReturnsStatusOnly() {

--- a/editors/vscode-prototype/test/extension-host-readiness.test.mjs
+++ b/editors/vscode-prototype/test/extension-host-readiness.test.mjs
@@ -106,6 +106,7 @@ async function testReadinessDocsAndCiPolicy() {
   assert.match(`${readme}\n${readiness}`, /proposeValidationCommand/);
   assert.match(`${readme}\n${readiness}`, /runApprovedValidationCommand/);
   assert.match(`${readme}\n${readiness}`, /showRecentValidationResults/);
+  assert.match(`${readme}\n${readiness}`, /showValidationCacheStatus/);
   assert.match(`${readme}\n${readiness}`, /clearValidationResultCache/);
   assert.match(`${readme}\n${readiness}`, /showPccxLabBackendStatus/);
   assert.match(`${readme}\n${readiness}`, /context bundle command/i);
@@ -161,6 +162,7 @@ async function testRuntimeRunnerIsPinnedAndBounded() {
   assert.match(suite, /proposeValidationCommand/);
   assert.match(suite, /runApprovedValidationCommand/);
   assert.match(suite, /showRecentValidationResults/);
+  assert.match(suite, /showValidationCacheStatus/);
   assert.match(suite, /clearValidationResultCache/);
   assert.match(suite, /validationRunner\.enabled/);
   assert.match(suite, /vscodeAdapterSmoke/);

--- a/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
+++ b/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
@@ -69,6 +69,7 @@ async function run() {
     "pccxSystemVerilog.proposeValidationCommand",
     "pccxSystemVerilog.runApprovedValidationCommand",
     "pccxSystemVerilog.showRecentValidationResults",
+    "pccxSystemVerilog.showValidationCacheStatus",
     "pccxSystemVerilog.clearValidationResultCache",
     "pccxSystemVerilog.showPccxLabBackendStatus",
   ]);
@@ -418,6 +419,23 @@ async function run() {
       postValidationContext.contextBundle.validation.recent.safety.allowlisted,
       true,
     );
+    assert.deepEqual(postValidationContext.contextBundle.validation.historyPolicy, {
+      maxResults: 5,
+      summaryOnly: true,
+      fullLogsExcluded: true,
+    });
+
+    const cacheStatus = await vscode.commands.executeCommand(
+      "pccxSystemVerilog.showValidationCacheStatus",
+    );
+    assert.equal(cacheStatus.ok, true);
+    assert.equal(cacheStatus.kind, "validation-result-cache-status");
+    assert.equal(cacheStatus.status.count, 2);
+    assert.equal(cacheStatus.status.maxSize, 5);
+    assert.equal(cacheStatus.status.latest.proposalId, "vscodeAdapterSmoke");
+    assert.equal(cacheStatus.status.latest.status, "passed");
+    assert.equal(cacheStatus.status.summaryOnly, true);
+    assert.equal(cacheStatus.status.fullLogsExcluded, true);
   } finally {
     await updatePrototypeConfig("validationRunner.enabled", false);
     await updatePrototypeConfig("validationRunner.mode", "disabled");

--- a/editors/vscode-prototype/test/extension-manifest.test.mjs
+++ b/editors/vscode-prototype/test/extension-manifest.test.mjs
@@ -19,6 +19,7 @@ const COMMAND_IDS = [
   "pccxSystemVerilog.proposeValidationCommand",
   "pccxSystemVerilog.runApprovedValidationCommand",
   "pccxSystemVerilog.showRecentValidationResults",
+  "pccxSystemVerilog.showValidationCacheStatus",
   "pccxSystemVerilog.clearValidationResultCache",
   "pccxSystemVerilog.showPccxLabBackendStatus",
 ];

--- a/editors/vscode-prototype/test/validation-result-cache.test.mjs
+++ b/editors/vscode-prototype/test/validation-result-cache.test.mjs
@@ -2,8 +2,11 @@ import assert from "node:assert/strict";
 
 import {
   VALIDATION_RESULT_CACHE_ENTRY_VERSION,
+  VALIDATION_RESULT_CACHE_STATUS_VERSION,
   createValidationResultCache,
   createValidationResultCacheEntry,
+  formatValidationResultCacheEntry,
+  formatValidationResultCacheStatus,
 } from "../src/validation-result-cache.mjs";
 
 function summary(proposalId, options = {}) {
@@ -112,8 +115,53 @@ function testCacheClearReturnsCountAndEmptiesEntries() {
   assert.equal(cache.size(), 0);
 }
 
+function testCacheStatusAndFormattingStaySummaryOnly() {
+  const cache = createValidationResultCache({ maxSize: 2, maxOutputLines: 2 });
+  const entry = cache.add(summary("vscodeAdapterSmoke", {
+    status: "failed",
+    exitCode: 1,
+    durationMs: 42,
+    stdoutSummary: {
+      lines: ["ok", "TOKEN=hidden", "/home/dev/repo/file.sv", "tail"],
+      lineCount: 4,
+      truncated: false,
+    },
+    stderrSummary: {
+      lines: ["failure"],
+      lineCount: 1,
+      truncated: false,
+    },
+  }));
+  const status = cache.status();
+  const entryText = formatValidationResultCacheEntry(entry);
+  const statusText = formatValidationResultCacheStatus(status);
+  const combined = `${entryText}\n${statusText}`;
+
+  assert.equal(status.version, VALIDATION_RESULT_CACHE_STATUS_VERSION);
+  assert.equal(status.count, 1);
+  assert.equal(status.maxSize, 2);
+  assert.equal(status.latest.proposalId, "vscodeAdapterSmoke");
+  assert.equal(status.latest.status, "failed");
+  assert.equal(status.latest.exitCode, 1);
+  assert.equal(status.latest.durationMs, 42);
+  assert.equal(status.redactionApplied, true);
+  assert.equal(status.truncated, true);
+  assert.equal(status.summaryOnly, true);
+  assert.equal(status.fullLogsExcluded, true);
+  assert.match(entryText, /Validation Result Summary/);
+  assert.match(entryText, /proposalId: vscodeAdapterSmoke/);
+  assert.match(entryText, /redactionApplied: yes/);
+  assert.match(statusText, /Validation Cache Status/);
+  assert.match(statusText, /fullLogsExcluded: yes/);
+  assert.doesNotMatch(combined, /TOKEN=hidden/);
+  assert.doesNotMatch(combined, /\/home\/dev/);
+  assert.doesNotMatch(combined, /tail/);
+  assert.doesNotMatch(combined, /scripts\/vscode-adapter-smoke\.sh/);
+}
+
 testCacheKeepsNewestFirstWithinMaxSize();
 testCacheEntriesAreSummaryOnlyRedactedAndBounded();
 testCacheClearReturnsCountAndEmptiesEntries();
+testCacheStatusAndFormattingStaySummaryOnly();
 
 console.log("vscode validation result cache tests ok");


### PR DESCRIPTION
## Summary
- Add summary-only validation cache status data and command.
- Route validation cache summaries to a dedicated VS Code output channel.
- Clarify bounded validation history metadata in context bundles.

## Scope
- Adds pccxSystemVerilog.showValidationCacheStatus.
- Polishes recent validation QuickPick details and selected-summary output.
- Adds deterministic tests for cache status, formatting, command registration, context metadata, and Extension Host smoke coverage.

## Non-goals
- No disk persistence.
- No raw command execution expansion.
- No pccx-lab execution.
- No launcher calls.
- No AI provider calls.
- No MCP, LSP, marketplace, or packaging flow.

## Validation
- npm ci --prefix editors/vscode-prototype
- bash scripts/vscode-adapter-smoke.sh
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- python3 -m pytest -q
- git diff --check
- bash scripts/vscode-extension-host-smoke.sh exits 2 by default as expected
- PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh

## Safety notes
- Validation output remains summary-only and bounded.
- Full logs, raw command strings, private home paths, secrets, generated artifacts, and pccx-lab outputs are excluded from cache/context output.
- The runner remains disabled by default and allowlist-only when explicitly enabled.

## Release/tag
No release or tag was created.

## FPGA repo
The FPGA repo was not touched.