### PR TITLE
feat(vscode): add patch proposal contract

### DIFF
--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -148,6 +148,9 @@ references, recent command status, current mode, validation summaries, and
 bounded snippets by path/range instead of whole workspaces.  Any command
 proposal or validation proposal must remain proposal-only until an
 editor/user-controlled executor accepts an allowlisted proposal ID.
+Patch proposals are also contract-only: they may describe reviewed edits
+with repository-relative paths and bounded hunk previews, but they do not
+apply changes or execute commands.
 Approved validation execution must use fixed argument arrays, bounded
 output, an explicit user-approved command invocation, and no shell
 interpolation.  pccx-lab command execution remains future/prepared in

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -292,6 +292,18 @@ direct file modification, and no stable API claim.
 The boundary notes are tracked in
 [`docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md`](./docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md).
 
+`src/patch-proposal-contract.mjs` defines a provider-free patch proposal
+contract for future user-reviewed edits.  The contract accepts only
+repository-relative paths, bounded hunk previews, bounded rationale and
+validation plan text, explicit risk level, and `requiresUserReview=true`.
+It rejects private paths, secret-like assignments, shell commands,
+generated artifacts, model files, raw provider output, unknown command
+fields, and auto-apply flags.  It does not apply patches, write files,
+execute validation, call pccx-lab, call pccx-llm-launcher, call an AI
+provider, implement MCP, implement LSP, package the extension, create a
+release, or create a tag.  The contract notes are tracked in
+[`docs/patch-proposal-contract.md`](./docs/patch-proposal-contract.md).
+
 `pccxSystemVerilog.proposeValidationCommand` returns allowlisted
 validation command proposals as JSON data.  The proposal includes
 allowlisted proposal IDs, argument-array templates, reasons, risk levels, and
@@ -357,6 +369,7 @@ Now:
 - AI assistant status command and bounded context bundle command
 - selected-symbol context
 - validation command proposal
+- patch proposal contract
 - disabled-by-default approved validation runner boundary
 - recent validation summary and cache status command
 - pccx-lab backend status command
@@ -397,6 +410,7 @@ node editors/vscode-prototype/test/context-bundle.test.mjs
 node editors/vscode-prototype/test/selected-symbol-context.test.mjs
 node editors/vscode-prototype/test/ai-assistant-boundary.test.mjs
 node editors/vscode-prototype/test/validation-proposals.test.mjs
+node editors/vscode-prototype/test/patch-proposal-contract.test.mjs
 node editors/vscode-prototype/test/validation-result-summary.test.mjs
 node editors/vscode-prototype/test/validation-result-cache.test.mjs
 node editors/vscode-prototype/test/approved-validation-runner.test.mjs

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -137,7 +137,8 @@ boundary, not a model integration.  pccx-llm-launcher is a future local LLM/chat
 contract.  The current extension code makes no AI provider calls, no
 pccx-llm-launcher runtime calls, and implements no MCP server.  AI
 actions are modeled as proposals, including command proposal and
-validation proposal shapes, rather than direct execution.  User approval
+validation proposal shapes, plus a checked patch proposal contract for
+future user-reviewed edits, rather than direct execution.  User approval
 is still required before applying patches, running validation commands,
 or committing changes.
 

--- a/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
+++ b/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
@@ -189,6 +189,12 @@ raw absolute private paths, generated artifacts, launcher calls, AI
 provider calls, MCP, LSP, marketplace packaging, release/tag flow, or
 real pccx-lab execution.
 
+Patch proposals are contract-only in this prototype.  The checked
+contract accepts repository-relative paths and bounded hunk previews for
+future user review, rejects private paths, secrets, shell commands,
+generated artifacts, raw provider output, and auto-apply fields, and does
+not apply changes.
+
 ## Prototype Daily-Driver Loop
 
 1. Inspect diagnostics and navigation.
@@ -209,6 +215,7 @@ Now:
 - context bundle command
 - selected-symbol context
 - validation command proposal
+- patch proposal contract
 - approved validation runner boundary
 - validation summary in the context bundle
 - validation cache status command

--- a/editors/vscode-prototype/docs/patch-proposal-contract.md
+++ b/editors/vscode-prototype/docs/patch-proposal-contract.md
@@ -1,0 +1,74 @@
+# Patch Proposal Contract
+
+This is a provider-free, proposal-only patch contract for the experimental
+local VS Code prototype.  It describes possible edits for user review; it
+does not apply patches, write files, call pccx-lab, call pccx-llm-launcher,
+call an AI provider, implement MCP, or implement LSP.
+
+## Shape
+
+```json
+{
+  "version": 1,
+  "proposalId": "missingEndmoduleFix",
+  "source": "local-prototype",
+  "title": "Add missing endmodule",
+  "summary": "Proposes a small SystemVerilog syntax fix for review.",
+  "riskLevel": "low",
+  "files": [
+    {
+      "path": "fixtures/missing_endmodule.sv",
+      "changeKind": "modify",
+      "reason": "The checked fixture is missing a closing declaration.",
+      "hunks": [
+        {
+          "oldStart": 1,
+          "oldLines": 3,
+          "newStart": 1,
+          "newLines": 4,
+          "preview": "@@\n module missing_endmodule;\n+endmodule"
+        }
+      ]
+    }
+  ],
+  "validationPlan": [
+    "Run the VS Code adapter smoke through the approved validation proposal."
+  ],
+  "nonGoals": [
+    "Do not apply the patch automatically."
+  ],
+  "requiresUserReview": true
+}
+```
+
+## Rules
+
+- `source` is `local-prototype`.
+- `riskLevel` is `low`, `medium`, or `high`.
+- `changeKind` is `modify`, `add`, `delete`, or `rename`.
+- `requiresUserReview` must be `true`.
+- Paths must be repository-relative and single-line.
+- Paths must not target private instruction locations, dependency caches,
+  generated outputs, lockfiles, model files, bitstreams, binary archives, or
+  secret-like names.
+- Text fields are bounded and must not include secret-like assignments,
+  private home paths, or shell commands.
+- Hunk previews are bounded and are previews only, not full file dumps.
+- Unknown keys such as raw commands, auto-apply flags, provider output, or
+  runtime output are rejected by the validator.
+
+## Non-Goals
+
+- No patch application.
+- No file writes.
+- No shell command execution.
+- No raw provider output.
+- No launcher runtime call.
+- No pccx-lab execution.
+- No MCP, LSP, marketplace packaging, release, or tag flow.
+
+## Validation
+
+The contract is implemented in `src/patch-proposal-contract.mjs` and tested
+by `test/patch-proposal-contract.test.mjs`.  The module is data-only and
+safe to use as a future handoff shape for user-reviewed patch previews.

--- a/editors/vscode-prototype/src/patch-proposal-contract.mjs
+++ b/editors/vscode-prototype/src/patch-proposal-contract.mjs
@@ -1,0 +1,343 @@
+import { isAbsolute } from "node:path";
+
+export const PATCH_PROPOSAL_CONTRACT_VERSION = "pccx.patchProposalContract.v0";
+export const PATCH_PROPOSAL_SCHEMA_VERSION = 1;
+export const PATCH_PROPOSAL_SOURCE = "local-prototype";
+
+export const PATCH_PROPOSAL_RISK_LEVELS = Object.freeze(["low", "medium", "high"]);
+export const PATCH_PROPOSAL_CHANGE_KINDS = Object.freeze(["modify", "add", "delete", "rename"]);
+
+export const PATCH_PROPOSAL_LIMITS = Object.freeze({
+  maxTitleCharacters: 160,
+  maxSummaryCharacters: 800,
+  maxReasonCharacters: 500,
+  maxListItemCharacters: 300,
+  maxFiles: 8,
+  maxHunksPerFile: 16,
+  maxPreviewCharacters: 1200,
+  maxPreviewLines: 40,
+  maxValidationPlanItems: 8,
+  maxNonGoals: 8,
+});
+
+const TOP_LEVEL_KEYS = new Set([
+  "version",
+  "proposalId",
+  "source",
+  "title",
+  "summary",
+  "riskLevel",
+  "files",
+  "validationPlan",
+  "nonGoals",
+  "requiresUserReview",
+]);
+
+const FILE_KEYS = new Set([
+  "path",
+  "changeKind",
+  "reason",
+  "hunks",
+]);
+
+const HUNK_KEYS = new Set([
+  "oldStart",
+  "oldLines",
+  "newStart",
+  "newLines",
+  "preview",
+]);
+
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]/i;
+const SECRET_LIKE_PATTERN =
+  /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b/i;
+const HOME_PATH_PATTERN = /(?:\/home\/[^/\s]+|\/Users\/[^/\s]+)/;
+const WINDOWS_ABSOLUTE_PATH_PATTERN = /^[A-Za-z]:[\\/]/;
+const SHELL_CONTROL_PATTERN = /(?:&&|\|\||;|`|\$\(|>|<)/;
+const SHELL_COMMAND_PATTERN =
+  /\b(?:bash|sh|zsh|fish|python|python3|node|npm|pnpm|yarn|git|gh|rm|mv|cp|curl|wget|make)\s+[^\n]+/i;
+const PRIVATE_PATH_PATTERN =
+  /(?:^|\/)(?:\.git|\.codex|\.vscode-test|node_modules|private[-_ ]?worker|worker[-_ ]?instruction|subagent[-_ ]?instruction)(?:\/|$)/i;
+const GENERATED_PATH_PATTERN =
+  /(?:^|\/)(?:dist|build|coverage|out|target|\.pytest_cache|__pycache__)(?:\/|$)/i;
+const GENERATED_FILE_PATTERN =
+  /(?:^|\/)(?:package-lock\.json|yarn\.lock|pnpm-lock\.yaml|AGENTS\.md)$/i;
+const MODEL_OR_BINARY_ARTIFACT_PATTERN =
+  /\.(?:bit|bin|elf|onnx|pt|pth|safetensors|xclbin|zip|tar|tgz|gz)$/i;
+
+function mergeLimits(limits = {}) {
+  return {
+    ...PATCH_PROPOSAL_LIMITS,
+    ...Object.fromEntries(
+      Object.entries(limits).filter(([, value]) => Number.isInteger(value) && value >= 0),
+    ),
+  };
+}
+
+function addError(errors, path, message) {
+  errors.push(`${path}: ${message}`);
+}
+
+function unknownKeys(value, allowedKeys) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return [];
+  }
+  return Object.keys(value).filter((key) => !allowedKeys.has(key));
+}
+
+function boundedString(value, path, errors, maxCharacters, options = {}) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    addError(errors, path, "must be a non-empty string");
+    return "";
+  }
+  if (value.includes("\0")) {
+    addError(errors, path, "must not contain NUL bytes");
+    return "";
+  }
+  if (value.length > maxCharacters) {
+    addError(errors, path, `must be at most ${maxCharacters} characters`);
+    return "";
+  }
+  if (SECRET_ASSIGNMENT_PATTERN.test(value)) {
+    addError(errors, path, "must not include secret-like assignments");
+  }
+  if (HOME_PATH_PATTERN.test(value)) {
+    addError(errors, path, "must not include private absolute home paths");
+  }
+  if (options.rejectShellCommands !== false && (
+    SHELL_CONTROL_PATTERN.test(value) ||
+    SHELL_COMMAND_PATTERN.test(value)
+  )) {
+    addError(errors, path, "must not include shell commands");
+  }
+  return value;
+}
+
+function boundedStringList(value, path, errors, maxItems, maxCharacters) {
+  if (!Array.isArray(value)) {
+    addError(errors, path, "must be an array");
+    return [];
+  }
+  if (value.length > maxItems) {
+    addError(errors, path, `must contain at most ${maxItems} item(s)`);
+  }
+  return value.slice(0, maxItems).map((item, index) => (
+    boundedString(item, `${path}[${index}]`, errors, maxCharacters)
+  ));
+}
+
+function normalizeRelativePath(value, path, errors) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    addError(errors, path, "must be a non-empty relative path");
+    return "";
+  }
+  if (value.includes("\0") || value.includes("\n") || value.includes("\r")) {
+    addError(errors, path, "must be a single-line relative path");
+    return "";
+  }
+  const normalized = value.replace(/\\/g, "/").replace(/^\.\//, "");
+  if (
+    isAbsolute(normalized) ||
+    WINDOWS_ABSOLUTE_PATH_PATTERN.test(value) ||
+    normalized === "" ||
+    normalized === "." ||
+    normalized === ".." ||
+    normalized.startsWith("../") ||
+    normalized.includes("/../")
+  ) {
+    addError(errors, path, "must be relative to the repository");
+  }
+  if (
+    PRIVATE_PATH_PATTERN.test(normalized) ||
+    GENERATED_PATH_PATTERN.test(normalized) ||
+    GENERATED_FILE_PATTERN.test(normalized) ||
+    MODEL_OR_BINARY_ARTIFACT_PATTERN.test(normalized) ||
+    SECRET_LIKE_PATTERN.test(normalized)
+  ) {
+    addError(errors, path, "must not target private, generated, secret-like, or binary artifact paths");
+  }
+  return normalized;
+}
+
+function integerField(value, path, errors, min = 0) {
+  if (!Number.isInteger(value) || value < min) {
+    addError(errors, path, `must be an integer >= ${min}`);
+    return min;
+  }
+  return value;
+}
+
+function normalizeHunk(hunk, path, errors, limits) {
+  if (!hunk || typeof hunk !== "object" || Array.isArray(hunk)) {
+    addError(errors, path, "must be an object");
+    return null;
+  }
+  for (const key of unknownKeys(hunk, HUNK_KEYS)) {
+    addError(errors, `${path}.${key}`, "is not allowed in patch proposals");
+  }
+  const preview = boundedString(
+    hunk.preview ?? "",
+    `${path}.preview`,
+    errors,
+    limits.maxPreviewCharacters,
+    { rejectShellCommands: false },
+  );
+  if (preview.split(/\r?\n/).length > limits.maxPreviewLines) {
+    addError(errors, `${path}.preview`, `must contain at most ${limits.maxPreviewLines} line(s)`);
+  }
+  if (SECRET_ASSIGNMENT_PATTERN.test(preview) || HOME_PATH_PATTERN.test(preview)) {
+    addError(errors, `${path}.preview`, "must stay redacted and path-safe");
+  }
+  return {
+    oldStart: integerField(hunk.oldStart, `${path}.oldStart`, errors, 1),
+    oldLines: integerField(hunk.oldLines, `${path}.oldLines`, errors, 0),
+    newStart: integerField(hunk.newStart, `${path}.newStart`, errors, 1),
+    newLines: integerField(hunk.newLines, `${path}.newLines`, errors, 0),
+    preview,
+  };
+}
+
+function normalizeFile(file, path, errors, limits) {
+  if (!file || typeof file !== "object" || Array.isArray(file)) {
+    addError(errors, path, "must be an object");
+    return null;
+  }
+  for (const key of unknownKeys(file, FILE_KEYS)) {
+    addError(errors, `${path}.${key}`, "is not allowed in patch proposals");
+  }
+  const changeKind = file.changeKind;
+  if (!PATCH_PROPOSAL_CHANGE_KINDS.includes(changeKind)) {
+    addError(errors, `${path}.changeKind`, `must be one of: ${PATCH_PROPOSAL_CHANGE_KINDS.join(", ")}`);
+  }
+  const hunks = Array.isArray(file.hunks) ? file.hunks : [];
+  if (!Array.isArray(file.hunks)) {
+    addError(errors, `${path}.hunks`, "must be an array");
+  }
+  if (hunks.length > limits.maxHunksPerFile) {
+    addError(errors, `${path}.hunks`, `must contain at most ${limits.maxHunksPerFile} hunk(s)`);
+  }
+  return {
+    path: normalizeRelativePath(file.path, `${path}.path`, errors),
+    changeKind: PATCH_PROPOSAL_CHANGE_KINDS.includes(changeKind) ? changeKind : "modify",
+    reason: boundedString(file.reason ?? "", `${path}.reason`, errors, limits.maxReasonCharacters),
+    hunks: hunks
+      .slice(0, limits.maxHunksPerFile)
+      .map((hunk, index) => normalizeHunk(hunk, `${path}.hunks[${index}]`, errors, limits))
+      .filter(Boolean),
+  };
+}
+
+export function normalizePatchProposal(proposal = {}, options = {}) {
+  const limits = mergeLimits(options.limits);
+  const errors = [];
+
+  if (!proposal || typeof proposal !== "object" || Array.isArray(proposal)) {
+    throw new Error("patch proposal must be an object");
+  }
+  for (const key of unknownKeys(proposal, TOP_LEVEL_KEYS)) {
+    addError(errors, key, "is not allowed in patch proposals");
+  }
+  if (proposal.version !== PATCH_PROPOSAL_SCHEMA_VERSION) {
+    addError(errors, "version", `must be ${PATCH_PROPOSAL_SCHEMA_VERSION}`);
+  }
+  if (proposal.source !== PATCH_PROPOSAL_SOURCE) {
+    addError(errors, "source", `must be ${PATCH_PROPOSAL_SOURCE}`);
+  }
+  if (!PATCH_PROPOSAL_RISK_LEVELS.includes(proposal.riskLevel)) {
+    addError(errors, "riskLevel", `must be one of: ${PATCH_PROPOSAL_RISK_LEVELS.join(", ")}`);
+  }
+  if (proposal.requiresUserReview !== true) {
+    addError(errors, "requiresUserReview", "must be true");
+  }
+  const files = Array.isArray(proposal.files) ? proposal.files : [];
+  if (!Array.isArray(proposal.files)) {
+    addError(errors, "files", "must be an array");
+  }
+  if (files.length === 0) {
+    addError(errors, "files", "must contain at least one file");
+  }
+  if (files.length > limits.maxFiles) {
+    addError(errors, "files", `must contain at most ${limits.maxFiles} file(s)`);
+  }
+
+  const normalized = {
+    version: PATCH_PROPOSAL_SCHEMA_VERSION,
+    proposalId: boundedString(proposal.proposalId ?? "", "proposalId", errors, 120),
+    source: PATCH_PROPOSAL_SOURCE,
+    title: boundedString(proposal.title ?? "", "title", errors, limits.maxTitleCharacters),
+    summary: boundedString(proposal.summary ?? "", "summary", errors, limits.maxSummaryCharacters),
+    riskLevel: PATCH_PROPOSAL_RISK_LEVELS.includes(proposal.riskLevel)
+      ? proposal.riskLevel
+      : "medium",
+    files: files
+      .slice(0, limits.maxFiles)
+      .map((file, index) => normalizeFile(file, `files[${index}]`, errors, limits))
+      .filter(Boolean),
+    validationPlan: boundedStringList(
+      proposal.validationPlan,
+      "validationPlan",
+      errors,
+      limits.maxValidationPlanItems,
+      limits.maxListItemCharacters,
+    ),
+    nonGoals: boundedStringList(
+      proposal.nonGoals,
+      "nonGoals",
+      errors,
+      limits.maxNonGoals,
+      limits.maxListItemCharacters,
+    ),
+    requiresUserReview: true,
+  };
+
+  if (errors.length > 0) {
+    throw new Error(`invalid patch proposal: ${errors.join("; ")}`);
+  }
+  return normalized;
+}
+
+export function validatePatchProposal(proposal = {}, options = {}) {
+  try {
+    return {
+      ok: true,
+      proposal: normalizePatchProposal(proposal, options),
+      errors: [],
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      proposal: null,
+      errors: error.message.replace(/^invalid patch proposal: /, "").split("; "),
+    };
+  }
+}
+
+export function createPatchProposalContractStatus() {
+  return {
+    version: PATCH_PROPOSAL_CONTRACT_VERSION,
+    schemaVersion: PATCH_PROPOSAL_SCHEMA_VERSION,
+    source: PATCH_PROPOSAL_SOURCE,
+    proposalOnly: true,
+    appliesPatches: false,
+    writesFiles: false,
+    providerCalls: false,
+    runtimeCalls: false,
+    requiresUserReview: true,
+    allowedChangeKinds: [...PATCH_PROPOSAL_CHANGE_KINDS],
+    allowedRiskLevels: [...PATCH_PROPOSAL_RISK_LEVELS],
+    disallowedActions: [
+      "applyPatch",
+      "writeFile",
+      "executeCommand",
+      "spawnProcess",
+      "providerCall",
+      "launcherCall",
+      "mcpCall",
+      "release",
+      "tag",
+      "changeRuleset",
+      "accessSecrets",
+    ],
+  };
+}

--- a/editors/vscode-prototype/test/extension-host-readiness.test.mjs
+++ b/editors/vscode-prototype/test/extension-host-readiness.test.mjs
@@ -111,6 +111,7 @@ async function testReadinessDocsAndCiPolicy() {
   assert.match(`${readme}\n${readiness}`, /showPccxLabBackendStatus/);
   assert.match(`${readme}\n${readiness}`, /context bundle command/i);
   assert.match(`${readme}\n${readiness}`, /validation command proposal/i);
+  assert.match(`${readme}\n${readiness}`, /patch proposal contract/i);
   assert.match(`${readme}\n${readiness}`, /pccx-lab backend status/i);
   assert.match(`${readme}\n${readiness}`, /AI assistant .*boundary/i);
   assert.match(`${readme}\n${readiness}`, /pccx-llm-launcher .*future local LLM\/chat backend/i);

--- a/editors/vscode-prototype/test/extension-manifest.test.mjs
+++ b/editors/vscode-prototype/test/extension-manifest.test.mjs
@@ -119,6 +119,7 @@ async function testDocsKeepExperimentalScope() {
   assert.match(combined, /context bundle command/i);
   assert.match(combined, /AI assistant status command/i);
   assert.match(combined, /validation command proposal/i);
+  assert.match(combined, /patch proposal contract/i);
   assert.match(combined, /approved validation runner/i);
   assert.match(combined, /allowlisted proposal IDs/i);
   assert.match(combined, /pccx-lab backend status/i);

--- a/editors/vscode-prototype/test/patch-proposal-contract.test.mjs
+++ b/editors/vscode-prototype/test/patch-proposal-contract.test.mjs
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+
+import {
+  PATCH_PROPOSAL_CHANGE_KINDS,
+  PATCH_PROPOSAL_CONTRACT_VERSION,
+  PATCH_PROPOSAL_RISK_LEVELS,
+  PATCH_PROPOSAL_SCHEMA_VERSION,
+  PATCH_PROPOSAL_SOURCE,
+  createPatchProposalContractStatus,
+  normalizePatchProposal,
+  validatePatchProposal,
+} from "../src/patch-proposal-contract.mjs";
+
+function safeProposal(overrides = {}) {
+  return {
+    version: PATCH_PROPOSAL_SCHEMA_VERSION,
+    proposalId: "missingEndmoduleFix",
+    source: PATCH_PROPOSAL_SOURCE,
+    title: "Add missing endmodule",
+    summary: "Proposes a small SystemVerilog syntax fix for review.",
+    riskLevel: "low",
+    files: [
+      {
+        path: "fixtures/missing_endmodule.sv",
+        changeKind: "modify",
+        reason: "The checked fixture is missing a closing declaration.",
+        hunks: [
+          {
+            oldStart: 1,
+            oldLines: 3,
+            newStart: 1,
+            newLines: 4,
+            preview: "@@\n module missing_endmodule;\n+endmodule",
+          },
+        ],
+      },
+    ],
+    validationPlan: [
+      "Run the VS Code adapter smoke through the approved validation proposal.",
+      "Run the repository test baseline through the approved validation proposal.",
+    ],
+    nonGoals: [
+      "Do not apply the patch automatically.",
+      "Do not add runtime provider calls.",
+    ],
+    requiresUserReview: true,
+    ...overrides,
+  };
+}
+
+function assertInvalid(proposal, pattern) {
+  const result = validatePatchProposal(proposal);
+
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), pattern);
+  assert.throws(() => normalizePatchProposal(proposal), pattern);
+}
+
+function testSafePatchProposalNormalizesDeterministically() {
+  const proposal = normalizePatchProposal(safeProposal());
+
+  assert.equal(proposal.version, 1);
+  assert.equal(proposal.proposalId, "missingEndmoduleFix");
+  assert.equal(proposal.source, "local-prototype");
+  assert.equal(proposal.riskLevel, "low");
+  assert.equal(proposal.requiresUserReview, true);
+  assert.equal(proposal.files.length, 1);
+  assert.equal(proposal.files[0].path, "fixtures/missing_endmodule.sv");
+  assert.equal(proposal.files[0].changeKind, "modify");
+  assert.equal(proposal.files[0].hunks.length, 1);
+  assert.equal(proposal.files[0].hunks[0].oldStart, 1);
+  assert.equal(proposal.validationPlan.length, 2);
+  assert.equal(proposal.nonGoals.length, 2);
+  assert.doesNotMatch(JSON.stringify(proposal), /\/home\/|TOKEN=|scripts\/private/);
+}
+
+function testContractStatusIsProposalOnly() {
+  const status = createPatchProposalContractStatus();
+
+  assert.equal(status.version, PATCH_PROPOSAL_CONTRACT_VERSION);
+  assert.equal(status.schemaVersion, PATCH_PROPOSAL_SCHEMA_VERSION);
+  assert.equal(status.source, PATCH_PROPOSAL_SOURCE);
+  assert.equal(status.proposalOnly, true);
+  assert.equal(status.appliesPatches, false);
+  assert.equal(status.writesFiles, false);
+  assert.equal(status.providerCalls, false);
+  assert.equal(status.runtimeCalls, false);
+  assert.equal(status.requiresUserReview, true);
+  assert.deepEqual(status.allowedChangeKinds, PATCH_PROPOSAL_CHANGE_KINDS);
+  assert.deepEqual(status.allowedRiskLevels, PATCH_PROPOSAL_RISK_LEVELS);
+  assert.ok(status.disallowedActions.includes("applyPatch"));
+  assert.ok(status.disallowedActions.includes("executeCommand"));
+  assert.ok(status.disallowedActions.includes("accessSecrets"));
+}
+
+function testRejectsUnsafePathsAndArtifacts() {
+  assertInvalid(
+    safeProposal({
+      files: [
+        {
+          path: "/home/dev/repo/rtl/top.sv",
+          changeKind: "modify",
+          reason: "Absolute path.",
+          hunks: [{ oldStart: 1, oldLines: 1, newStart: 1, newLines: 1, preview: "@@" }],
+        },
+      ],
+    }),
+    /relative to the repository/,
+  );
+  assertInvalid(
+    safeProposal({
+      files: [
+        {
+          path: "node_modules/pkg/generated.js",
+          changeKind: "modify",
+          reason: "Generated dependency path.",
+          hunks: [{ oldStart: 1, oldLines: 1, newStart: 1, newLines: 1, preview: "@@" }],
+        },
+      ],
+    }),
+    /private, generated, secret-like, or binary artifact paths/,
+  );
+  assertInvalid(
+    safeProposal({
+      files: [
+        {
+          path: "models/local.safetensors",
+          changeKind: "add",
+          reason: "Model artifact.",
+          hunks: [{ oldStart: 1, oldLines: 0, newStart: 1, newLines: 1, preview: "@@" }],
+        },
+      ],
+    }),
+    /private, generated, secret-like, or binary artifact paths/,
+  );
+}
+
+function testRejectsSecretsShellCommandsAndAutoApplyShape() {
+  assertInvalid(
+    safeProposal({ summary: "TOKEN=hidden" }),
+    /secret-like assignments/,
+  );
+  assertInvalid(
+    safeProposal({ validationPlan: ["python3 -m pytest -q"] }),
+    /shell commands/,
+  );
+  assertInvalid(
+    safeProposal({ requiresUserReview: false }),
+    /requiresUserReview: must be true/,
+  );
+  assertInvalid(
+    {
+      ...safeProposal(),
+      autoApply: true,
+    },
+    /autoApply: is not allowed/,
+  );
+}
+
+function testRejectsBulkPreviewAndUnknownNestedKeys() {
+  const bulkPreview = Array.from({ length: 45 }, (_, index) => `line ${index}`).join("\n");
+
+  assertInvalid(
+    safeProposal({
+      files: [
+        {
+          path: "rtl/top.sv",
+          changeKind: "modify",
+          reason: "Too much preview text.",
+          hunks: [{ oldStart: 1, oldLines: 1, newStart: 1, newLines: 1, preview: bulkPreview }],
+        },
+      ],
+    }),
+    /at most 40 line/,
+  );
+  assertInvalid(
+    safeProposal({
+      files: [
+        {
+          path: "rtl/top.sv",
+          changeKind: "modify",
+          reason: "Unknown key.",
+          command: "bash scripts/private.sh",
+          hunks: [{ oldStart: 1, oldLines: 1, newStart: 1, newLines: 1, preview: "@@" }],
+        },
+      ],
+    }),
+    /files\[0\]\.command: is not allowed/,
+  );
+}
+
+testSafePatchProposalNormalizesDeterministically();
+testContractStatusIsProposalOnly();
+testRejectsUnsafePathsAndArtifacts();
+testRejectsSecretsShellCommandsAndAutoApplyShape();
+testRejectsBulkPreviewAndUnknownNestedKeys();
+
+console.log("vscode patch proposal contract tests ok");

--- a/editors/vscode-prototype/test/static-boundary.test.mjs
+++ b/editors/vscode-prototype/test/static-boundary.test.mjs
@@ -132,6 +132,7 @@ async function testNoDirectShellInterpolation() {
 async function testProposalAndStatusModulesAreDataOnly() {
   const proposalAndStatusSource = await readCombined([
     resolve(EXTENSION_ROOT, "src/validation-proposals.mjs"),
+    resolve(EXTENSION_ROOT, "src/patch-proposal-contract.mjs"),
     resolve(EXTENSION_ROOT, "src/pccx-lab-status.mjs"),
   ]);
 
@@ -147,6 +148,7 @@ async function testProposalAndStatusModulesAreDataOnly() {
   assert.doesNotMatch(proposalAndStatusSource, /\bgh\s+(?:secret|ruleset)\b/i);
   assert.match(proposalAndStatusSource, /proposalOnly/);
   assert.match(proposalAndStatusSource, /executes: false/);
+  assert.match(proposalAndStatusSource, /appliesPatches: false/);
   assert.match(proposalAndStatusSource, /backendCommandExecuted: false/);
 }
 

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -18,6 +18,7 @@ node editors/vscode-prototype/test/context-bundle.test.mjs
 node editors/vscode-prototype/test/selected-symbol-context.test.mjs
 node editors/vscode-prototype/test/ai-assistant-boundary.test.mjs
 node editors/vscode-prototype/test/validation-proposals.test.mjs
+node editors/vscode-prototype/test/patch-proposal-contract.test.mjs
 node editors/vscode-prototype/test/validation-result-summary.test.mjs
 node editors/vscode-prototype/test/validation-result-cache.test.mjs
 node editors/vscode-prototype/test/approved-validation-runner.test.mjs


### PR DESCRIPTION
## Summary
- Add a provider-free patch proposal contract and validator for future user-reviewed edits.
- Document the proposal-only patch shape and add deterministic safety tests.
- Include the new contract test in the VS Code adapter smoke path.

## Scope
- Adds editors/vscode-prototype/src/patch-proposal-contract.mjs.
- Adds docs/patch-proposal-contract.md and README/boundary references.
- Validates relative paths, bounded previews, risk levels, review requirement, and unsafe text/path/key rejection.

## Non-goals
- No patch application.
- No file writes.
- No shell command execution from proposals.
- No pccx-lab execution.
- No launcher calls.
- No AI provider calls.
- No MCP, LSP, marketplace, or packaging flow.

## Validation
- npm ci --prefix editors/vscode-prototype
- bash scripts/vscode-adapter-smoke.sh
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- python3 -m pytest -q
- git diff --check
- bash scripts/vscode-extension-host-smoke.sh exits 2 by default as expected
- PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh

## Safety notes
- Proposal data is contract-only and requires user review.
- Private paths, secrets, shell commands, generated artifacts, model/binary artifacts, raw provider output, unknown command fields, and auto-apply flags are rejected.
- The extension still does not apply patches or execute proposal data.

## Release/tag
No release or tag was created.

## FPGA repo
The FPGA repo was not touched.