### PR TITLE
feat(vscode): preview checked patch proposals

### DIFF
--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -141,6 +141,8 @@ The contributed commands are:
 - `pccxSystemVerilog.showRecentValidationResults`
 - `pccxSystemVerilog.showValidationCacheStatus`
 - `pccxSystemVerilog.clearValidationResultCache`
+- `pccxSystemVerilog.showPatchProposalPreview`
+- `pccxSystemVerilog.clearPatchProposalPreview`
 - `pccxSystemVerilog.showPccxLabBackendStatus`
 
 The prototype-only settings are:
@@ -303,6 +305,10 @@ execute validation, call pccx-lab, call pccx-llm-launcher, call an AI
 provider, implement MCP, implement LSP, package the extension, create a
 release, or create a tag.  The contract notes are tracked in
 [`docs/patch-proposal-contract.md`](./docs/patch-proposal-contract.md).
+`pccxSystemVerilog.showPatchProposalPreview` previews checked patch
+proposals through VS Code-native output without applying changes, and
+`pccxSystemVerilog.clearPatchProposalPreview` clears only the in-memory
+preview state.
 
 `pccxSystemVerilog.proposeValidationCommand` returns allowlisted
 validation command proposals as JSON data.  The proposal includes
@@ -411,6 +417,7 @@ node editors/vscode-prototype/test/selected-symbol-context.test.mjs
 node editors/vscode-prototype/test/ai-assistant-boundary.test.mjs
 node editors/vscode-prototype/test/validation-proposals.test.mjs
 node editors/vscode-prototype/test/patch-proposal-contract.test.mjs
+node editors/vscode-prototype/test/patch-proposal-preview.test.mjs
 node editors/vscode-prototype/test/validation-result-summary.test.mjs
 node editors/vscode-prototype/test/validation-result-cache.test.mjs
 node editors/vscode-prototype/test/approved-validation-runner.test.mjs

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -141,6 +141,9 @@ validation proposal shapes, plus a checked patch proposal contract for
 future user-reviewed edits, rather than direct execution.  User approval
 is still required before applying patches, running validation commands,
 or committing changes.
+`pccxSystemVerilog.showPatchProposalPreview` previews checked proposal IDs
+only, and `pccxSystemVerilog.clearPatchProposalPreview` clears the
+in-memory preview state without file writes.
 
 `pccxSystemVerilog.proposeValidationCommand` currently proposes only
 allowlisted templates, including the VS Code adapter smoke, editor bridge

--- a/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
+++ b/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
@@ -193,7 +193,9 @@ Patch proposals are contract-only in this prototype.  The checked
 contract accepts repository-relative paths and bounded hunk previews for
 future user review, rejects private paths, secrets, shell commands,
 generated artifacts, raw provider output, and auto-apply fields, and does
-not apply changes.
+not apply changes.  The preview command shows checked proposal IDs only
+through VS Code-native output and the clear command removes only the
+in-memory preview result.
 
 ## Prototype Daily-Driver Loop
 

--- a/editors/vscode-prototype/docs/patch-proposal-contract.md
+++ b/editors/vscode-prototype/docs/patch-proposal-contract.md
@@ -72,3 +72,10 @@ call an AI provider, implement MCP, or implement LSP.
 The contract is implemented in `src/patch-proposal-contract.mjs` and tested
 by `test/patch-proposal-contract.test.mjs`.  The module is data-only and
 safe to use as a future handoff shape for user-reviewed patch previews.
+
+`pccxSystemVerilog.showPatchProposalPreview` previews checked proposal IDs
+through VS Code-native output without applying patches or writing files.
+`pccxSystemVerilog.clearPatchProposalPreview` clears only the in-memory
+preview result.  The preview path is implemented in
+`src/patch-proposal-preview.mjs` and tested by
+`test/patch-proposal-preview.test.mjs`.

--- a/editors/vscode-prototype/package.json
+++ b/editors/vscode-prototype/package.json
@@ -28,6 +28,8 @@
     "onCommand:pccxSystemVerilog.showRecentValidationResults",
     "onCommand:pccxSystemVerilog.showValidationCacheStatus",
     "onCommand:pccxSystemVerilog.clearValidationResultCache",
+    "onCommand:pccxSystemVerilog.showPatchProposalPreview",
+    "onCommand:pccxSystemVerilog.clearPatchProposalPreview",
     "onCommand:pccxSystemVerilog.showPccxLabBackendStatus"
   ],
   "contributes": {
@@ -91,6 +93,14 @@
       {
         "command": "pccxSystemVerilog.clearValidationResultCache",
         "title": "PCCX SystemVerilog: Clear Validation Result Cache (Experimental)"
+      },
+      {
+        "command": "pccxSystemVerilog.showPatchProposalPreview",
+        "title": "PCCX SystemVerilog: Show Patch Proposal Preview (Experimental)"
+      },
+      {
+        "command": "pccxSystemVerilog.clearPatchProposalPreview",
+        "title": "PCCX SystemVerilog: Clear Patch Proposal Preview (Experimental)"
       },
       {
         "command": "pccxSystemVerilog.showPccxLabBackendStatus",

--- a/editors/vscode-prototype/src/config.mjs
+++ b/editors/vscode-prototype/src/config.mjs
@@ -38,6 +38,8 @@ export const AI_COMMAND_IDS = Object.freeze([
   "pccxSystemVerilog.showRecentValidationResults",
   "pccxSystemVerilog.showValidationCacheStatus",
   "pccxSystemVerilog.clearValidationResultCache",
+  "pccxSystemVerilog.showPatchProposalPreview",
+  "pccxSystemVerilog.clearPatchProposalPreview",
 ]);
 
 export const PCCX_LAB_COMMAND_IDS = Object.freeze([

--- a/editors/vscode-prototype/src/extension.mjs
+++ b/editors/vscode-prototype/src/extension.mjs
@@ -48,6 +48,10 @@ import {
 import {
   createPccxLabBackendStatus,
 } from "./pccx-lab-status.mjs";
+import {
+  createPatchProposalPreview,
+  listCheckedPatchProposals,
+} from "./patch-proposal-preview.mjs";
 
 const EXTENSION_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_DIAGNOSTIC_FILE_ROOT = resolve(EXTENSION_ROOT, "../..");
@@ -75,6 +79,10 @@ export const SHOW_VALIDATION_CACHE_STATUS_COMMAND =
   "pccxSystemVerilog.showValidationCacheStatus";
 export const CLEAR_VALIDATION_RESULT_CACHE_COMMAND =
   "pccxSystemVerilog.clearValidationResultCache";
+export const SHOW_PATCH_PROPOSAL_PREVIEW_COMMAND =
+  "pccxSystemVerilog.showPatchProposalPreview";
+export const CLEAR_PATCH_PROPOSAL_PREVIEW_COMMAND =
+  "pccxSystemVerilog.clearPatchProposalPreview";
 export const PCCX_LAB_BACKEND_STATUS_COMMAND =
   "pccxSystemVerilog.showPccxLabBackendStatus";
 
@@ -260,6 +268,15 @@ function validationEntryQuickPickItems(entries) {
   }));
 }
 
+function patchProposalQuickPickItems(proposals) {
+  return proposals.map((proposal) => ({
+    label: proposal.title,
+    description: [proposal.riskLevel, proposal.proposalId].filter(Boolean).join(" "),
+    detail: proposal.summary,
+    proposalId: proposal.proposalId,
+  }));
+}
+
 function validationOutputChannelFromRuntime(runtime = {}) {
   return runtime.validationOutputChannel ?? runtime.outputChannel;
 }
@@ -350,6 +367,15 @@ function appendCommandOutput(outputChannel, commandId, result) {
     outputChannel.appendLine(JSON.stringify({
       kind: result.kind,
       clearedCount: result.clearedCount,
+    }, null, 2));
+  }
+  if (result.kind === "patch-proposal-preview") {
+    outputChannel.appendLine(result.previewText);
+  }
+  if (result.kind === "patch-proposal-preview-clear") {
+    outputChannel.appendLine(JSON.stringify({
+      kind: result.kind,
+      cleared: result.cleared,
     }, null, 2));
   }
   if (result.status?.kind === "pccx-lab-backend-status") {
@@ -813,6 +839,65 @@ export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
         vscodeApi?.window?.showWarningMessage?.(result.error, result);
       }
       appendValidationOutput(validationOutputChannelFromRuntime(runtime), commandId, result);
+      appendCommandOutput(runtime.outputChannel, commandId, result);
+      return result;
+    }
+
+    if (commandId === SHOW_PATCH_PROPOSAL_PREVIEW_COMMAND) {
+      let result;
+      try {
+        let request = input;
+        if (request == null && typeof vscodeApi?.window?.showQuickPick === "function") {
+          const selected = await vscodeApi.window.showQuickPick(
+            patchProposalQuickPickItems(listCheckedPatchProposals({
+              checkedPatchProposals: runtime.checkedPatchProposals,
+            })),
+            {
+              title: "Patch Proposal Preview",
+              placeHolder: "Select a checked patch proposal",
+            },
+          );
+          request = selected?.proposalId ?? null;
+        }
+        result = {
+          ok: true,
+          commandId,
+          ...createPatchProposalPreview(request, {
+            checkedPatchProposals: runtime.checkedPatchProposals,
+          }),
+        };
+        runtime.recentPatchProposalPreview = result;
+        vscodeApi?.window?.showInformationMessage?.(
+          `Patch proposal preview: ${result.summary.title}`,
+          result,
+        );
+      } catch (error) {
+        result = { ok: false, commandId, error: error.message };
+        vscodeApi?.window?.showWarningMessage?.(result.error, result);
+      }
+      appendCommandOutput(runtime.outputChannel, commandId, result);
+      return result;
+    }
+
+    if (commandId === CLEAR_PATCH_PROPOSAL_PREVIEW_COMMAND) {
+      let result;
+      try {
+        const cleared = runtime.recentPatchProposalPreview != null;
+        runtime.recentPatchProposalPreview = null;
+        result = {
+          ok: true,
+          commandId,
+          kind: "patch-proposal-preview-clear",
+          cleared,
+        };
+        vscodeApi?.window?.showInformationMessage?.(
+          cleared ? "Cleared patch proposal preview." : "No patch proposal preview was cached.",
+          result,
+        );
+      } catch (error) {
+        result = { ok: false, commandId, error: error.message };
+        vscodeApi?.window?.showWarningMessage?.(result.error, result);
+      }
       appendCommandOutput(runtime.outputChannel, commandId, result);
       return result;
     }

--- a/editors/vscode-prototype/src/patch-proposal-preview.mjs
+++ b/editors/vscode-prototype/src/patch-proposal-preview.mjs
@@ -1,0 +1,159 @@
+import {
+  PATCH_PROPOSAL_SCHEMA_VERSION,
+  PATCH_PROPOSAL_SOURCE,
+  normalizePatchProposal,
+} from "./patch-proposal-contract.mjs";
+
+export const PATCH_PROPOSAL_PREVIEW_VERSION = "pccx.patchProposalPreview.v0";
+
+const CHECKED_PATCH_PROPOSALS = Object.freeze([
+  Object.freeze({
+    version: PATCH_PROPOSAL_SCHEMA_VERSION,
+    proposalId: "missingEndmodulePreview",
+    source: PATCH_PROPOSAL_SOURCE,
+    title: "Preview missing endmodule fix",
+    summary: "Shows a small checked SystemVerilog syntax fix proposal for review.",
+    riskLevel: "low",
+    files: Object.freeze([
+      Object.freeze({
+        path: "fixtures/missing_endmodule.sv",
+        changeKind: "modify",
+        reason: "The checked fixture is missing a closing declaration.",
+        hunks: Object.freeze([
+          Object.freeze({
+            oldStart: 1,
+            oldLines: 3,
+            newStart: 1,
+            newLines: 4,
+            preview: "@@\n module missing_endmodule;\n+endmodule",
+          }),
+        ]),
+      }),
+    ]),
+    validationPlan: Object.freeze([
+      "Run the VS Code adapter smoke through the approved validation proposal.",
+      "Run the repository test baseline through the approved validation proposal.",
+    ]),
+    nonGoals: Object.freeze([
+      "Do not apply the patch automatically.",
+      "Do not add runtime provider calls.",
+    ]),
+    requiresUserReview: true,
+  }),
+]);
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function proposalIdFromInput(input) {
+  if (input == null) {
+    return CHECKED_PATCH_PROPOSALS[0].proposalId;
+  }
+  if (typeof input === "string") {
+    return input;
+  }
+  if (typeof input === "object" && typeof input.proposalId === "string") {
+    return input.proposalId;
+  }
+  if (typeof input === "object" && typeof input.id === "string") {
+    return input.id;
+  }
+  throw new Error("patch proposal preview accepts checked proposal IDs only");
+}
+
+function checkedProposals(options = {}) {
+  return Array.isArray(options.checkedPatchProposals)
+    ? options.checkedPatchProposals
+    : CHECKED_PATCH_PROPOSALS;
+}
+
+export function listCheckedPatchProposals(options = {}) {
+  return checkedProposals(options).map((proposal) => normalizePatchProposal(proposal));
+}
+
+export function findCheckedPatchProposalById(proposalId, options = {}) {
+  if (typeof proposalId !== "string" || proposalId.trim().length === 0) {
+    return null;
+  }
+  const proposal = checkedProposals(options).find((item) => item?.proposalId === proposalId);
+  return proposal ? normalizePatchProposal(proposal) : null;
+}
+
+function yesNo(value) {
+  return value === true ? "yes" : "no";
+}
+
+function previewSummary(proposal) {
+  return {
+    proposalId: proposal.proposalId,
+    title: proposal.title,
+    riskLevel: proposal.riskLevel,
+    fileCount: proposal.files.length,
+    hunkCount: proposal.files.reduce((count, file) => count + file.hunks.length, 0),
+    validationPlanCount: proposal.validationPlan.length,
+    requiresUserReview: proposal.requiresUserReview,
+  };
+}
+
+export function formatPatchProposalPreview(proposal) {
+  const lines = [
+    "Patch Proposal Preview",
+    `proposalId: ${proposal.proposalId}`,
+    `title: ${proposal.title}`,
+    `riskLevel: ${proposal.riskLevel}`,
+    `requiresUserReview: ${yesNo(proposal.requiresUserReview)}`,
+    "files:",
+  ];
+
+  for (const file of proposal.files) {
+    lines.push(`- ${file.path} (${file.changeKind})`);
+    lines.push(`  reason: ${file.reason}`);
+    for (const hunk of file.hunks) {
+      lines.push(
+        `  hunk: old ${hunk.oldStart}+${hunk.oldLines} -> new ${hunk.newStart}+${hunk.newLines}`,
+      );
+      for (const previewLine of hunk.preview.split(/\r?\n/)) {
+        lines.push(`    ${previewLine}`);
+      }
+    }
+  }
+
+  lines.push("validationPlan:");
+  for (const item of proposal.validationPlan) {
+    lines.push(`- ${item}`);
+  }
+  lines.push("nonGoals:");
+  for (const item of proposal.nonGoals) {
+    lines.push(`- ${item}`);
+  }
+  lines.push("safety:");
+  lines.push("- appliesPatches: no");
+  lines.push("- writesFiles: no");
+  lines.push("- providerCalls: no");
+  lines.push("- runtimeCalls: no");
+  return lines.join("\n");
+}
+
+export function createPatchProposalPreview(input = null, options = {}) {
+  if (input && typeof input === "object" && Object.hasOwn(input, "proposal")) {
+    throw new Error("patch proposal preview accepts checked proposal IDs only");
+  }
+  const proposalId = proposalIdFromInput(input);
+  const proposal = findCheckedPatchProposalById(proposalId, options);
+  if (!proposal) {
+    throw new Error(`unknown checked patch proposal: ${proposalId}`);
+  }
+  return {
+    version: PATCH_PROPOSAL_PREVIEW_VERSION,
+    kind: "patch-proposal-preview",
+    proposal: clone(proposal),
+    summary: previewSummary(proposal),
+    previewText: formatPatchProposalPreview(proposal),
+    proposalOnly: true,
+    appliesPatches: false,
+    writesFiles: false,
+    providerCalls: false,
+    runtimeCalls: false,
+  };
+}

--- a/editors/vscode-prototype/test/extension-entrypoint.test.mjs
+++ b/editors/vscode-prototype/test/extension-entrypoint.test.mjs
@@ -4,12 +4,14 @@ import {
   AI_CONTEXT_BUNDLE_COMMAND,
   AI_ASSISTANT_STATUS_COMMAND,
   APPROVED_VALIDATION_RUNNER_COMMAND,
+  CLEAR_PATCH_PROPOSAL_PREVIEW_COMMAND,
   CLEAR_VALIDATION_RESULT_CACHE_COMMAND,
   COMMAND_IDS,
   CHECKED_EXAMPLE_NAVIGATION_COMMAND,
   FACADE_COMMAND_IDS,
   LIVE_WORKSPACE_NAVIGATION_COMMAND,
   PCCX_LAB_BACKEND_STATUS_COMMAND,
+  SHOW_PATCH_PROPOSAL_PREVIEW_COMMAND,
   SHOW_RECENT_VALIDATION_RESULTS_COMMAND,
   SHOW_VALIDATION_CACHE_STATUS_COMMAND,
   VALIDATION_PROPOSAL_COMMAND,
@@ -1194,6 +1196,61 @@ async function testValidationResultCacheCommandsShowAndClear() {
   assert.ok(informationMessages.some(([message]) => /Cleared 1 cached validation result/.test(message)));
 }
 
+async function testPatchProposalPreviewCommandsShowAndClearCheckedProposalOnly() {
+  const informationMessages = [];
+  const warningMessages = [];
+  const outputLines = [];
+  const runtime = {
+    outputChannel: {
+      appendLine(line) {
+        outputLines.push(line);
+      },
+      show() {},
+    },
+  };
+  const vscodeApi = {
+    window: {
+      showInformationMessage(...args) {
+        informationMessages.push(args);
+      },
+      showWarningMessage(...args) {
+        warningMessages.push(args);
+      },
+    },
+  };
+  const showHandler = createCommandHandler(SHOW_PATCH_PROPOSAL_PREVIEW_COMMAND, vscodeApi, runtime);
+  const clearHandler = createCommandHandler(CLEAR_PATCH_PROPOSAL_PREVIEW_COMMAND, vscodeApi, runtime);
+
+  const shown = await showHandler("missingEndmodulePreview");
+
+  assert.equal(shown.ok, true);
+  assert.equal(shown.kind, "patch-proposal-preview");
+  assert.equal(shown.summary.proposalId, "missingEndmodulePreview");
+  assert.equal(shown.proposalOnly, true);
+  assert.equal(shown.appliesPatches, false);
+  assert.equal(shown.writesFiles, false);
+  assert.equal(shown.providerCalls, false);
+  assert.equal(shown.runtimeCalls, false);
+  assert.equal(runtime.recentPatchProposalPreview.summary.proposalId, "missingEndmodulePreview");
+  assert.ok(outputLines.some((line) => line.includes("Patch Proposal Preview")));
+  assert.ok(outputLines.some((line) => line.includes("appliesPatches: no")));
+  assert.ok(informationMessages.some(([message]) => /Patch proposal preview/.test(message)));
+  assert.doesNotMatch(JSON.stringify(shown), /\/home\/|TOKEN=|scripts\/private/);
+
+  const rejected = await showHandler({ proposal: { proposalId: "unsafe" } });
+
+  assert.equal(rejected.ok, false);
+  assert.match(rejected.error, /checked proposal IDs only/);
+  assert.ok(warningMessages.some(([message]) => /checked proposal IDs only/.test(message)));
+
+  const cleared = await clearHandler();
+
+  assert.equal(cleared.ok, true);
+  assert.equal(cleared.kind, "patch-proposal-preview-clear");
+  assert.equal(cleared.cleared, true);
+  assert.equal(runtime.recentPatchProposalPreview, null);
+}
+
 async function testPccxLabBackendStatusCommandReturnsStatusOnly() {
   const settings = new Map([
     ["mode", "checkedExample"],
@@ -1264,6 +1321,7 @@ await testApprovedValidationRunnerBlocksByDefaultAndUpdatesContext();
 await testApprovedValidationRunnerRequiresProposalIdWhenEnabled();
 await testApprovedValidationRunnerExecutesAllowlistedProposalWhenEnabled();
 await testValidationResultCacheCommandsShowAndClear();
+await testPatchProposalPreviewCommandsShowAndClearCheckedProposalOnly();
 await testPccxLabBackendStatusCommandReturnsStatusOnly();
 
 console.log("vscode extension entrypoint tests ok");

--- a/editors/vscode-prototype/test/extension-host-readiness.test.mjs
+++ b/editors/vscode-prototype/test/extension-host-readiness.test.mjs
@@ -108,6 +108,8 @@ async function testReadinessDocsAndCiPolicy() {
   assert.match(`${readme}\n${readiness}`, /showRecentValidationResults/);
   assert.match(`${readme}\n${readiness}`, /showValidationCacheStatus/);
   assert.match(`${readme}\n${readiness}`, /clearValidationResultCache/);
+  assert.match(`${readme}\n${readiness}`, /showPatchProposalPreview/);
+  assert.match(`${readme}\n${readiness}`, /clearPatchProposalPreview/);
   assert.match(`${readme}\n${readiness}`, /showPccxLabBackendStatus/);
   assert.match(`${readme}\n${readiness}`, /context bundle command/i);
   assert.match(`${readme}\n${readiness}`, /validation command proposal/i);
@@ -165,6 +167,8 @@ async function testRuntimeRunnerIsPinnedAndBounded() {
   assert.match(suite, /showRecentValidationResults/);
   assert.match(suite, /showValidationCacheStatus/);
   assert.match(suite, /clearValidationResultCache/);
+  assert.match(suite, /showPatchProposalPreview/);
+  assert.match(suite, /clearPatchProposalPreview/);
   assert.match(suite, /validationRunner\.enabled/);
   assert.match(suite, /vscodeAdapterSmoke/);
   assert.match(suite, /showPccxLabBackendStatus/);

--- a/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
+++ b/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
@@ -71,6 +71,8 @@ async function run() {
     "pccxSystemVerilog.showRecentValidationResults",
     "pccxSystemVerilog.showValidationCacheStatus",
     "pccxSystemVerilog.clearValidationResultCache",
+    "pccxSystemVerilog.showPatchProposalPreview",
+    "pccxSystemVerilog.clearPatchProposalPreview",
     "pccxSystemVerilog.showPccxLabBackendStatus",
   ]);
 
@@ -373,6 +375,27 @@ async function run() {
   assert.ok(validationProposal.proposals.some((proposal) => (
     proposal.command?.env?.PCCX_RUN_EXTENSION_HOST_SMOKE === "1"
   )));
+
+  const patchPreview = await vscode.commands.executeCommand(
+    "pccxSystemVerilog.showPatchProposalPreview",
+    "missingEndmodulePreview",
+  );
+  assert.equal(patchPreview.ok, true);
+  assert.equal(patchPreview.kind, "patch-proposal-preview");
+  assert.equal(patchPreview.summary.proposalId, "missingEndmodulePreview");
+  assert.equal(patchPreview.proposalOnly, true);
+  assert.equal(patchPreview.appliesPatches, false);
+  assert.equal(patchPreview.writesFiles, false);
+  assert.equal(patchPreview.providerCalls, false);
+  assert.equal(patchPreview.runtimeCalls, false);
+  assert.doesNotMatch(JSON.stringify(patchPreview), /\/home\//);
+
+  const clearPatchPreview = await vscode.commands.executeCommand(
+    "pccxSystemVerilog.clearPatchProposalPreview",
+  );
+  assert.equal(clearPatchPreview.ok, true);
+  assert.equal(clearPatchPreview.kind, "patch-proposal-preview-clear");
+  assert.equal(clearPatchPreview.cleared, true);
 
   const disabledValidationRun = await vscode.commands.executeCommand(
     "pccxSystemVerilog.runApprovedValidationCommand",

--- a/editors/vscode-prototype/test/extension-manifest.test.mjs
+++ b/editors/vscode-prototype/test/extension-manifest.test.mjs
@@ -21,6 +21,8 @@ const COMMAND_IDS = [
   "pccxSystemVerilog.showRecentValidationResults",
   "pccxSystemVerilog.showValidationCacheStatus",
   "pccxSystemVerilog.clearValidationResultCache",
+  "pccxSystemVerilog.showPatchProposalPreview",
+  "pccxSystemVerilog.clearPatchProposalPreview",
   "pccxSystemVerilog.showPccxLabBackendStatus",
 ];
 

--- a/editors/vscode-prototype/test/patch-proposal-preview.test.mjs
+++ b/editors/vscode-prototype/test/patch-proposal-preview.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+
+import {
+  PATCH_PROPOSAL_PREVIEW_VERSION,
+  createPatchProposalPreview,
+  findCheckedPatchProposalById,
+  formatPatchProposalPreview,
+  listCheckedPatchProposals,
+} from "../src/patch-proposal-preview.mjs";
+
+function unsafeProposal() {
+  return {
+    version: 1,
+    proposalId: "unsafe",
+    source: "local-prototype",
+    title: "Unsafe proposal",
+    summary: "Attempts to use a private path.",
+    riskLevel: "high",
+    files: [
+      {
+        path: "/home/dev/repo/rtl/top.sv",
+        changeKind: "modify",
+        reason: "Private absolute path.",
+        hunks: [{ oldStart: 1, oldLines: 1, newStart: 1, newLines: 1, preview: "@@" }],
+      },
+    ],
+    validationPlan: ["Review manually."],
+    nonGoals: ["Do not apply automatically."],
+    requiresUserReview: true,
+  };
+}
+
+function testCheckedPreviewIsSummaryOnlyAndDoesNotApply() {
+  const preview = createPatchProposalPreview("missingEndmodulePreview");
+
+  assert.equal(preview.version, PATCH_PROPOSAL_PREVIEW_VERSION);
+  assert.equal(preview.kind, "patch-proposal-preview");
+  assert.equal(preview.proposalOnly, true);
+  assert.equal(preview.appliesPatches, false);
+  assert.equal(preview.writesFiles, false);
+  assert.equal(preview.providerCalls, false);
+  assert.equal(preview.runtimeCalls, false);
+  assert.equal(preview.summary.proposalId, "missingEndmodulePreview");
+  assert.equal(preview.summary.riskLevel, "low");
+  assert.equal(preview.summary.fileCount, 1);
+  assert.equal(preview.summary.hunkCount, 1);
+  assert.equal(preview.summary.requiresUserReview, true);
+  assert.match(preview.previewText, /Patch Proposal Preview/);
+  assert.match(preview.previewText, /fixtures\/missing_endmodule\.sv/);
+  assert.match(preview.previewText, /appliesPatches: no/);
+  assert.doesNotMatch(JSON.stringify(preview), /\/home\/|TOKEN=|scripts\/private/);
+}
+
+function testCheckedProposalListingAndLookupValidateContract() {
+  const proposals = listCheckedPatchProposals();
+  const proposal = findCheckedPatchProposalById("missingEndmodulePreview");
+
+  assert.ok(proposals.some((item) => item.proposalId === "missingEndmodulePreview"));
+  assert.equal(proposal.proposalId, "missingEndmodulePreview");
+  assert.equal(proposal.files[0].path, "fixtures/missing_endmodule.sv");
+  assert.equal(findCheckedPatchProposalById("bash scripts/private.sh"), null);
+}
+
+function testPreviewRejectsRawProposalObjects() {
+  assert.throws(
+    () => createPatchProposalPreview({ proposal: unsafeProposal() }),
+    /checked proposal IDs only/,
+  );
+}
+
+function testPreviewRejectsUnsafeCheckedProposalData() {
+  assert.throws(
+    () => createPatchProposalPreview("unsafe", {
+      checkedPatchProposals: [unsafeProposal()],
+    }),
+    /relative to the repository/,
+  );
+}
+
+function testPreviewFormattingIsDeterministic() {
+  const proposal = findCheckedPatchProposalById("missingEndmodulePreview");
+  const first = formatPatchProposalPreview(proposal);
+  const second = formatPatchProposalPreview(proposal);
+
+  assert.equal(first, second);
+  assert.match(first, /validationPlan:/);
+  assert.match(first, /nonGoals:/);
+}
+
+testCheckedPreviewIsSummaryOnlyAndDoesNotApply();
+testCheckedProposalListingAndLookupValidateContract();
+testPreviewRejectsRawProposalObjects();
+testPreviewRejectsUnsafeCheckedProposalData();
+testPreviewFormattingIsDeterministic();
+
+console.log("vscode patch proposal preview tests ok");

--- a/editors/vscode-prototype/test/static-boundary.test.mjs
+++ b/editors/vscode-prototype/test/static-boundary.test.mjs
@@ -133,6 +133,7 @@ async function testProposalAndStatusModulesAreDataOnly() {
   const proposalAndStatusSource = await readCombined([
     resolve(EXTENSION_ROOT, "src/validation-proposals.mjs"),
     resolve(EXTENSION_ROOT, "src/patch-proposal-contract.mjs"),
+    resolve(EXTENSION_ROOT, "src/patch-proposal-preview.mjs"),
     resolve(EXTENSION_ROOT, "src/pccx-lab-status.mjs"),
   ]);
 

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -19,6 +19,7 @@ node editors/vscode-prototype/test/selected-symbol-context.test.mjs
 node editors/vscode-prototype/test/ai-assistant-boundary.test.mjs
 node editors/vscode-prototype/test/validation-proposals.test.mjs
 node editors/vscode-prototype/test/patch-proposal-contract.test.mjs
+node editors/vscode-prototype/test/patch-proposal-preview.test.mjs
 node editors/vscode-prototype/test/validation-result-summary.test.mjs
 node editors/vscode-prototype/test/validation-result-cache.test.mjs
 node editors/vscode-prototype/test/approved-validation-runner.test.mjs


### PR DESCRIPTION
## Summary
- Add a VS Code command to preview checked patch proposals without applying them.
- Add a clear command for the in-memory patch preview result.
- Extend static, manifest, entrypoint, adapter smoke, and opt-in Extension Host smoke coverage.

## Scope
- Adds pccxSystemVerilog.showPatchProposalPreview.
- Adds pccxSystemVerilog.clearPatchProposalPreview.
- Adds a checked in-memory patch proposal preview module and deterministic tests.

## Non-goals
- No patch application.
- No file writes.
- No raw proposal object input from the command path.
- No pccx-lab execution.
- No launcher calls.
- No AI provider calls.
- No MCP, LSP, marketplace, or packaging flow.

## Validation
- npm ci --prefix editors/vscode-prototype
- bash scripts/vscode-adapter-smoke.sh
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- python3 -m pytest -q
- git diff --check
- bash scripts/vscode-extension-host-smoke.sh exits 2 by default as expected
- PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh

## Safety notes
- Preview accepts checked proposal IDs only.
- The preview validates the patch proposal contract before display.
- Preview output is bounded proposal text; it does not modify files, execute commands, or call providers.

## Release/tag
No release or tag was created.

## FPGA repo
The FPGA repo was not touched.