### PR TITLE
feat(vscode): add validation-to-patch handoff contract

### DIFF
--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -151,6 +151,9 @@ editor/user-controlled executor accepts an allowlisted proposal ID.
 Patch proposals are also contract-only: they may describe reviewed edits
 with repository-relative paths and bounded hunk previews, but they do not
 apply changes or execute commands.
+Validation-to-patch handoff may create bounded context seeds from failed
+validation summaries and related diagnostics, but it does not create patch
+content for passing validation results and does not apply changes.
 Approved validation execution must use fixed argument arrays, bounded
 output, an explicit user-approved command invocation, and no shell
 interpolation.  pccx-lab command execution remains future/prepared in

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -310,6 +310,15 @@ proposals through VS Code-native output without applying changes, and
 `pccxSystemVerilog.clearPatchProposalPreview` clears only the in-memory
 preview state.
 
+`src/validation-patch-handoff.mjs` maps failed or blocked validation
+summaries into bounded patch proposal context seeds.  Passing validation
+summaries produce no seed.  The helper carries proposal ID, status,
+bounded failure summary, related diagnostics, candidate file paths, and a
+suggested approved validation plan without full logs, private paths,
+generated artifacts, shell commands, patch generation, or patch
+application.  The handoff notes are tracked in
+[`docs/validation-patch-handoff.md`](./docs/validation-patch-handoff.md).
+
 `pccxSystemVerilog.proposeValidationCommand` returns allowlisted
 validation command proposals as JSON data.  The proposal includes
 allowlisted proposal IDs, argument-array templates, reasons, risk levels, and
@@ -418,6 +427,7 @@ node editors/vscode-prototype/test/ai-assistant-boundary.test.mjs
 node editors/vscode-prototype/test/validation-proposals.test.mjs
 node editors/vscode-prototype/test/patch-proposal-contract.test.mjs
 node editors/vscode-prototype/test/patch-proposal-preview.test.mjs
+node editors/vscode-prototype/test/validation-patch-handoff.test.mjs
 node editors/vscode-prototype/test/validation-result-summary.test.mjs
 node editors/vscode-prototype/test/validation-result-cache.test.mjs
 node editors/vscode-prototype/test/approved-validation-runner.test.mjs

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -144,6 +144,9 @@ or committing changes.
 `pccxSystemVerilog.showPatchProposalPreview` previews checked proposal IDs
 only, and `pccxSystemVerilog.clearPatchProposalPreview` clears the
 in-memory preview state without file writes.
+The validation-to-patch handoff helper is a bounded context seed only; it
+does not generate a patch for passing validation results and does not
+apply changes.
 
 `pccxSystemVerilog.proposeValidationCommand` currently proposes only
 allowlisted templates, including the VS Code adapter smoke, editor bridge

--- a/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
+++ b/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
@@ -197,6 +197,12 @@ not apply changes.  The preview command shows checked proposal IDs only
 through VS Code-native output and the clear command removes only the
 in-memory preview result.
 
+Validation-to-patch handoff is also contract-only.  Failed or blocked
+validation summaries can produce a bounded context seed with related
+diagnostics, candidate files, and an approved validation plan.  Passing
+validation summaries produce no seed, and the helper does not generate or
+apply patches.
+
 ## Prototype Daily-Driver Loop
 
 1. Inspect diagnostics and navigation.
@@ -218,6 +224,7 @@ Now:
 - selected-symbol context
 - validation command proposal
 - patch proposal contract
+- validation-to-patch handoff contract
 - approved validation runner boundary
 - validation summary in the context bundle
 - validation cache status command

--- a/editors/vscode-prototype/docs/validation-patch-handoff.md
+++ b/editors/vscode-prototype/docs/validation-patch-handoff.md
@@ -1,0 +1,65 @@
+# Validation Patch Handoff
+
+This document describes the deterministic handoff from a validation summary
+to a patch proposal context seed.  It is contract-only: it does not generate
+patches, apply patches, write files, call pccx-lab, call pccx-llm-launcher,
+call a provider, implement MCP, or implement LSP.
+
+## Seed Shape
+
+```json
+{
+  "version": "pccx.validationPatchHandoff.v0",
+  "kind": "validation-patch-context-seed",
+  "validationProposalId": "vscodeAdapterSmoke",
+  "validationStatus": "failed",
+  "boundedFailureSummary": "VS Code adapter smoke failed (exit 1)",
+  "relatedDiagnostics": [
+    {
+      "path": "rtl/top.sv",
+      "range": {
+        "start": { "line": 0, "character": 0 },
+        "end": { "line": 0, "character": 6 }
+      },
+      "severity": "Error",
+      "message": "missing endmodule",
+      "source": "pccx_ide_cli",
+      "code": "PCCX-SCAFFOLD-003"
+    }
+  ],
+  "candidateFiles": ["rtl/top.sv"],
+  "suggestedValidationPlan": [
+    "Re-run vscodeAdapterSmoke through the approved validation proposal after user-reviewed changes."
+  ],
+  "safety": {
+    "summaryOnly": true,
+    "fullLogsExcluded": true,
+    "generatesPatch": false,
+    "appliesPatch": false,
+    "writesFiles": false,
+    "providerCalls": false,
+    "runtimeCalls": false,
+    "launcherCalls": false,
+    "pccxLabExecution": false
+  }
+}
+```
+
+## Rules
+
+- Failed or blocked validation summaries may produce a bounded context seed.
+- Passing validation summaries produce no seed.
+- Full stdout/stderr logs are not included.
+- Private home paths and secret-like assignment lines are redacted.
+- Candidate files are repository-relative and come only from explicit
+  context or bounded diagnostics.
+- Dependency caches, private instruction paths, generated outputs,
+  lockfiles, and secret-like paths are excluded.
+- The handoff suggests validation only through approved validation proposal
+  wording; it does not embed shell commands.
+
+## Implementation
+
+`src/validation-patch-handoff.mjs` implements the helper and
+`test/validation-patch-handoff.test.mjs` covers failure seeds, passing
+validation behavior, redaction, bounds, and contract-only safety flags.

--- a/editors/vscode-prototype/src/validation-patch-handoff.mjs
+++ b/editors/vscode-prototype/src/validation-patch-handoff.mjs
@@ -1,0 +1,262 @@
+import { isAbsolute, relative } from "node:path";
+
+export const VALIDATION_PATCH_HANDOFF_VERSION = "pccx.validationPatchHandoff.v0";
+
+export const VALIDATION_PATCH_HANDOFF_LIMITS = Object.freeze({
+  maxFailureSummaryCharacters: 800,
+  maxDiagnosticMessageCharacters: 300,
+  maxDiagnostics: 5,
+  maxCandidateFiles: 5,
+  maxValidationPlanItems: 5,
+});
+
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]/i;
+const SECRET_LIKE_PATTERN =
+  /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b/i;
+const HOME_PATH_PATTERN = /(?:\/home\/[^/\s]+|\/Users\/[^/\s]+)/g;
+const PRIVATE_PATH_PATTERN =
+  /(?:^|\/)(?:\.git|\.codex|\.vscode-test|node_modules|private[-_ ]?worker|worker[-_ ]?instruction|subagent[-_ ]?instruction)(?:\/|$)/i;
+const GENERATED_PATH_PATTERN =
+  /(?:^|\/)(?:dist|build|coverage|out|target|\.pytest_cache|__pycache__)(?:\/|$)/i;
+const GENERATED_FILE_PATTERN =
+  /(?:^|\/)(?:package-lock\.json|yarn\.lock|pnpm-lock\.yaml|AGENTS\.md)$/i;
+
+function mergeLimits(limits = {}) {
+  return {
+    ...VALIDATION_PATCH_HANDOFF_LIMITS,
+    ...Object.fromEntries(
+      Object.entries(limits).filter(([, value]) => Number.isInteger(value) && value >= 0),
+    ),
+  };
+}
+
+function finiteNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function scrubText(value, maxCharacters) {
+  if (typeof value !== "string" || value.length === 0 || maxCharacters === 0) {
+    return "";
+  }
+  return value
+    .split(/\r?\n/)
+    .map((line) => (SECRET_ASSIGNMENT_PATTERN.test(line) ? "[redacted]" : line))
+    .join("\n")
+    .replace(HOME_PATH_PATTERN, "[home]")
+    .slice(0, maxCharacters);
+}
+
+function normalizeWorkspacePath(workspaceRoot) {
+  if (typeof workspaceRoot !== "string" || workspaceRoot.trim().length === 0) {
+    return null;
+  }
+  return workspaceRoot.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function normalizePathRef(path, workspaceRoot = null) {
+  if (typeof path !== "string" || path.trim().length === 0) {
+    return null;
+  }
+  if (path.includes("\0") || path.includes("\n") || path.includes("\r")) {
+    return null;
+  }
+  let normalized = path.replace(/\\/g, "/").replace(/^\.\//, "");
+  const root = normalizeWorkspacePath(workspaceRoot);
+
+  if (isAbsolute(normalized)) {
+    if (!root) {
+      return null;
+    }
+    const rel = relative(root, normalized).replace(/\\/g, "/");
+    if (rel.startsWith("../") || rel === ".." || isAbsolute(rel)) {
+      return null;
+    }
+    normalized = rel;
+  }
+
+  if (
+    normalized === "" ||
+    normalized === "." ||
+    normalized === ".." ||
+    normalized.startsWith("../") ||
+    normalized.includes("/../") ||
+    PRIVATE_PATH_PATTERN.test(normalized) ||
+    GENERATED_PATH_PATTERN.test(normalized) ||
+    GENERATED_FILE_PATTERN.test(normalized) ||
+    SECRET_LIKE_PATTERN.test(normalized)
+  ) {
+    return null;
+  }
+  return normalized;
+}
+
+function normalizeRange(range) {
+  if (!range || typeof range !== "object") {
+    return null;
+  }
+  const start = {
+    line: Math.max(0, Math.floor(finiteNumber(range.start?.line))),
+    character: Math.max(0, Math.floor(finiteNumber(range.start?.character))),
+  };
+  const end = {
+    line: Math.max(0, Math.floor(finiteNumber(range.end?.line))),
+    character: Math.max(0, Math.floor(finiteNumber(range.end?.character))),
+  };
+  if (
+    end.line < start.line ||
+    (end.line === start.line && end.character < start.character)
+  ) {
+    return { start, end: { ...start } };
+  }
+  return { start, end };
+}
+
+function normalizeDiagnostic(diagnostic, workspaceRoot, limits) {
+  const path = normalizePathRef(diagnostic?.path ?? diagnostic?.file, workspaceRoot);
+  if (!path) {
+    return null;
+  }
+  return {
+    path,
+    range: normalizeRange(diagnostic.range),
+    severity: scrubText(diagnostic.severity ?? "Information", 80),
+    message: scrubText(diagnostic.message ?? "", limits.maxDiagnosticMessageCharacters),
+    source: scrubText(diagnostic.source ?? "", 120),
+    code: scrubText(diagnostic.code ?? "", 120),
+  };
+}
+
+function sortedByPathAndMessage(items) {
+  return [...items].sort((a, b) => {
+    const pathOrder = String(a.path ?? "").localeCompare(String(b.path ?? ""));
+    if (pathOrder !== 0) {
+      return pathOrder;
+    }
+    return String(a.message ?? "").localeCompare(String(b.message ?? ""));
+  });
+}
+
+function outputLines(summary) {
+  return Array.isArray(summary?.lines) ? summary.lines : [];
+}
+
+function failureSummary(validation, limits) {
+  const sourceLines = [
+    validation.summaryText ?? validation.summary ?? "",
+    ...(Array.isArray(validation.failureHints) ? validation.failureHints : []),
+    ...outputLines(validation.stderrSummary),
+    ...outputLines(validation.stdoutSummary).filter((line) => (
+      /error|failed|failure|traceback|timed out|timeout|blocked/i.test(String(line ?? ""))
+    )),
+  ].filter(Boolean);
+  const text = sourceLines.join("\n");
+  return scrubText(text, limits.maxFailureSummaryCharacters);
+}
+
+function suggestedValidationPlan(validation) {
+  const proposalId = typeof validation?.proposalId === "string" && validation.proposalId
+    ? validation.proposalId
+    : "";
+  if (!proposalId) {
+    return ["Re-run the relevant approved validation proposal after user-reviewed changes."];
+  }
+  return [`Re-run ${proposalId} through the approved validation proposal after user-reviewed changes.`];
+}
+
+function candidateFilesFromDiagnostics(diagnostics, limits) {
+  const seen = new Set();
+  const files = [];
+  for (const diagnostic of diagnostics) {
+    if (!seen.has(diagnostic.path)) {
+      seen.add(diagnostic.path);
+      files.push(diagnostic.path);
+    }
+    if (files.length >= limits.maxCandidateFiles) {
+      break;
+    }
+  }
+  return files;
+}
+
+function statusAllowsHandoff(status) {
+  return status !== "passed" && status !== "ok" && status !== "success";
+}
+
+export function createValidationPatchHandoffSeed(validation = {}, context = {}, options = {}) {
+  const status = typeof validation?.status === "string" && validation.status
+    ? validation.status
+    : "unknown";
+  if (!statusAllowsHandoff(status)) {
+    return null;
+  }
+
+  const limits = mergeLimits(options.limits);
+  const workspaceRoot = options.workspaceRoot ?? context.workspaceRoot ?? null;
+  const relatedDiagnostics = sortedByPathAndMessage(
+    (Array.isArray(context.relatedDiagnostics)
+      ? context.relatedDiagnostics
+      : Array.isArray(context.diagnostics)
+        ? context.diagnostics
+        : [])
+      .map((diagnostic) => normalizeDiagnostic(diagnostic, workspaceRoot, limits))
+      .filter(Boolean),
+  ).slice(0, limits.maxDiagnostics);
+  const explicitCandidateFiles = Array.isArray(context.candidateFiles)
+    ? context.candidateFiles
+      .map((path) => normalizePathRef(path, workspaceRoot))
+      .filter(Boolean)
+    : [];
+  const candidateFiles = [
+    ...new Set([
+      ...explicitCandidateFiles,
+      ...candidateFilesFromDiagnostics(relatedDiagnostics, limits),
+    ]),
+  ].slice(0, limits.maxCandidateFiles);
+
+  return {
+    version: VALIDATION_PATCH_HANDOFF_VERSION,
+    kind: "validation-patch-context-seed",
+    validationProposalId: scrubText(validation.proposalId ?? "", 120),
+    validationStatus: scrubText(status, 80),
+    boundedFailureSummary: failureSummary(validation, limits),
+    relatedDiagnostics,
+    candidateFiles,
+    suggestedValidationPlan: suggestedValidationPlan(validation)
+      .map((item) => scrubText(item, 300))
+      .slice(0, limits.maxValidationPlanItems),
+    safety: {
+      summaryOnly: true,
+      fullLogsExcluded: true,
+      generatesPatch: false,
+      appliesPatch: false,
+      writesFiles: false,
+      providerCalls: false,
+      runtimeCalls: false,
+      launcherCalls: false,
+      pccxLabExecution: false,
+    },
+    sourceFlags: {
+      validationRedactionApplied: validation.redactionApplied === true,
+      validationTruncated: validation.truncated === true ||
+        validation.stdoutSummary?.truncated === true ||
+        validation.stderrSummary?.truncated === true,
+    },
+  };
+}
+
+export function createValidationPatchHandoffStatus() {
+  return {
+    version: VALIDATION_PATCH_HANDOFF_VERSION,
+    proposalOnly: true,
+    contextSeedOnly: true,
+    generatesPatch: false,
+    appliesPatch: false,
+    writesFiles: false,
+    providerCalls: false,
+    runtimeCalls: false,
+    launcherCalls: false,
+    pccxLabExecution: false,
+  };
+}

--- a/editors/vscode-prototype/test/extension-host-readiness.test.mjs
+++ b/editors/vscode-prototype/test/extension-host-readiness.test.mjs
@@ -114,6 +114,7 @@ async function testReadinessDocsAndCiPolicy() {
   assert.match(`${readme}\n${readiness}`, /context bundle command/i);
   assert.match(`${readme}\n${readiness}`, /validation command proposal/i);
   assert.match(`${readme}\n${readiness}`, /patch proposal contract/i);
+  assert.match(`${readme}\n${readiness}`, /validation-to-patch handoff/i);
   assert.match(`${readme}\n${readiness}`, /pccx-lab backend status/i);
   assert.match(`${readme}\n${readiness}`, /AI assistant .*boundary/i);
   assert.match(`${readme}\n${readiness}`, /pccx-llm-launcher .*future local LLM\/chat backend/i);

--- a/editors/vscode-prototype/test/extension-manifest.test.mjs
+++ b/editors/vscode-prototype/test/extension-manifest.test.mjs
@@ -122,6 +122,7 @@ async function testDocsKeepExperimentalScope() {
   assert.match(combined, /AI assistant status command/i);
   assert.match(combined, /validation command proposal/i);
   assert.match(combined, /patch proposal contract/i);
+  assert.match(combined, /validation-to-patch handoff/i);
   assert.match(combined, /approved validation runner/i);
   assert.match(combined, /allowlisted proposal IDs/i);
   assert.match(combined, /pccx-lab backend status/i);

--- a/editors/vscode-prototype/test/static-boundary.test.mjs
+++ b/editors/vscode-prototype/test/static-boundary.test.mjs
@@ -134,6 +134,7 @@ async function testProposalAndStatusModulesAreDataOnly() {
     resolve(EXTENSION_ROOT, "src/validation-proposals.mjs"),
     resolve(EXTENSION_ROOT, "src/patch-proposal-contract.mjs"),
     resolve(EXTENSION_ROOT, "src/patch-proposal-preview.mjs"),
+    resolve(EXTENSION_ROOT, "src/validation-patch-handoff.mjs"),
     resolve(EXTENSION_ROOT, "src/pccx-lab-status.mjs"),
   ]);
 

--- a/editors/vscode-prototype/test/validation-patch-handoff.test.mjs
+++ b/editors/vscode-prototype/test/validation-patch-handoff.test.mjs
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+
+import {
+  VALIDATION_PATCH_HANDOFF_VERSION,
+  createValidationPatchHandoffSeed,
+  createValidationPatchHandoffStatus,
+} from "../src/validation-patch-handoff.mjs";
+
+function failedValidation(overrides = {}) {
+  return {
+    proposalId: "vscodeAdapterSmoke",
+    status: "failed",
+    summaryText: "VS Code adapter smoke failed (exit 1)",
+    stdoutSummary: {
+      lines: ["adapter ok", "TOKEN=hidden", "error: missing endmodule"],
+      lineCount: 3,
+      truncated: false,
+    },
+    stderrSummary: {
+      lines: ["/home/dev/repo/rtl/top.sv:1: failure"],
+      lineCount: 1,
+      truncated: false,
+    },
+    failureHints: ["TOKEN=hidden", "failure: missing endmodule"],
+    truncated: false,
+    redactionApplied: false,
+    ...overrides,
+  };
+}
+
+function testFailedValidationCreatesBoundedContextSeed() {
+  const seed = createValidationPatchHandoffSeed(
+    failedValidation(),
+    {
+      workspaceRoot: "/repo",
+      relatedDiagnostics: [
+        {
+          file: "/repo/rtl/top.sv",
+          severity: "Error",
+          message: "missing endmodule",
+          source: "pccx_ide_cli",
+          code: "PCCX-SCAFFOLD-003",
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 6 },
+          },
+        },
+      ],
+    },
+    { workspaceRoot: "/repo" },
+  );
+  const serialized = JSON.stringify(seed);
+
+  assert.equal(seed.version, VALIDATION_PATCH_HANDOFF_VERSION);
+  assert.equal(seed.kind, "validation-patch-context-seed");
+  assert.equal(seed.validationProposalId, "vscodeAdapterSmoke");
+  assert.equal(seed.validationStatus, "failed");
+  assert.match(seed.boundedFailureSummary, /VS Code adapter smoke failed/);
+  assert.match(seed.boundedFailureSummary, /\[redacted\]/);
+  assert.match(seed.boundedFailureSummary, /\[home\]/);
+  assert.deepEqual(seed.candidateFiles, ["rtl/top.sv"]);
+  assert.equal(seed.relatedDiagnostics.length, 1);
+  assert.equal(seed.relatedDiagnostics[0].path, "rtl/top.sv");
+  assert.equal(seed.relatedDiagnostics[0].message, "missing endmodule");
+  assert.deepEqual(seed.suggestedValidationPlan, [
+    "Re-run vscodeAdapterSmoke through the approved validation proposal after user-reviewed changes.",
+  ]);
+  assert.equal(seed.safety.summaryOnly, true);
+  assert.equal(seed.safety.fullLogsExcluded, true);
+  assert.equal(seed.safety.generatesPatch, false);
+  assert.equal(seed.safety.appliesPatch, false);
+  assert.equal(seed.safety.providerCalls, false);
+  assert.equal(seed.safety.pccxLabExecution, false);
+  assert.doesNotMatch(serialized, /TOKEN=hidden/);
+  assert.doesNotMatch(serialized, /\/home\/dev/);
+}
+
+function testPassingValidationDoesNotCreateFakeFixSeed() {
+  const seed = createValidationPatchHandoffSeed({
+    proposalId: "pytestBaseline",
+    status: "passed",
+    summaryText: "pytest baseline passed",
+  });
+
+  assert.equal(seed, null);
+}
+
+function testHandoffBoundsDiagnosticsAndExcludesUnsafePaths() {
+  const diagnostics = [
+    { file: "/repo/rtl/z.sv", message: "z" },
+    { file: "/repo/node_modules/pkg/ignored.sv", message: "ignored" },
+    { file: "/repo/.codex/private.md", message: "ignored" },
+    { file: "/home/dev/outside.sv", message: "outside" },
+    { file: "/repo/rtl/a.sv", message: "a" },
+    { file: "/repo/rtl/b.sv", message: "b" },
+  ];
+  const seed = createValidationPatchHandoffSeed(
+    failedValidation({
+      summaryText: "x".repeat(120),
+      stdoutSummary: { lines: ["error " + "y".repeat(120)], lineCount: 1, truncated: true },
+      stderrSummary: { lines: [], lineCount: 0, truncated: false },
+      truncated: true,
+    }),
+    {
+      workspaceRoot: "/repo",
+      relatedDiagnostics: diagnostics,
+      candidateFiles: [
+        "/repo/rtl/explicit.sv",
+        "/repo/package-lock.json",
+        "/repo/rtl/api-token.sv",
+      ],
+    },
+    {
+      workspaceRoot: "/repo",
+      limits: {
+        maxFailureSummaryCharacters: 40,
+        maxDiagnostics: 2,
+        maxCandidateFiles: 2,
+      },
+    },
+  );
+  const serialized = JSON.stringify(seed);
+
+  assert.ok(seed.boundedFailureSummary.length <= 40);
+  assert.deepEqual(seed.relatedDiagnostics.map((diagnostic) => diagnostic.path), [
+    "rtl/a.sv",
+    "rtl/b.sv",
+  ]);
+  assert.deepEqual(seed.candidateFiles, ["rtl/explicit.sv", "rtl/a.sv"]);
+  assert.equal(seed.sourceFlags.validationTruncated, true);
+  assert.doesNotMatch(serialized, /package-lock\.json/);
+  assert.doesNotMatch(serialized, /api-token/);
+  assert.doesNotMatch(serialized, /node_modules/);
+  assert.doesNotMatch(serialized, /\.codex/);
+  assert.doesNotMatch(serialized, /\/home\/dev/);
+}
+
+function testHandoffStatusIsContractOnly() {
+  const status = createValidationPatchHandoffStatus();
+
+  assert.equal(status.version, VALIDATION_PATCH_HANDOFF_VERSION);
+  assert.equal(status.proposalOnly, true);
+  assert.equal(status.contextSeedOnly, true);
+  assert.equal(status.generatesPatch, false);
+  assert.equal(status.appliesPatch, false);
+  assert.equal(status.writesFiles, false);
+  assert.equal(status.providerCalls, false);
+  assert.equal(status.runtimeCalls, false);
+  assert.equal(status.launcherCalls, false);
+  assert.equal(status.pccxLabExecution, false);
+}
+
+testFailedValidationCreatesBoundedContextSeed();
+testPassingValidationDoesNotCreateFakeFixSeed();
+testHandoffBoundsDiagnosticsAndExcludesUnsafePaths();
+testHandoffStatusIsContractOnly();
+
+console.log("vscode validation patch handoff tests ok");

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -20,6 +20,7 @@ node editors/vscode-prototype/test/ai-assistant-boundary.test.mjs
 node editors/vscode-prototype/test/validation-proposals.test.mjs
 node editors/vscode-prototype/test/patch-proposal-contract.test.mjs
 node editors/vscode-prototype/test/patch-proposal-preview.test.mjs
+node editors/vscode-prototype/test/validation-patch-handoff.test.mjs
 node editors/vscode-prototype/test/validation-result-summary.test.mjs
 node editors/vscode-prototype/test/validation-result-cache.test.mjs
 node editors/vscode-prototype/test/approved-validation-runner.test.mjs


### PR DESCRIPTION
## Summary
- Add a deterministic validation-to-patch context seed helper.
- Document the contract-only handoff from failed validation summaries to bounded patch context.
- Add tests for passing validation, redaction, bounds, candidate files, diagnostics, and safety flags.

## Scope
- Adds editors/vscode-prototype/src/validation-patch-handoff.mjs.
- Adds docs/validation-patch-handoff.md and related README/boundary references.
- Includes the new handoff test in the VS Code adapter smoke path.

## Non-goals
- No patch generation.
- No patch application.
- No file writes.
- No pccx-lab execution.
- No launcher calls.
- No AI provider calls.
- No MCP, LSP, marketplace, or packaging flow.

## Validation
- npm ci --prefix editors/vscode-prototype
- bash scripts/vscode-adapter-smoke.sh
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- python3 -m pytest -q
- git diff --check
- bash scripts/vscode-extension-host-smoke.sh exits 2 by default as expected
- PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh

## Safety notes
- Passing validation summaries produce no fake fix seed.
- Failed/blocked summaries produce only bounded context seeds.
- Full logs, private paths, secret-like data, generated paths, and unsafe candidate files are excluded or redacted.

## Release/tag
No release or tag was created.

## FPGA repo
The FPGA repo was not touched.