### PR TITLE
feat(vscode): define pccx-lab command descriptor contract

### DIFF
--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -154,6 +154,8 @@ apply changes or execute commands.
 Validation-to-patch handoff may create bounded context seeds from failed
 validation summaries and related diagnostics, but it does not create patch
 content for passing validation results and does not apply changes.
+pccx-lab command descriptors are data-only preparation for a future
+CLI/core boundary and do not execute pccx-lab.
 Approved validation execution must use fixed argument arrays, bounded
 output, an explicit user-approved command invocation, and no shell
 interpolation.  pccx-lab command execution remains future/prepared in

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -319,6 +319,15 @@ generated artifacts, shell commands, patch generation, or patch
 application.  The handoff notes are tracked in
 [`docs/validation-patch-handoff.md`](./docs/validation-patch-handoff.md).
 
+`src/pccx-lab-command-descriptor.mjs` defines a data-only pccx-lab command
+descriptor contract.  The checked descriptor is `labStatus` with
+`executionState: "future"`, fixed empty args, explicit approval required,
+and bounded output policy.  The contract rejects raw command strings,
+unsafe args, private paths, secrets, and output policies that do not redact
+or drop private paths.  It does not execute pccx-lab.  The boundary notes
+are tracked in
+[`docs/pccx-lab-command-boundary.md`](./docs/pccx-lab-command-boundary.md).
+
 `pccxSystemVerilog.proposeValidationCommand` returns allowlisted
 validation command proposals as JSON data.  The proposal includes
 allowlisted proposal IDs, argument-array templates, reasons, risk levels, and
@@ -428,6 +437,7 @@ node editors/vscode-prototype/test/validation-proposals.test.mjs
 node editors/vscode-prototype/test/patch-proposal-contract.test.mjs
 node editors/vscode-prototype/test/patch-proposal-preview.test.mjs
 node editors/vscode-prototype/test/validation-patch-handoff.test.mjs
+node editors/vscode-prototype/test/pccx-lab-command-descriptor.test.mjs
 node editors/vscode-prototype/test/validation-result-summary.test.mjs
 node editors/vscode-prototype/test/validation-result-cache.test.mjs
 node editors/vscode-prototype/test/approved-validation-runner.test.mjs

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -147,6 +147,8 @@ in-memory preview state without file writes.
 The validation-to-patch handoff helper is a bounded context seed only; it
 does not generate a patch for passing validation results and does not
 apply changes.
+The pccx-lab command descriptor contract is data-only future-state
+preparation and does not execute pccx-lab.
 
 `pccxSystemVerilog.proposeValidationCommand` currently proposes only
 allowlisted templates, including the VS Code adapter smoke, editor bridge

--- a/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
+++ b/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
@@ -203,6 +203,10 @@ diagnostics, candidate files, and an approved validation plan.  Passing
 validation summaries produce no seed, and the helper does not generate or
 apply patches.
 
+pccx-lab command descriptors are data-only.  The checked status descriptor
+is future-state preparation for a reviewed CLI/core boundary; it has no
+executable field and does not run pccx-lab.
+
 ## Prototype Daily-Driver Loop
 
 1. Inspect diagnostics and navigation.
@@ -225,6 +229,7 @@ Now:
 - validation command proposal
 - patch proposal contract
 - validation-to-patch handoff contract
+- pccx-lab command descriptor contract
 - approved validation runner boundary
 - validation summary in the context bundle
 - validation cache status command

--- a/editors/vscode-prototype/docs/pccx-lab-command-boundary.md
+++ b/editors/vscode-prototype/docs/pccx-lab-command-boundary.md
@@ -1,0 +1,53 @@
+# pccx-lab Command Boundary
+
+This document defines a pccx-lab command descriptor contract for the
+experimental local VS Code prototype.  It is data-only and does not execute
+pccx-lab, spawn a process, call a launcher, call a provider, implement MCP,
+or implement LSP.
+
+## Descriptor Shape
+
+```json
+{
+  "version": 1,
+  "descriptorId": "labStatus",
+  "label": "pccx-lab backend status",
+  "category": "status",
+  "executionState": "future",
+  "args": [],
+  "workingDirectoryPolicy": "repo-root",
+  "outputPolicy": {
+    "maxLines": 120,
+    "redactSecrets": true,
+    "dropPrivatePaths": true
+  },
+  "requiresExplicitApproval": true
+}
+```
+
+## Rules
+
+- `category` is `status`, `diagnostics`, `trace`, or `verification`.
+- `executionState` is `future`, `disabled`, or `allowlisted`.
+- `workingDirectoryPolicy` is `repo-root`, `workspace-root`, or `configured`.
+- `requiresExplicitApproval` must be `true`.
+- `args` are fixed argument items only and must not include raw shell command
+  text, shell control syntax, secrets, or private home paths.
+- `outputPolicy.redactSecrets` and `outputPolicy.dropPrivatePaths` must both
+  be `true`.
+- The descriptor has no executable, raw command string, environment variable,
+  or runtime output fields.
+
+## Current Status
+
+The checked descriptor is `labStatus` with `executionState: "future"`.
+It is preparation for a reviewed pccx-lab CLI/core boundary and is not a
+runtime integration.  Any later execution path must be disabled by default,
+allowlisted, fixed-argument, explicitly approved, bounded, and reviewed in a
+separate PR.
+
+## Validation
+
+`src/pccx-lab-command-descriptor.mjs` implements the contract and
+`test/pccx-lab-command-descriptor.test.mjs` covers safe descriptor data,
+unsafe field rejection, output policy bounds, and no-execution status.

--- a/editors/vscode-prototype/src/pccx-lab-command-descriptor.mjs
+++ b/editors/vscode-prototype/src/pccx-lab-command-descriptor.mjs
@@ -1,0 +1,223 @@
+export const PCCX_LAB_COMMAND_DESCRIPTOR_VERSION = "pccx.pccxLabCommandDescriptor.v0";
+export const PCCX_LAB_COMMAND_DESCRIPTOR_SCHEMA_VERSION = 1;
+
+export const PCCX_LAB_COMMAND_CATEGORIES = Object.freeze([
+  "status",
+  "diagnostics",
+  "trace",
+  "verification",
+]);
+
+export const PCCX_LAB_COMMAND_EXECUTION_STATES = Object.freeze([
+  "future",
+  "disabled",
+  "allowlisted",
+]);
+
+export const PCCX_LAB_WORKING_DIRECTORY_POLICIES = Object.freeze([
+  "repo-root",
+  "workspace-root",
+  "configured",
+]);
+
+const DESCRIPTOR_KEYS = new Set([
+  "version",
+  "descriptorId",
+  "label",
+  "category",
+  "executionState",
+  "args",
+  "workingDirectoryPolicy",
+  "outputPolicy",
+  "requiresExplicitApproval",
+]);
+
+const OUTPUT_POLICY_KEYS = new Set([
+  "maxLines",
+  "redactSecrets",
+  "dropPrivatePaths",
+]);
+
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]/i;
+const HOME_PATH_PATTERN = /(?:\/home\/[^/\s]+|\/Users\/[^/\s]+)/;
+const SHELL_CONTROL_PATTERN = /(?:&&|\|\||;|`|\$\(|>|<)/;
+const RAW_SHELL_COMMAND_PATTERN =
+  /\b(?:bash|sh|zsh|fish|python|python3|node|npm|pnpm|yarn|git|gh|rm|mv|cp|curl|wget|make)\s+[^\n]+/i;
+
+const DEFAULT_DESCRIPTORS = Object.freeze([
+  Object.freeze({
+    version: PCCX_LAB_COMMAND_DESCRIPTOR_SCHEMA_VERSION,
+    descriptorId: "labStatus",
+    label: "pccx-lab backend status",
+    category: "status",
+    executionState: "future",
+    args: Object.freeze([]),
+    workingDirectoryPolicy: "repo-root",
+    outputPolicy: Object.freeze({
+      maxLines: 120,
+      redactSecrets: true,
+      dropPrivatePaths: true,
+    }),
+    requiresExplicitApproval: true,
+  }),
+]);
+
+function addError(errors, path, message) {
+  errors.push(`${path}: ${message}`);
+}
+
+function unknownKeys(value, allowedKeys) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return [];
+  }
+  return Object.keys(value).filter((key) => !allowedKeys.has(key));
+}
+
+function boundedString(value, path, errors, maxCharacters) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    addError(errors, path, "must be a non-empty string");
+    return "";
+  }
+  if (value.length > maxCharacters || value.includes("\0") || value.includes("\n") || value.includes("\r")) {
+    addError(errors, path, `must be a single-line string up to ${maxCharacters} characters`);
+  }
+  if (
+    SECRET_ASSIGNMENT_PATTERN.test(value) ||
+    HOME_PATH_PATTERN.test(value) ||
+    SHELL_CONTROL_PATTERN.test(value) ||
+    RAW_SHELL_COMMAND_PATTERN.test(value)
+  ) {
+    addError(errors, path, "must not include secrets, private paths, or shell command text");
+  }
+  return value;
+}
+
+function boundedArgs(args, errors) {
+  if (!Array.isArray(args)) {
+    addError(errors, "args", "must be an array");
+    return [];
+  }
+  if (args.length > 12) {
+    addError(errors, "args", "must contain at most 12 fixed argument item(s)");
+  }
+  return args.slice(0, 12).map((arg, index) => (
+    boundedString(arg, `args[${index}]`, errors, 160)
+  ));
+}
+
+function normalizeOutputPolicy(policy, errors) {
+  if (!policy || typeof policy !== "object" || Array.isArray(policy)) {
+    addError(errors, "outputPolicy", "must be an object");
+    return {
+      maxLines: 120,
+      redactSecrets: true,
+      dropPrivatePaths: true,
+    };
+  }
+  for (const key of unknownKeys(policy, OUTPUT_POLICY_KEYS)) {
+    addError(errors, `outputPolicy.${key}`, "is not allowed in pccx-lab command descriptors");
+  }
+  const maxLines = Number.isInteger(policy.maxLines) ? policy.maxLines : 120;
+  if (maxLines < 1 || maxLines > 500) {
+    addError(errors, "outputPolicy.maxLines", "must be between 1 and 500");
+  }
+  if (policy.redactSecrets !== true) {
+    addError(errors, "outputPolicy.redactSecrets", "must be true");
+  }
+  if (policy.dropPrivatePaths !== true) {
+    addError(errors, "outputPolicy.dropPrivatePaths", "must be true");
+  }
+  return {
+    maxLines: Math.min(500, Math.max(1, maxLines)),
+    redactSecrets: true,
+    dropPrivatePaths: true,
+  };
+}
+
+export function normalizePccxLabCommandDescriptor(descriptor = {}) {
+  const errors = [];
+  if (!descriptor || typeof descriptor !== "object" || Array.isArray(descriptor)) {
+    throw new Error("pccx-lab command descriptor must be an object");
+  }
+  for (const key of unknownKeys(descriptor, DESCRIPTOR_KEYS)) {
+    addError(errors, key, "is not allowed in pccx-lab command descriptors");
+  }
+  if (descriptor.version !== PCCX_LAB_COMMAND_DESCRIPTOR_SCHEMA_VERSION) {
+    addError(errors, "version", `must be ${PCCX_LAB_COMMAND_DESCRIPTOR_SCHEMA_VERSION}`);
+  }
+  if (!PCCX_LAB_COMMAND_CATEGORIES.includes(descriptor.category)) {
+    addError(errors, "category", `must be one of: ${PCCX_LAB_COMMAND_CATEGORIES.join(", ")}`);
+  }
+  if (!PCCX_LAB_COMMAND_EXECUTION_STATES.includes(descriptor.executionState)) {
+    addError(errors, "executionState", `must be one of: ${PCCX_LAB_COMMAND_EXECUTION_STATES.join(", ")}`);
+  }
+  if (!PCCX_LAB_WORKING_DIRECTORY_POLICIES.includes(descriptor.workingDirectoryPolicy)) {
+    addError(
+      errors,
+      "workingDirectoryPolicy",
+      `must be one of: ${PCCX_LAB_WORKING_DIRECTORY_POLICIES.join(", ")}`,
+    );
+  }
+  if (descriptor.requiresExplicitApproval !== true) {
+    addError(errors, "requiresExplicitApproval", "must be true");
+  }
+
+  const normalized = {
+    version: PCCX_LAB_COMMAND_DESCRIPTOR_SCHEMA_VERSION,
+    descriptorId: boundedString(descriptor.descriptorId ?? "", "descriptorId", errors, 120),
+    label: boundedString(descriptor.label ?? "", "label", errors, 160),
+    category: PCCX_LAB_COMMAND_CATEGORIES.includes(descriptor.category)
+      ? descriptor.category
+      : "status",
+    executionState: PCCX_LAB_COMMAND_EXECUTION_STATES.includes(descriptor.executionState)
+      ? descriptor.executionState
+      : "future",
+    args: boundedArgs(descriptor.args, errors),
+    workingDirectoryPolicy: PCCX_LAB_WORKING_DIRECTORY_POLICIES.includes(descriptor.workingDirectoryPolicy)
+      ? descriptor.workingDirectoryPolicy
+      : "repo-root",
+    outputPolicy: normalizeOutputPolicy(descriptor.outputPolicy, errors),
+    requiresExplicitApproval: true,
+  };
+
+  if (errors.length > 0) {
+    throw new Error(`invalid pccx-lab command descriptor: ${errors.join("; ")}`);
+  }
+  return normalized;
+}
+
+export function validatePccxLabCommandDescriptor(descriptor = {}) {
+  try {
+    return {
+      ok: true,
+      descriptor: normalizePccxLabCommandDescriptor(descriptor),
+      errors: [],
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      descriptor: null,
+      errors: error.message.replace(/^invalid pccx-lab command descriptor: /, "").split("; "),
+    };
+  }
+}
+
+export function listPccxLabCommandDescriptors() {
+  return DEFAULT_DESCRIPTORS.map((descriptor) => normalizePccxLabCommandDescriptor(descriptor));
+}
+
+export function createPccxLabCommandDescriptorStatus() {
+  return {
+    version: PCCX_LAB_COMMAND_DESCRIPTOR_VERSION,
+    schemaVersion: PCCX_LAB_COMMAND_DESCRIPTOR_SCHEMA_VERSION,
+    descriptorOnly: true,
+    executes: false,
+    backendCommandExecuted: false,
+    providerCalls: false,
+    runtimeCalls: false,
+    launcherCalls: false,
+    mcpCalls: false,
+    descriptors: listPccxLabCommandDescriptors(),
+  };
+}

--- a/editors/vscode-prototype/test/extension-host-readiness.test.mjs
+++ b/editors/vscode-prototype/test/extension-host-readiness.test.mjs
@@ -115,6 +115,7 @@ async function testReadinessDocsAndCiPolicy() {
   assert.match(`${readme}\n${readiness}`, /validation command proposal/i);
   assert.match(`${readme}\n${readiness}`, /patch proposal contract/i);
   assert.match(`${readme}\n${readiness}`, /validation-to-patch handoff/i);
+  assert.match(`${readme}\n${readiness}`, /pccx-lab command descriptor contract/i);
   assert.match(`${readme}\n${readiness}`, /pccx-lab backend status/i);
   assert.match(`${readme}\n${readiness}`, /AI assistant .*boundary/i);
   assert.match(`${readme}\n${readiness}`, /pccx-llm-launcher .*future local LLM\/chat backend/i);

--- a/editors/vscode-prototype/test/extension-manifest.test.mjs
+++ b/editors/vscode-prototype/test/extension-manifest.test.mjs
@@ -123,6 +123,7 @@ async function testDocsKeepExperimentalScope() {
   assert.match(combined, /validation command proposal/i);
   assert.match(combined, /patch proposal contract/i);
   assert.match(combined, /validation-to-patch handoff/i);
+  assert.match(combined, /pccx-lab command\s+descriptor contract/i);
   assert.match(combined, /approved validation runner/i);
   assert.match(combined, /allowlisted proposal IDs/i);
   assert.match(combined, /pccx-lab backend status/i);

--- a/editors/vscode-prototype/test/pccx-lab-command-descriptor.test.mjs
+++ b/editors/vscode-prototype/test/pccx-lab-command-descriptor.test.mjs
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+
+import {
+  PCCX_LAB_COMMAND_CATEGORIES,
+  PCCX_LAB_COMMAND_DESCRIPTOR_SCHEMA_VERSION,
+  PCCX_LAB_COMMAND_DESCRIPTOR_VERSION,
+  PCCX_LAB_COMMAND_EXECUTION_STATES,
+  PCCX_LAB_WORKING_DIRECTORY_POLICIES,
+  createPccxLabCommandDescriptorStatus,
+  listPccxLabCommandDescriptors,
+  normalizePccxLabCommandDescriptor,
+  validatePccxLabCommandDescriptor,
+} from "../src/pccx-lab-command-descriptor.mjs";
+
+function descriptor(overrides = {}) {
+  return {
+    version: PCCX_LAB_COMMAND_DESCRIPTOR_SCHEMA_VERSION,
+    descriptorId: "labStatus",
+    label: "pccx-lab backend status",
+    category: "status",
+    executionState: "future",
+    args: [],
+    workingDirectoryPolicy: "repo-root",
+    outputPolicy: {
+      maxLines: 120,
+      redactSecrets: true,
+      dropPrivatePaths: true,
+    },
+    requiresExplicitApproval: true,
+    ...overrides,
+  };
+}
+
+function assertInvalid(value, pattern) {
+  const result = validatePccxLabCommandDescriptor(value);
+
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), pattern);
+  assert.throws(() => normalizePccxLabCommandDescriptor(value), pattern);
+}
+
+function testDescriptorNormalizesSafeDataOnlyShape() {
+  const normalized = normalizePccxLabCommandDescriptor(descriptor());
+
+  assert.equal(normalized.version, 1);
+  assert.equal(normalized.descriptorId, "labStatus");
+  assert.equal(normalized.label, "pccx-lab backend status");
+  assert.equal(normalized.category, "status");
+  assert.equal(normalized.executionState, "future");
+  assert.deepEqual(normalized.args, []);
+  assert.equal(normalized.workingDirectoryPolicy, "repo-root");
+  assert.deepEqual(normalized.outputPolicy, {
+    maxLines: 120,
+    redactSecrets: true,
+    dropPrivatePaths: true,
+  });
+  assert.equal(normalized.requiresExplicitApproval, true);
+}
+
+function testStatusListsDefaultFutureDescriptorWithoutExecution() {
+  const status = createPccxLabCommandDescriptorStatus();
+  const descriptors = listPccxLabCommandDescriptors();
+
+  assert.equal(status.version, PCCX_LAB_COMMAND_DESCRIPTOR_VERSION);
+  assert.equal(status.schemaVersion, PCCX_LAB_COMMAND_DESCRIPTOR_SCHEMA_VERSION);
+  assert.equal(status.descriptorOnly, true);
+  assert.equal(status.executes, false);
+  assert.equal(status.backendCommandExecuted, false);
+  assert.equal(status.providerCalls, false);
+  assert.equal(status.runtimeCalls, false);
+  assert.equal(status.launcherCalls, false);
+  assert.equal(status.mcpCalls, false);
+  assert.deepEqual(status.descriptors, descriptors);
+  assert.equal(descriptors[0].descriptorId, "labStatus");
+  assert.equal(descriptors[0].executionState, "future");
+}
+
+function testAllowedEnumsAreExplicit() {
+  assert.deepEqual(PCCX_LAB_COMMAND_CATEGORIES, [
+    "status",
+    "diagnostics",
+    "trace",
+    "verification",
+  ]);
+  assert.deepEqual(PCCX_LAB_COMMAND_EXECUTION_STATES, [
+    "future",
+    "disabled",
+    "allowlisted",
+  ]);
+  assert.deepEqual(PCCX_LAB_WORKING_DIRECTORY_POLICIES, [
+    "repo-root",
+    "workspace-root",
+    "configured",
+  ]);
+}
+
+function testRejectsRawShellCommandAndUnsafeText() {
+  assertInvalid(
+    descriptor({ args: ["bash scripts/private.sh"] }),
+    /args\[0\]: must not include secrets, private paths, or shell command text/,
+  );
+  assertInvalid(
+    descriptor({ label: "/home/dev/private" }),
+    /label: must not include secrets, private paths, or shell command text/,
+  );
+  assertInvalid(
+    descriptor({ descriptorId: "token=hidden" }),
+    /descriptorId: must not include secrets, private paths, or shell command text/,
+  );
+}
+
+function testRejectsExecutionOrOutputPolicyEscapes() {
+  assertInvalid(
+    {
+      ...descriptor(),
+      command: "pccx-lab status",
+    },
+    /command: is not allowed/,
+  );
+  assertInvalid(
+    descriptor({ requiresExplicitApproval: false }),
+    /requiresExplicitApproval: must be true/,
+  );
+  assertInvalid(
+    descriptor({
+      outputPolicy: {
+        maxLines: 1000,
+        redactSecrets: true,
+        dropPrivatePaths: true,
+      },
+    }),
+    /outputPolicy\.maxLines: must be between 1 and 500/,
+  );
+  assertInvalid(
+    descriptor({
+      outputPolicy: {
+        maxLines: 120,
+        redactSecrets: false,
+        dropPrivatePaths: true,
+      },
+    }),
+    /outputPolicy\.redactSecrets: must be true/,
+  );
+}
+
+testDescriptorNormalizesSafeDataOnlyShape();
+testStatusListsDefaultFutureDescriptorWithoutExecution();
+testAllowedEnumsAreExplicit();
+testRejectsRawShellCommandAndUnsafeText();
+testRejectsExecutionOrOutputPolicyEscapes();
+
+console.log("vscode pccx-lab command descriptor tests ok");

--- a/editors/vscode-prototype/test/static-boundary.test.mjs
+++ b/editors/vscode-prototype/test/static-boundary.test.mjs
@@ -135,6 +135,7 @@ async function testProposalAndStatusModulesAreDataOnly() {
     resolve(EXTENSION_ROOT, "src/patch-proposal-contract.mjs"),
     resolve(EXTENSION_ROOT, "src/patch-proposal-preview.mjs"),
     resolve(EXTENSION_ROOT, "src/validation-patch-handoff.mjs"),
+    resolve(EXTENSION_ROOT, "src/pccx-lab-command-descriptor.mjs"),
     resolve(EXTENSION_ROOT, "src/pccx-lab-status.mjs"),
   ]);
 

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -21,6 +21,7 @@ node editors/vscode-prototype/test/validation-proposals.test.mjs
 node editors/vscode-prototype/test/patch-proposal-contract.test.mjs
 node editors/vscode-prototype/test/patch-proposal-preview.test.mjs
 node editors/vscode-prototype/test/validation-patch-handoff.test.mjs
+node editors/vscode-prototype/test/pccx-lab-command-descriptor.test.mjs
 node editors/vscode-prototype/test/validation-result-summary.test.mjs
 node editors/vscode-prototype/test/validation-result-cache.test.mjs
 node editors/vscode-prototype/test/approved-validation-runner.test.mjs


### PR DESCRIPTION
## Summary
- Add a data-only pccx-lab command descriptor contract.
- Document the future/disabled command boundary without execution.
- Add tests for descriptor shape, enum bounds, unsafe text rejection, output policy safety, and no-execution status.

## Scope
- Adds editors/vscode-prototype/src/pccx-lab-command-descriptor.mjs.
- Adds docs/pccx-lab-command-boundary.md and related README/boundary references.
- Includes the descriptor test in the VS Code adapter smoke path.

## Non-goals
- No pccx-lab execution.
- No executable or raw command string descriptor field.
- No arbitrary user args.
- No launcher calls.
- No AI provider calls.
- No MCP, LSP, marketplace, or packaging flow.

## Validation
- npm ci --prefix editors/vscode-prototype
- bash scripts/vscode-adapter-smoke.sh
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- python3 -m pytest -q
- git diff --check
- bash scripts/vscode-extension-host-smoke.sh exits 2 by default as expected
- PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh

## Safety notes
- Descriptors are data-only and currently future-state.
- Unsafe args, raw command text, private paths, secrets, unbounded output policy, and missing explicit approval are rejected.
- No backend command is executed.

## Release/tag
No release or tag was created.

## FPGA repo
The FPGA repo was not touched.