### PR TITLE
feat(vscode): define launcher status integration contract

### DIFF
--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -156,6 +156,9 @@ validation summaries and related diagnostics, but it does not create patch
 content for passing validation results and does not apply changes.
 pccx-lab command descriptors are data-only preparation for a future
 CLI/core boundary and do not execute pccx-lab.
+Launcher status contracts are also status-only and do not call
+pccx-llm-launcher, include model paths, include board logs, or make device
+performance claims.
 Approved validation execution must use fixed argument arrays, bounded
 output, an explicit user-approved command invocation, and no shell
 interpolation.  pccx-lab command execution remains future/prepared in

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -328,6 +328,14 @@ or drop private paths.  It does not execute pccx-lab.  The boundary notes
 are tracked in
 [`docs/pccx-lab-command-boundary.md`](./docs/pccx-lab-command-boundary.md).
 
+`src/launcher-status-contract.mjs` defines a status-only launcher
+integration contract for future pccx-llm-launcher work.  The default
+status is fixture-only and future-state, uses a deterministic timestamp,
+and rejects secrets, private paths, model artifacts, board logs, and board
+performance claims.  It does not call the launcher or communicate with a
+device.  The boundary notes are tracked in
+[`docs/launcher-integration-boundary.md`](./docs/launcher-integration-boundary.md).
+
 `pccxSystemVerilog.proposeValidationCommand` returns allowlisted
 validation command proposals as JSON data.  The proposal includes
 allowlisted proposal IDs, argument-array templates, reasons, risk levels, and
@@ -438,6 +446,7 @@ node editors/vscode-prototype/test/patch-proposal-contract.test.mjs
 node editors/vscode-prototype/test/patch-proposal-preview.test.mjs
 node editors/vscode-prototype/test/validation-patch-handoff.test.mjs
 node editors/vscode-prototype/test/pccx-lab-command-descriptor.test.mjs
+node editors/vscode-prototype/test/launcher-status-contract.test.mjs
 node editors/vscode-prototype/test/validation-result-summary.test.mjs
 node editors/vscode-prototype/test/validation-result-cache.test.mjs
 node editors/vscode-prototype/test/approved-validation-runner.test.mjs

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -149,6 +149,8 @@ does not generate a patch for passing validation results and does not
 apply changes.
 The pccx-lab command descriptor contract is data-only future-state
 preparation and does not execute pccx-lab.
+The launcher status contract is fixture-only future-state metadata and
+does not call pccx-llm-launcher or communicate with devices.
 
 `pccxSystemVerilog.proposeValidationCommand` currently proposes only
 allowlisted templates, including the VS Code adapter smoke, editor bridge

--- a/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
+++ b/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
@@ -207,6 +207,11 @@ pccx-lab command descriptors are data-only.  The checked status descriptor
 is future-state preparation for a reviewed CLI/core boundary; it has no
 executable field and does not run pccx-lab.
 
+Launcher status is fixture-only in this prototype.  The contract can carry
+bounded future-state metadata, but it does not call pccx-llm-launcher,
+communicate with devices, include model paths, include board logs, or make
+device performance claims.
+
 ## Prototype Daily-Driver Loop
 
 1. Inspect diagnostics and navigation.
@@ -230,6 +235,7 @@ Now:
 - patch proposal contract
 - validation-to-patch handoff contract
 - pccx-lab command descriptor contract
+- launcher status contract
 - approved validation runner boundary
 - validation summary in the context bundle
 - validation cache status command

--- a/editors/vscode-prototype/docs/launcher-integration-boundary.md
+++ b/editors/vscode-prototype/docs/launcher-integration-boundary.md
@@ -1,0 +1,54 @@
+# Launcher Integration Boundary
+
+This document defines a status-only contract for future pccx-llm-launcher
+integration.  The current VS Code prototype does not call the launcher, does
+not communicate with devices, does not load models, does not include model
+paths or board logs, and makes no board inference or performance claim.
+
+## Status Shape
+
+```json
+{
+  "version": 1,
+  "launcherStatus": "future",
+  "deviceStatus": "unknown",
+  "sessionStatus": "none",
+  "modelStatus": "unknown",
+  "backendKind": "future",
+  "capabilities": [
+    "future bounded context consumer",
+    "future local status bridge"
+  ],
+  "limitations": [
+    "no launcher runtime calls in this prototype",
+    "no device communication in this prototype",
+    "no model or board performance claims"
+  ],
+  "lastUpdatedAt": "1970-01-01T00:00:00.000Z"
+}
+```
+
+## Rules
+
+- `launcherStatus` is `unavailable`, `available`, `future`, or `disabled`.
+- `deviceStatus` is `unknown`, `not-connected`, `connected`, or `future`.
+- `sessionStatus` is `none`, `starting`, `running`, `stopped`, or `future`.
+- `modelStatus` is `unknown`, `not-loaded`, `loaded`, or `future`.
+- `backendKind` is `local`, `external`, `future`, or `unknown`.
+- Capabilities and limitations are bounded strings.
+- Status text must not include secrets, private home paths, model artifacts,
+  board logs, or board performance claims.
+- Unknown fields such as model paths or runtime output are rejected.
+
+## Current Status
+
+The checked default is fixture-only and future-state.  It is suitable for
+context bundle metadata and documentation, but it is not a runtime launcher
+integration.
+
+## Validation
+
+`src/launcher-status-contract.mjs` implements the contract and
+`test/launcher-status-contract.test.mjs` covers deterministic defaults,
+safe fixture status, invalid enum rejection, unsafe text rejection, and
+no-runtime-call safety flags.

--- a/editors/vscode-prototype/src/launcher-status-contract.mjs
+++ b/editors/vscode-prototype/src/launcher-status-contract.mjs
@@ -1,0 +1,212 @@
+export const LAUNCHER_STATUS_CONTRACT_VERSION = "pccx.launcherStatusContract.v0";
+export const LAUNCHER_STATUS_SCHEMA_VERSION = 1;
+export const DETERMINISTIC_LAUNCHER_STATUS_TIMESTAMP = "1970-01-01T00:00:00.000Z";
+
+export const LAUNCHER_STATUSES = Object.freeze(["unavailable", "available", "future", "disabled"]);
+export const LAUNCHER_DEVICE_STATUSES = Object.freeze(["unknown", "not-connected", "connected", "future"]);
+export const LAUNCHER_SESSION_STATUSES = Object.freeze(["none", "starting", "running", "stopped", "future"]);
+export const LAUNCHER_MODEL_STATUSES = Object.freeze(["unknown", "not-loaded", "loaded", "future"]);
+export const LAUNCHER_BACKEND_KINDS = Object.freeze(["local", "external", "future", "unknown"]);
+
+const STATUS_KEYS = new Set([
+  "version",
+  "launcherStatus",
+  "deviceStatus",
+  "sessionStatus",
+  "modelStatus",
+  "backendKind",
+  "capabilities",
+  "limitations",
+  "lastUpdatedAt",
+]);
+
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]/i;
+const HOME_PATH_PATTERN = /(?:\/home\/[^/\s]+|\/Users\/[^/\s]+)/;
+const MODEL_OR_WEIGHT_PATH_PATTERN =
+  /\.(?:bin|gguf|onnx|pt|pth|safetensors|xclbin|bit)(?:\s|$)/i;
+const BOARD_OR_PERFORMANCE_CLAIM_PATTERN =
+  /(?:kv260[\s\S]{0,40}(?:inference|model|runs|working)|20\s*tok\/s|timing\s+clos(?:ed|ure))/i;
+
+function unknownKeys(value, allowedKeys) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return [];
+  }
+  return Object.keys(value).filter((key) => !allowedKeys.has(key));
+}
+
+function addError(errors, path, message) {
+  errors.push(`${path}: ${message}`);
+}
+
+function enumField(value, path, allowedValues, fallback, errors) {
+  if (value == null) {
+    return fallback;
+  }
+  if (!allowedValues.includes(value)) {
+    addError(errors, path, `must be one of: ${allowedValues.join(", ")}`);
+    return fallback;
+  }
+  return value;
+}
+
+function boundedString(value, path, errors, maxCharacters = 240) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    addError(errors, path, "must be a non-empty string");
+    return "";
+  }
+  if (value.length > maxCharacters || value.includes("\0") || value.includes("\n") || value.includes("\r")) {
+    addError(errors, path, `must be a single-line string up to ${maxCharacters} characters`);
+  }
+  if (
+    SECRET_ASSIGNMENT_PATTERN.test(value) ||
+    HOME_PATH_PATTERN.test(value) ||
+    MODEL_OR_WEIGHT_PATH_PATTERN.test(value) ||
+    BOARD_OR_PERFORMANCE_CLAIM_PATTERN.test(value)
+  ) {
+    addError(errors, path, "must not include secrets, private paths, model artifacts, board logs, or performance claims");
+  }
+  return value;
+}
+
+function boundedStringList(value, path, errors) {
+  if (value == null) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    addError(errors, path, "must be an array");
+    return [];
+  }
+  if (value.length > 12) {
+    addError(errors, path, "must contain at most 12 item(s)");
+  }
+  return value.slice(0, 12).map((item, index) => boundedString(item, `${path}[${index}]`, errors));
+}
+
+function timestampField(value, errors) {
+  const timestamp = typeof value === "string" && value
+    ? value
+    : DETERMINISTIC_LAUNCHER_STATUS_TIMESTAMP;
+  if (Number.isNaN(Date.parse(timestamp))) {
+    addError(errors, "lastUpdatedAt", "must be an ISO timestamp string");
+    return DETERMINISTIC_LAUNCHER_STATUS_TIMESTAMP;
+  }
+  if (HOME_PATH_PATTERN.test(timestamp) || SECRET_ASSIGNMENT_PATTERN.test(timestamp)) {
+    addError(errors, "lastUpdatedAt", "must not include private or secret-like text");
+  }
+  return timestamp;
+}
+
+export function normalizeLauncherStatusContract(status = {}) {
+  const errors = [];
+  if (!status || typeof status !== "object" || Array.isArray(status)) {
+    throw new Error("launcher status contract must be an object");
+  }
+  for (const key of unknownKeys(status, STATUS_KEYS)) {
+    addError(errors, key, "is not allowed in launcher status contracts");
+  }
+  if (status.version != null && status.version !== LAUNCHER_STATUS_SCHEMA_VERSION) {
+    addError(errors, "version", `must be ${LAUNCHER_STATUS_SCHEMA_VERSION}`);
+  }
+
+  const normalized = {
+    version: LAUNCHER_STATUS_SCHEMA_VERSION,
+    launcherStatus: enumField(
+      status.launcherStatus,
+      "launcherStatus",
+      LAUNCHER_STATUSES,
+      "future",
+      errors,
+    ),
+    deviceStatus: enumField(
+      status.deviceStatus,
+      "deviceStatus",
+      LAUNCHER_DEVICE_STATUSES,
+      "unknown",
+      errors,
+    ),
+    sessionStatus: enumField(
+      status.sessionStatus,
+      "sessionStatus",
+      LAUNCHER_SESSION_STATUSES,
+      "none",
+      errors,
+    ),
+    modelStatus: enumField(
+      status.modelStatus,
+      "modelStatus",
+      LAUNCHER_MODEL_STATUSES,
+      "unknown",
+      errors,
+    ),
+    backendKind: enumField(
+      status.backendKind,
+      "backendKind",
+      LAUNCHER_BACKEND_KINDS,
+      "future",
+      errors,
+    ),
+    capabilities: boundedStringList(status.capabilities, "capabilities", errors),
+    limitations: boundedStringList(status.limitations, "limitations", errors),
+    lastUpdatedAt: timestampField(status.lastUpdatedAt, errors),
+  };
+
+  if (errors.length > 0) {
+    throw new Error(`invalid launcher status contract: ${errors.join("; ")}`);
+  }
+  return normalized;
+}
+
+export function validateLauncherStatusContract(status = {}) {
+  try {
+    return {
+      ok: true,
+      status: normalizeLauncherStatusContract(status),
+      errors: [],
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      status: null,
+      errors: error.message.replace(/^invalid launcher status contract: /, "").split("; "),
+    };
+  }
+}
+
+export function createDefaultLauncherStatusContract(overrides = {}) {
+  return normalizeLauncherStatusContract({
+    version: LAUNCHER_STATUS_SCHEMA_VERSION,
+    launcherStatus: "future",
+    deviceStatus: "unknown",
+    sessionStatus: "none",
+    modelStatus: "unknown",
+    backendKind: "future",
+    capabilities: [
+      "future bounded context consumer",
+      "future local status bridge",
+    ],
+    limitations: [
+      "no launcher runtime calls in this prototype",
+      "no device communication in this prototype",
+      "no model or board performance claims",
+    ],
+    lastUpdatedAt: DETERMINISTIC_LAUNCHER_STATUS_TIMESTAMP,
+    ...overrides,
+  });
+}
+
+export function createLauncherStatusContractStatus() {
+  return {
+    version: LAUNCHER_STATUS_CONTRACT_VERSION,
+    schemaVersion: LAUNCHER_STATUS_SCHEMA_VERSION,
+    statusOnly: true,
+    fixtureOnly: true,
+    providerCalls: false,
+    runtimeCalls: false,
+    launcherCalls: false,
+    deviceCommunication: false,
+    modelPathsIncluded: false,
+    boardLogsIncluded: false,
+    status: createDefaultLauncherStatusContract(),
+  };
+}

--- a/editors/vscode-prototype/test/extension-host-readiness.test.mjs
+++ b/editors/vscode-prototype/test/extension-host-readiness.test.mjs
@@ -116,6 +116,7 @@ async function testReadinessDocsAndCiPolicy() {
   assert.match(`${readme}\n${readiness}`, /patch proposal contract/i);
   assert.match(`${readme}\n${readiness}`, /validation-to-patch handoff/i);
   assert.match(`${readme}\n${readiness}`, /pccx-lab command descriptor contract/i);
+  assert.match(`${readme}\n${readiness}`, /launcher status contract/i);
   assert.match(`${readme}\n${readiness}`, /pccx-lab backend status/i);
   assert.match(`${readme}\n${readiness}`, /AI assistant .*boundary/i);
   assert.match(`${readme}\n${readiness}`, /pccx-llm-launcher .*future local LLM\/chat backend/i);

--- a/editors/vscode-prototype/test/extension-manifest.test.mjs
+++ b/editors/vscode-prototype/test/extension-manifest.test.mjs
@@ -124,6 +124,7 @@ async function testDocsKeepExperimentalScope() {
   assert.match(combined, /patch proposal contract/i);
   assert.match(combined, /validation-to-patch handoff/i);
   assert.match(combined, /pccx-lab command\s+descriptor contract/i);
+  assert.match(combined, /launcher status contract/i);
   assert.match(combined, /approved validation runner/i);
   assert.match(combined, /allowlisted proposal IDs/i);
   assert.match(combined, /pccx-lab backend status/i);

--- a/editors/vscode-prototype/test/launcher-status-contract.test.mjs
+++ b/editors/vscode-prototype/test/launcher-status-contract.test.mjs
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+
+import {
+  DETERMINISTIC_LAUNCHER_STATUS_TIMESTAMP,
+  LAUNCHER_BACKEND_KINDS,
+  LAUNCHER_DEVICE_STATUSES,
+  LAUNCHER_MODEL_STATUSES,
+  LAUNCHER_SESSION_STATUSES,
+  LAUNCHER_STATUS_CONTRACT_VERSION,
+  LAUNCHER_STATUS_SCHEMA_VERSION,
+  LAUNCHER_STATUSES,
+  createDefaultLauncherStatusContract,
+  createLauncherStatusContractStatus,
+  normalizeLauncherStatusContract,
+  validateLauncherStatusContract,
+} from "../src/launcher-status-contract.mjs";
+
+function assertInvalid(value, pattern) {
+  const result = validateLauncherStatusContract(value);
+
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), pattern);
+  assert.throws(() => normalizeLauncherStatusContract(value), pattern);
+}
+
+function status(overrides = {}) {
+  return {
+    version: 1,
+    launcherStatus: "future",
+    deviceStatus: "unknown",
+    sessionStatus: "none",
+    modelStatus: "unknown",
+    backendKind: "future",
+    capabilities: ["future bounded context consumer"],
+    limitations: ["no runtime calls"],
+    lastUpdatedAt: DETERMINISTIC_LAUNCHER_STATUS_TIMESTAMP,
+    ...overrides,
+  };
+}
+
+function testDefaultLauncherStatusIsFutureOnlyAndDeterministic() {
+  const status = createDefaultLauncherStatusContract();
+
+  assert.equal(status.version, LAUNCHER_STATUS_SCHEMA_VERSION);
+  assert.equal(status.launcherStatus, "future");
+  assert.equal(status.deviceStatus, "unknown");
+  assert.equal(status.sessionStatus, "none");
+  assert.equal(status.modelStatus, "unknown");
+  assert.equal(status.backendKind, "future");
+  assert.ok(status.capabilities.includes("future bounded context consumer"));
+  assert.ok(status.limitations.includes("no launcher runtime calls in this prototype"));
+  assert.equal(status.lastUpdatedAt, DETERMINISTIC_LAUNCHER_STATUS_TIMESTAMP);
+}
+
+function testLauncherStatusWrapperHasNoRuntimeCalls() {
+  const wrapper = createLauncherStatusContractStatus();
+
+  assert.equal(wrapper.version, LAUNCHER_STATUS_CONTRACT_VERSION);
+  assert.equal(wrapper.schemaVersion, LAUNCHER_STATUS_SCHEMA_VERSION);
+  assert.equal(wrapper.statusOnly, true);
+  assert.equal(wrapper.fixtureOnly, true);
+  assert.equal(wrapper.providerCalls, false);
+  assert.equal(wrapper.runtimeCalls, false);
+  assert.equal(wrapper.launcherCalls, false);
+  assert.equal(wrapper.deviceCommunication, false);
+  assert.equal(wrapper.modelPathsIncluded, false);
+  assert.equal(wrapper.boardLogsIncluded, false);
+  assert.equal(wrapper.status.launcherStatus, "future");
+}
+
+function testAllowedEnumsAreExplicit() {
+  assert.deepEqual(LAUNCHER_STATUSES, ["unavailable", "available", "future", "disabled"]);
+  assert.deepEqual(LAUNCHER_DEVICE_STATUSES, ["unknown", "not-connected", "connected", "future"]);
+  assert.deepEqual(LAUNCHER_SESSION_STATUSES, ["none", "starting", "running", "stopped", "future"]);
+  assert.deepEqual(LAUNCHER_MODEL_STATUSES, ["unknown", "not-loaded", "loaded", "future"]);
+  assert.deepEqual(LAUNCHER_BACKEND_KINDS, ["local", "external", "future", "unknown"]);
+}
+
+function testCanNormalizeSafeFixtureStatus() {
+  const status = normalizeLauncherStatusContract({
+    version: 1,
+    launcherStatus: "disabled",
+    deviceStatus: "future",
+    sessionStatus: "future",
+    modelStatus: "future",
+    backendKind: "future",
+    capabilities: ["bounded status fixture"],
+    limitations: ["no runtime calls"],
+    lastUpdatedAt: "2026-01-01T00:00:00.000Z",
+  });
+
+  assert.equal(status.launcherStatus, "disabled");
+  assert.equal(status.lastUpdatedAt, "2026-01-01T00:00:00.000Z");
+  assert.deepEqual(status.capabilities, ["bounded status fixture"]);
+}
+
+function testRejectsUnsafeStringsAndClaims() {
+  assertInvalid(
+    status({
+      capabilities: ["/home/dev/models/local.gguf"],
+    }),
+    /model artifacts/,
+  );
+  assertInvalid(
+    status({
+      limitations: ["TOKEN=hidden"],
+    }),
+    /secrets/,
+  );
+  assertInvalid(
+    status({
+      capabilities: ["KV260 model runs"],
+    }),
+    /performance claims/,
+  );
+  assertInvalid(
+    {
+      ...status(),
+      modelPath: "weights/local.bin",
+    },
+    /modelPath: is not allowed/,
+  );
+}
+
+function testRejectsInvalidEnumsAndTimestamp() {
+  assertInvalid(
+    status({ launcherStatus: "ready" }),
+    /launcherStatus: must be one of/,
+  );
+  assertInvalid(
+    status({ lastUpdatedAt: "not-a-date" }),
+    /lastUpdatedAt: must be an ISO timestamp string/,
+  );
+}
+
+testDefaultLauncherStatusIsFutureOnlyAndDeterministic();
+testLauncherStatusWrapperHasNoRuntimeCalls();
+testAllowedEnumsAreExplicit();
+testCanNormalizeSafeFixtureStatus();
+testRejectsUnsafeStringsAndClaims();
+testRejectsInvalidEnumsAndTimestamp();
+
+console.log("vscode launcher status contract tests ok");

--- a/editors/vscode-prototype/test/static-boundary.test.mjs
+++ b/editors/vscode-prototype/test/static-boundary.test.mjs
@@ -136,6 +136,7 @@ async function testProposalAndStatusModulesAreDataOnly() {
     resolve(EXTENSION_ROOT, "src/patch-proposal-preview.mjs"),
     resolve(EXTENSION_ROOT, "src/validation-patch-handoff.mjs"),
     resolve(EXTENSION_ROOT, "src/pccx-lab-command-descriptor.mjs"),
+    resolve(EXTENSION_ROOT, "src/launcher-status-contract.mjs"),
     resolve(EXTENSION_ROOT, "src/pccx-lab-status.mjs"),
   ]);
 

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -22,6 +22,7 @@ node editors/vscode-prototype/test/patch-proposal-contract.test.mjs
 node editors/vscode-prototype/test/patch-proposal-preview.test.mjs
 node editors/vscode-prototype/test/validation-patch-handoff.test.mjs
 node editors/vscode-prototype/test/pccx-lab-command-descriptor.test.mjs
+node editors/vscode-prototype/test/launcher-status-contract.test.mjs
 node editors/vscode-prototype/test/validation-result-summary.test.mjs
 node editors/vscode-prototype/test/validation-result-cache.test.mjs
 node editors/vscode-prototype/test/approved-validation-runner.test.mjs


### PR DESCRIPTION
## Summary
- Add a status-only launcher integration contract for future pccx-llm-launcher work.
- Document fixture-only launcher status boundaries without runtime calls.
- Add tests for deterministic defaults, enums, unsafe text rejection, and no-runtime-call safety flags.

## Scope
- Adds editors/vscode-prototype/src/launcher-status-contract.mjs.
- Adds docs/launcher-integration-boundary.md and related README/boundary references.
- Includes the launcher status test in the VS Code adapter smoke path.

## Non-goals
- No launcher runtime calls.
- No device communication.
- No model paths or weights.
- No board logs or performance claims.
- No pccx-lab execution.
- No AI provider calls.
- No MCP, LSP, marketplace, or packaging flow.

## Validation
- npm ci --prefix editors/vscode-prototype
- bash scripts/vscode-adapter-smoke.sh
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- python3 -m pytest -q
- git diff --check
- bash scripts/vscode-extension-host-smoke.sh exits 2 by default as expected
- PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh

## Safety notes
- Launcher status remains fixture-only and future-state.
- Status text rejects secrets, private paths, model artifacts, board logs, and board performance claims.
- No launcher or device process is contacted.

## Release/tag
No release or tag was created.

## FPGA repo
The FPGA repo was not touched.