### PR TITLE
feat(vscode): add local workflow status command

### DIFF
--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -143,6 +143,7 @@ The contributed commands are:
 - `pccxSystemVerilog.clearValidationResultCache`
 - `pccxSystemVerilog.showPatchProposalPreview`
 - `pccxSystemVerilog.clearPatchProposalPreview`
+- `pccxSystemVerilog.showLocalWorkflowStatus`
 - `pccxSystemVerilog.showPccxLabBackendStatus`
 
 The prototype-only settings are:
@@ -336,6 +337,14 @@ performance claims.  It does not call the launcher or communicate with a
 device.  The boundary notes are tracked in
 [`docs/launcher-integration-boundary.md`](./docs/launcher-integration-boundary.md).
 
+`src/local-workflow-status.mjs` summarizes local prototype state for
+`pccxSystemVerilog.showLocalWorkflowStatus`: extension mode, live workspace
+gate, validation runner state, recent validation cache status, pccx-lab
+descriptor state, launcher fixture state, and a bounded context item count.
+It uses local/fixture data only and does not execute pccx-lab, call the
+launcher, call providers, implement MCP, implement LSP, or package the
+extension.
+
 `pccxSystemVerilog.proposeValidationCommand` returns allowlisted
 validation command proposals as JSON data.  The proposal includes
 allowlisted proposal IDs, argument-array templates, reasons, risk levels, and
@@ -447,6 +456,7 @@ node editors/vscode-prototype/test/patch-proposal-preview.test.mjs
 node editors/vscode-prototype/test/validation-patch-handoff.test.mjs
 node editors/vscode-prototype/test/pccx-lab-command-descriptor.test.mjs
 node editors/vscode-prototype/test/launcher-status-contract.test.mjs
+node editors/vscode-prototype/test/local-workflow-status.test.mjs
 node editors/vscode-prototype/test/validation-result-summary.test.mjs
 node editors/vscode-prototype/test/validation-result-cache.test.mjs
 node editors/vscode-prototype/test/approved-validation-runner.test.mjs

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -151,6 +151,9 @@ The pccx-lab command descriptor contract is data-only future-state
 preparation and does not execute pccx-lab.
 The launcher status contract is fixture-only future-state metadata and
 does not call pccx-llm-launcher or communicate with devices.
+`pccxSystemVerilog.showLocalWorkflowStatus` summarizes local/fixture
+workflow state without pccx-lab execution, launcher calls, provider calls,
+MCP, or LSP.
 
 `pccxSystemVerilog.proposeValidationCommand` currently proposes only
 allowlisted templates, including the VS Code adapter smoke, editor bridge

--- a/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
+++ b/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
@@ -212,6 +212,11 @@ bounded future-state metadata, but it does not call pccx-llm-launcher,
 communicate with devices, include model paths, include board logs, or make
 device performance claims.
 
+Local workflow status aggregates only local and fixture state: extension
+mode, validation runner settings, recent validation cache summary,
+pccx-lab descriptor state, launcher fixture status, and bounded context
+counts.  It does not execute pccx-lab or call the launcher.
+
 ## Prototype Daily-Driver Loop
 
 1. Inspect diagnostics and navigation.
@@ -236,6 +241,7 @@ Now:
 - validation-to-patch handoff contract
 - pccx-lab command descriptor contract
 - launcher status contract
+- local workflow status command
 - approved validation runner boundary
 - validation summary in the context bundle
 - validation cache status command

--- a/editors/vscode-prototype/package.json
+++ b/editors/vscode-prototype/package.json
@@ -30,6 +30,7 @@
     "onCommand:pccxSystemVerilog.clearValidationResultCache",
     "onCommand:pccxSystemVerilog.showPatchProposalPreview",
     "onCommand:pccxSystemVerilog.clearPatchProposalPreview",
+    "onCommand:pccxSystemVerilog.showLocalWorkflowStatus",
     "onCommand:pccxSystemVerilog.showPccxLabBackendStatus"
   ],
   "contributes": {
@@ -101,6 +102,10 @@
       {
         "command": "pccxSystemVerilog.clearPatchProposalPreview",
         "title": "PCCX SystemVerilog: Clear Patch Proposal Preview (Experimental)"
+      },
+      {
+        "command": "pccxSystemVerilog.showLocalWorkflowStatus",
+        "title": "PCCX SystemVerilog: Show Local Workflow Status (Experimental)"
       },
       {
         "command": "pccxSystemVerilog.showPccxLabBackendStatus",

--- a/editors/vscode-prototype/src/config.mjs
+++ b/editors/vscode-prototype/src/config.mjs
@@ -40,6 +40,7 @@ export const AI_COMMAND_IDS = Object.freeze([
   "pccxSystemVerilog.clearValidationResultCache",
   "pccxSystemVerilog.showPatchProposalPreview",
   "pccxSystemVerilog.clearPatchProposalPreview",
+  "pccxSystemVerilog.showLocalWorkflowStatus",
 ]);
 
 export const PCCX_LAB_COMMAND_IDS = Object.freeze([

--- a/editors/vscode-prototype/src/extension.mjs
+++ b/editors/vscode-prototype/src/extension.mjs
@@ -52,6 +52,10 @@ import {
   createPatchProposalPreview,
   listCheckedPatchProposals,
 } from "./patch-proposal-preview.mjs";
+import {
+  createLocalWorkflowStatus,
+  formatLocalWorkflowStatus,
+} from "./local-workflow-status.mjs";
 
 const EXTENSION_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_DIAGNOSTIC_FILE_ROOT = resolve(EXTENSION_ROOT, "../..");
@@ -83,6 +87,8 @@ export const SHOW_PATCH_PROPOSAL_PREVIEW_COMMAND =
   "pccxSystemVerilog.showPatchProposalPreview";
 export const CLEAR_PATCH_PROPOSAL_PREVIEW_COMMAND =
   "pccxSystemVerilog.clearPatchProposalPreview";
+export const SHOW_LOCAL_WORKFLOW_STATUS_COMMAND =
+  "pccxSystemVerilog.showLocalWorkflowStatus";
 export const PCCX_LAB_BACKEND_STATUS_COMMAND =
   "pccxSystemVerilog.showPccxLabBackendStatus";
 
@@ -377,6 +383,9 @@ function appendCommandOutput(outputChannel, commandId, result) {
       kind: result.kind,
       cleared: result.cleared,
     }, null, 2));
+  }
+  if (result.kind === "local-workflow-status") {
+    outputChannel.appendLine(formatLocalWorkflowStatus(result.status));
   }
   if (result.status?.kind === "pccx-lab-backend-status") {
     outputChannel.appendLine(JSON.stringify(result.status, null, 2));
@@ -892,6 +901,46 @@ export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
         };
         vscodeApi?.window?.showInformationMessage?.(
           cleared ? "Cleared patch proposal preview." : "No patch proposal preview was cached.",
+          result,
+        );
+      } catch (error) {
+        result = { ok: false, commandId, error: error.message };
+        vscodeApi?.window?.showWarningMessage?.(result.error, result);
+      }
+      appendCommandOutput(runtime.outputChannel, commandId, result);
+      return result;
+    }
+
+    if (commandId === SHOW_LOCAL_WORKFLOW_STATUS_COMMAND) {
+      let result;
+      try {
+        const config = normalizeConfig(rawConfig);
+        const validationCache = validationResultCacheFromRuntime(runtime);
+        let contextSummary = null;
+        try {
+          const context = collectActiveDocumentContext(vscodeApi, runtime, config);
+          const request = createAssistantRequest(config, context.input, {
+            workspaceRoot: context.workspaceRoot,
+          });
+          contextSummary = request.contextSummary;
+        } catch {
+          contextSummary = null;
+        }
+        const status = createLocalWorkflowStatus(config, {
+          validationResultCache: validationCache,
+          contextSummary,
+          validationHistoryCount: validationCache.size(),
+          launcherStatusCount: 1,
+          labStatusCount: 1,
+        });
+        result = {
+          ok: true,
+          commandId,
+          kind: "local-workflow-status",
+          status,
+        };
+        vscodeApi?.window?.showInformationMessage?.(
+          `Local workflow status: ${status.extensionMode}, validation ${status.recentValidation.latestStatus}.`,
           result,
         );
       } catch (error) {

--- a/editors/vscode-prototype/src/local-workflow-status.mjs
+++ b/editors/vscode-prototype/src/local-workflow-status.mjs
@@ -1,0 +1,106 @@
+import {
+  createLauncherStatusContractStatus,
+} from "./launcher-status-contract.mjs";
+import {
+  createPccxLabCommandDescriptorStatus,
+} from "./pccx-lab-command-descriptor.mjs";
+
+export const LOCAL_WORKFLOW_STATUS_VERSION = "pccx.localWorkflowStatus.v0";
+
+function validationStatusFromCache(cache) {
+  if (!cache || typeof cache.status !== "function") {
+    return {
+      count: 0,
+      maxSize: 0,
+      latestStatus: "none",
+      latestProposalId: "",
+      redactionApplied: false,
+      truncated: false,
+    };
+  }
+  const status = cache.status();
+  return {
+    count: status.count,
+    maxSize: status.maxSize,
+    latestStatus: status.latest?.status ?? "none",
+    latestProposalId: status.latest?.proposalId ?? "",
+    redactionApplied: status.redactionApplied === true,
+    truncated: status.truncated === true,
+  };
+}
+
+function contextBundleEstimate(input = {}) {
+  const contextSummary = input.contextSummary ?? null;
+  return {
+    itemCount: [
+      contextSummary?.diagnosticCount ?? input.diagnosticCount ?? 0,
+      contextSummary?.snippetCount ?? input.snippetCount ?? 0,
+      contextSummary?.declarationCount ?? input.declarationCount ?? 0,
+      contextSummary?.pccxLabOutputCount ?? input.pccxLabOutputCount ?? 0,
+      input.validationHistoryCount ?? 0,
+      input.launcherStatusCount ?? 0,
+      input.labStatusCount ?? 0,
+    ].reduce((sum, value) => sum + Math.max(0, Number.isInteger(value) ? value : 0), 0),
+    diagnosticCount: contextSummary?.diagnosticCount ?? input.diagnosticCount ?? 0,
+    snippetCount: contextSummary?.snippetCount ?? input.snippetCount ?? 0,
+    declarationCount: contextSummary?.declarationCount ?? input.declarationCount ?? 0,
+    validationHistoryCount: input.validationHistoryCount ?? 0,
+  };
+}
+
+export function createLocalWorkflowStatus(config = {}, input = {}) {
+  const pccxLabBoundary = createPccxLabCommandDescriptorStatus();
+  const launcherBoundary = createLauncherStatusContractStatus();
+  const validationCache = validationStatusFromCache(input.validationResultCache);
+  const extensionMode = typeof config.mode === "string" ? config.mode : "checkedExample";
+  const validationRunner = config.validationRunner ?? {};
+
+  return {
+    version: LOCAL_WORKFLOW_STATUS_VERSION,
+    kind: "local-workflow-status",
+    extensionMode,
+    liveWorkspace: {
+      enabled: config.liveWorkspace?.enabled === true,
+    },
+    validationRunner: {
+      enabled: validationRunner.enabled === true,
+      mode: typeof validationRunner.mode === "string" ? validationRunner.mode : "disabled",
+    },
+    recentValidation: validationCache,
+    pccxLabBoundary: {
+      state: pccxLabBoundary.descriptors[0]?.executionState ?? "future",
+      descriptorOnly: pccxLabBoundary.descriptorOnly === true,
+      executes: pccxLabBoundary.executes === true,
+      descriptorCount: pccxLabBoundary.descriptors.length,
+    },
+    launcherBoundary: {
+      state: launcherBoundary.status.launcherStatus,
+      fixtureOnly: launcherBoundary.fixtureOnly === true,
+      runtimeCalls: launcherBoundary.runtimeCalls === true,
+      launcherCalls: launcherBoundary.launcherCalls === true,
+    },
+    contextBundle: contextBundleEstimate(input),
+    safety: {
+      providerCalls: false,
+      launcherCalls: false,
+      pccxLabExecution: false,
+      mcpCalls: false,
+      lspImplemented: false,
+      marketplaceFlow: false,
+    },
+  };
+}
+
+export function formatLocalWorkflowStatus(status) {
+  return [
+    "Local Workflow Status",
+    `extensionMode: ${status.extensionMode}`,
+    `liveWorkspaceEnabled: ${status.liveWorkspace.enabled ? "yes" : "no"}`,
+    `validationRunner: ${status.validationRunner.enabled ? "enabled" : "disabled"} (${status.validationRunner.mode})`,
+    `recentValidation: ${status.recentValidation.count}/${status.recentValidation.maxSize} latest=${status.recentValidation.latestStatus}`,
+    `pccxLabBoundary: ${status.pccxLabBoundary.state} descriptorOnly=${status.pccxLabBoundary.descriptorOnly ? "yes" : "no"}`,
+    `launcherBoundary: ${status.launcherBoundary.state} fixtureOnly=${status.launcherBoundary.fixtureOnly ? "yes" : "no"}`,
+    `contextBundleItems: ${status.contextBundle.itemCount}`,
+    "safety: no provider calls, no launcher calls, no pccx-lab execution",
+  ].join("\n");
+}

--- a/editors/vscode-prototype/test/extension-entrypoint.test.mjs
+++ b/editors/vscode-prototype/test/extension-entrypoint.test.mjs
@@ -11,6 +11,7 @@ import {
   FACADE_COMMAND_IDS,
   LIVE_WORKSPACE_NAVIGATION_COMMAND,
   PCCX_LAB_BACKEND_STATUS_COMMAND,
+  SHOW_LOCAL_WORKFLOW_STATUS_COMMAND,
   SHOW_PATCH_PROPOSAL_PREVIEW_COMMAND,
   SHOW_RECENT_VALIDATION_RESULTS_COMMAND,
   SHOW_VALIDATION_CACHE_STATUS_COMMAND,
@@ -1251,6 +1252,47 @@ async function testPatchProposalPreviewCommandsShowAndClearCheckedProposalOnly()
   assert.equal(runtime.recentPatchProposalPreview, null);
 }
 
+async function testLocalWorkflowStatusCommandReturnsFixtureOnlyBoundaryState() {
+  const outputLines = [];
+  const informationMessages = [];
+  const runtime = {
+    outputChannel: {
+      appendLine(line) {
+        outputLines.push(line);
+      },
+      show() {},
+    },
+  };
+  const handler = createCommandHandler(
+    SHOW_LOCAL_WORKFLOW_STATUS_COMMAND,
+    {
+      window: {
+        showInformationMessage(...args) {
+          informationMessages.push(args);
+        },
+      },
+    },
+    runtime,
+  );
+
+  const result = await handler();
+
+  assert.equal(result.ok, true);
+  assert.equal(result.commandId, SHOW_LOCAL_WORKFLOW_STATUS_COMMAND);
+  assert.equal(result.kind, "local-workflow-status");
+  assert.equal(result.status.extensionMode, "checkedExample");
+  assert.equal(result.status.validationRunner.enabled, false);
+  assert.equal(result.status.recentValidation.count, 0);
+  assert.equal(result.status.pccxLabBoundary.state, "future");
+  assert.equal(result.status.pccxLabBoundary.executes, false);
+  assert.equal(result.status.launcherBoundary.state, "future");
+  assert.equal(result.status.launcherBoundary.launcherCalls, false);
+  assert.equal(result.status.safety.providerCalls, false);
+  assert.equal(result.status.safety.pccxLabExecution, false);
+  assert.ok(outputLines.some((line) => line.includes("Local Workflow Status")));
+  assert.ok(informationMessages.some(([message]) => /Local workflow status/.test(message)));
+}
+
 async function testPccxLabBackendStatusCommandReturnsStatusOnly() {
   const settings = new Map([
     ["mode", "checkedExample"],
@@ -1322,6 +1364,7 @@ await testApprovedValidationRunnerRequiresProposalIdWhenEnabled();
 await testApprovedValidationRunnerExecutesAllowlistedProposalWhenEnabled();
 await testValidationResultCacheCommandsShowAndClear();
 await testPatchProposalPreviewCommandsShowAndClearCheckedProposalOnly();
+await testLocalWorkflowStatusCommandReturnsFixtureOnlyBoundaryState();
 await testPccxLabBackendStatusCommandReturnsStatusOnly();
 
 console.log("vscode extension entrypoint tests ok");

--- a/editors/vscode-prototype/test/extension-host-readiness.test.mjs
+++ b/editors/vscode-prototype/test/extension-host-readiness.test.mjs
@@ -110,6 +110,7 @@ async function testReadinessDocsAndCiPolicy() {
   assert.match(`${readme}\n${readiness}`, /clearValidationResultCache/);
   assert.match(`${readme}\n${readiness}`, /showPatchProposalPreview/);
   assert.match(`${readme}\n${readiness}`, /clearPatchProposalPreview/);
+  assert.match(`${readme}\n${readiness}`, /showLocalWorkflowStatus/);
   assert.match(`${readme}\n${readiness}`, /showPccxLabBackendStatus/);
   assert.match(`${readme}\n${readiness}`, /context bundle command/i);
   assert.match(`${readme}\n${readiness}`, /validation command proposal/i);
@@ -172,6 +173,7 @@ async function testRuntimeRunnerIsPinnedAndBounded() {
   assert.match(suite, /clearValidationResultCache/);
   assert.match(suite, /showPatchProposalPreview/);
   assert.match(suite, /clearPatchProposalPreview/);
+  assert.match(suite, /showLocalWorkflowStatus/);
   assert.match(suite, /validationRunner\.enabled/);
   assert.match(suite, /vscodeAdapterSmoke/);
   assert.match(suite, /showPccxLabBackendStatus/);

--- a/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
+++ b/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
@@ -73,6 +73,7 @@ async function run() {
     "pccxSystemVerilog.clearValidationResultCache",
     "pccxSystemVerilog.showPatchProposalPreview",
     "pccxSystemVerilog.clearPatchProposalPreview",
+    "pccxSystemVerilog.showLocalWorkflowStatus",
     "pccxSystemVerilog.showPccxLabBackendStatus",
   ]);
 
@@ -396,6 +397,19 @@ async function run() {
   assert.equal(clearPatchPreview.ok, true);
   assert.equal(clearPatchPreview.kind, "patch-proposal-preview-clear");
   assert.equal(clearPatchPreview.cleared, true);
+
+  const localWorkflowStatus = await vscode.commands.executeCommand(
+    "pccxSystemVerilog.showLocalWorkflowStatus",
+  );
+  assert.equal(localWorkflowStatus.ok, true);
+  assert.equal(localWorkflowStatus.kind, "local-workflow-status");
+  assert.equal(localWorkflowStatus.status.extensionMode, "liveWorkspace");
+  assert.equal(localWorkflowStatus.status.pccxLabBoundary.state, "future");
+  assert.equal(localWorkflowStatus.status.pccxLabBoundary.executes, false);
+  assert.equal(localWorkflowStatus.status.launcherBoundary.state, "future");
+  assert.equal(localWorkflowStatus.status.launcherBoundary.launcherCalls, false);
+  assert.equal(localWorkflowStatus.status.safety.providerCalls, false);
+  assert.equal(localWorkflowStatus.status.safety.pccxLabExecution, false);
 
   const disabledValidationRun = await vscode.commands.executeCommand(
     "pccxSystemVerilog.runApprovedValidationCommand",

--- a/editors/vscode-prototype/test/extension-manifest.test.mjs
+++ b/editors/vscode-prototype/test/extension-manifest.test.mjs
@@ -23,6 +23,7 @@ const COMMAND_IDS = [
   "pccxSystemVerilog.clearValidationResultCache",
   "pccxSystemVerilog.showPatchProposalPreview",
   "pccxSystemVerilog.clearPatchProposalPreview",
+  "pccxSystemVerilog.showLocalWorkflowStatus",
   "pccxSystemVerilog.showPccxLabBackendStatus",
 ];
 
@@ -125,6 +126,7 @@ async function testDocsKeepExperimentalScope() {
   assert.match(combined, /validation-to-patch handoff/i);
   assert.match(combined, /pccx-lab command\s+descriptor contract/i);
   assert.match(combined, /launcher status contract/i);
+  assert.match(combined, /showLocalWorkflowStatus/);
   assert.match(combined, /approved validation runner/i);
   assert.match(combined, /allowlisted proposal IDs/i);
   assert.match(combined, /pccx-lab backend status/i);

--- a/editors/vscode-prototype/test/local-workflow-status.test.mjs
+++ b/editors/vscode-prototype/test/local-workflow-status.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+
+import {
+  LOCAL_WORKFLOW_STATUS_VERSION,
+  createLocalWorkflowStatus,
+  formatLocalWorkflowStatus,
+} from "../src/local-workflow-status.mjs";
+import {
+  createValidationResultCache,
+} from "../src/validation-result-cache.mjs";
+
+function testLocalWorkflowStatusUsesDeterministicLocalDataOnly() {
+  const cache = createValidationResultCache({ maxSize: 5 });
+  cache.add({
+    proposalId: "vscodeAdapterSmoke",
+    commandLabel: "VS Code adapter smoke",
+    status: "passed",
+    exitCode: 0,
+    durationMs: 12,
+    stdoutSummary: { lines: ["ok"], lineCount: 1, truncated: false },
+    stderrSummary: { lines: [], lineCount: 0, truncated: false },
+    safety: { allowlisted: true, shell: false, fixedArgs: true },
+  });
+
+  const status = createLocalWorkflowStatus(
+    {
+      mode: "liveWorkspace",
+      liveWorkspace: { enabled: true },
+      validationRunner: { enabled: true, mode: "allowlisted" },
+    },
+    {
+      validationResultCache: cache,
+      contextSummary: {
+        diagnosticCount: 2,
+        snippetCount: 1,
+        declarationCount: 3,
+        pccxLabOutputCount: 0,
+      },
+      validationHistoryCount: 1,
+      launcherStatusCount: 1,
+      labStatusCount: 1,
+    },
+  );
+
+  assert.equal(status.version, LOCAL_WORKFLOW_STATUS_VERSION);
+  assert.equal(status.kind, "local-workflow-status");
+  assert.equal(status.extensionMode, "liveWorkspace");
+  assert.equal(status.liveWorkspace.enabled, true);
+  assert.deepEqual(status.validationRunner, { enabled: true, mode: "allowlisted" });
+  assert.equal(status.recentValidation.count, 1);
+  assert.equal(status.recentValidation.maxSize, 5);
+  assert.equal(status.recentValidation.latestStatus, "passed");
+  assert.equal(status.recentValidation.latestProposalId, "vscodeAdapterSmoke");
+  assert.equal(status.pccxLabBoundary.state, "future");
+  assert.equal(status.pccxLabBoundary.descriptorOnly, true);
+  assert.equal(status.pccxLabBoundary.executes, false);
+  assert.equal(status.launcherBoundary.state, "future");
+  assert.equal(status.launcherBoundary.fixtureOnly, true);
+  assert.equal(status.launcherBoundary.runtimeCalls, false);
+  assert.equal(status.contextBundle.itemCount, 9);
+  assert.equal(status.safety.providerCalls, false);
+  assert.equal(status.safety.launcherCalls, false);
+  assert.equal(status.safety.pccxLabExecution, false);
+}
+
+function testLocalWorkflowStatusDefaultsAreDisabledAndSafe() {
+  const status = createLocalWorkflowStatus({}, {});
+  const text = formatLocalWorkflowStatus(status);
+
+  assert.equal(status.extensionMode, "checkedExample");
+  assert.equal(status.liveWorkspace.enabled, false);
+  assert.deepEqual(status.validationRunner, { enabled: false, mode: "disabled" });
+  assert.equal(status.recentValidation.count, 0);
+  assert.equal(status.pccxLabBoundary.executes, false);
+  assert.equal(status.launcherBoundary.launcherCalls, false);
+  assert.match(text, /Local Workflow Status/);
+  assert.match(text, /validationRunner: disabled/);
+  assert.match(text, /no pccx-lab execution/);
+  assert.doesNotMatch(JSON.stringify(status), /\/home\/|TOKEN=|model\.gguf/);
+}
+
+testLocalWorkflowStatusUsesDeterministicLocalDataOnly();
+testLocalWorkflowStatusDefaultsAreDisabledAndSafe();
+
+console.log("vscode local workflow status tests ok");

--- a/editors/vscode-prototype/test/static-boundary.test.mjs
+++ b/editors/vscode-prototype/test/static-boundary.test.mjs
@@ -137,6 +137,7 @@ async function testProposalAndStatusModulesAreDataOnly() {
     resolve(EXTENSION_ROOT, "src/validation-patch-handoff.mjs"),
     resolve(EXTENSION_ROOT, "src/pccx-lab-command-descriptor.mjs"),
     resolve(EXTENSION_ROOT, "src/launcher-status-contract.mjs"),
+    resolve(EXTENSION_ROOT, "src/local-workflow-status.mjs"),
     resolve(EXTENSION_ROOT, "src/pccx-lab-status.mjs"),
   ]);
 

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -23,6 +23,7 @@ node editors/vscode-prototype/test/patch-proposal-preview.test.mjs
 node editors/vscode-prototype/test/validation-patch-handoff.test.mjs
 node editors/vscode-prototype/test/pccx-lab-command-descriptor.test.mjs
 node editors/vscode-prototype/test/launcher-status-contract.test.mjs
+node editors/vscode-prototype/test/local-workflow-status.test.mjs
 node editors/vscode-prototype/test/validation-result-summary.test.mjs
 node editors/vscode-prototype/test/validation-result-cache.test.mjs
 node editors/vscode-prototype/test/approved-validation-runner.test.mjs


### PR DESCRIPTION
## Summary
- Add a local workflow status command for the VS Code prototype.
- Summarize extension mode, validation runner state, validation cache status, pccx-lab descriptor state, launcher fixture state, and bounded context counts.
- Extend entrypoint, manifest, static, adapter smoke, and opt-in Extension Host smoke coverage.

## Scope
- Adds pccxSystemVerilog.showLocalWorkflowStatus.
- Adds editors/vscode-prototype/src/local-workflow-status.mjs.
- Uses local/fixture data only.

## Non-goals
- No real pccx-lab execution.
- No real launcher calls.
- No AI provider calls.
- No MCP, LSP, marketplace, or packaging flow.

## Validation
- npm ci --prefix editors/vscode-prototype
- bash scripts/vscode-adapter-smoke.sh
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- python3 -m pytest -q
- git diff --check
- bash scripts/vscode-extension-host-smoke.sh exits 2 by default as expected
- PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh

## Safety notes
- Status is local/fixture-only.
- pccx-lab remains descriptor-only/future-state.
- Launcher remains fixture-only/future-state.
- No backend command, launcher process, provider, MCP, or LSP is invoked.

## Release/tag
No release or tag was created.

## FPGA repo
The FPGA repo was not touched.