### PR TITLE
feat(vscode): add context bundle budget audit

### DIFF
--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -144,6 +144,7 @@ The contributed commands are:
 - `pccxSystemVerilog.showPatchProposalPreview`
 - `pccxSystemVerilog.clearPatchProposalPreview`
 - `pccxSystemVerilog.showLocalWorkflowStatus`
+- `pccxSystemVerilog.showContextBundleAudit`
 - `pccxSystemVerilog.showPccxLabBackendStatus`
 
 The prototype-only settings are:
@@ -345,6 +346,12 @@ It uses local/fixture data only and does not execute pccx-lab, call the
 launcher, call providers, implement MCP, implement LSP, or package the
 extension.
 
+`src/context-bundle-audit.mjs` reports approximate context bundle size,
+diagnostic/snippet/validation summary counts, redaction/truncation flags,
+and excluded categories for `pccxSystemVerilog.showContextBundleAudit`.
+The audit is local-only, summary-only, and does not upload context or call
+providers.
+
 `pccxSystemVerilog.proposeValidationCommand` returns allowlisted
 validation command proposals as JSON data.  The proposal includes
 allowlisted proposal IDs, argument-array templates, reasons, risk levels, and
@@ -457,6 +464,7 @@ node editors/vscode-prototype/test/validation-patch-handoff.test.mjs
 node editors/vscode-prototype/test/pccx-lab-command-descriptor.test.mjs
 node editors/vscode-prototype/test/launcher-status-contract.test.mjs
 node editors/vscode-prototype/test/local-workflow-status.test.mjs
+node editors/vscode-prototype/test/context-bundle-audit.test.mjs
 node editors/vscode-prototype/test/validation-result-summary.test.mjs
 node editors/vscode-prototype/test/validation-result-cache.test.mjs
 node editors/vscode-prototype/test/approved-validation-runner.test.mjs

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -154,6 +154,8 @@ does not call pccx-llm-launcher or communicate with devices.
 `pccxSystemVerilog.showLocalWorkflowStatus` summarizes local/fixture
 workflow state without pccx-lab execution, launcher calls, provider calls,
 MCP, or LSP.
+`pccxSystemVerilog.showContextBundleAudit` reports local context bundle
+size and safety metadata without uploading context or calling providers.
 
 `pccxSystemVerilog.proposeValidationCommand` currently proposes only
 allowlisted templates, including the VS Code adapter smoke, editor bridge

--- a/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
+++ b/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
@@ -217,6 +217,11 @@ mode, validation runner settings, recent validation cache summary,
 pccx-lab descriptor state, launcher fixture status, and bounded context
 counts.  It does not execute pccx-lab or call the launcher.
 
+Context bundle audit reports local size and safety budget metadata:
+approximate character count, bounded item counts, redaction/truncation
+flags, and excluded categories.  It does not upload context or call a
+provider.
+
 ## Prototype Daily-Driver Loop
 
 1. Inspect diagnostics and navigation.
@@ -242,6 +247,7 @@ Now:
 - pccx-lab command descriptor contract
 - launcher status contract
 - local workflow status command
+- context bundle audit command
 - approved validation runner boundary
 - validation summary in the context bundle
 - validation cache status command

--- a/editors/vscode-prototype/package.json
+++ b/editors/vscode-prototype/package.json
@@ -31,6 +31,7 @@
     "onCommand:pccxSystemVerilog.showPatchProposalPreview",
     "onCommand:pccxSystemVerilog.clearPatchProposalPreview",
     "onCommand:pccxSystemVerilog.showLocalWorkflowStatus",
+    "onCommand:pccxSystemVerilog.showContextBundleAudit",
     "onCommand:pccxSystemVerilog.showPccxLabBackendStatus"
   ],
   "contributes": {
@@ -106,6 +107,10 @@
       {
         "command": "pccxSystemVerilog.showLocalWorkflowStatus",
         "title": "PCCX SystemVerilog: Show Local Workflow Status (Experimental)"
+      },
+      {
+        "command": "pccxSystemVerilog.showContextBundleAudit",
+        "title": "PCCX SystemVerilog: Show Context Bundle Audit (Experimental)"
       },
       {
         "command": "pccxSystemVerilog.showPccxLabBackendStatus",

--- a/editors/vscode-prototype/src/config.mjs
+++ b/editors/vscode-prototype/src/config.mjs
@@ -41,6 +41,7 @@ export const AI_COMMAND_IDS = Object.freeze([
   "pccxSystemVerilog.showPatchProposalPreview",
   "pccxSystemVerilog.clearPatchProposalPreview",
   "pccxSystemVerilog.showLocalWorkflowStatus",
+  "pccxSystemVerilog.showContextBundleAudit",
 ]);
 
 export const PCCX_LAB_COMMAND_IDS = Object.freeze([

--- a/editors/vscode-prototype/src/context-bundle-audit.mjs
+++ b/editors/vscode-prototype/src/context-bundle-audit.mjs
@@ -1,0 +1,90 @@
+export const CONTEXT_BUNDLE_AUDIT_VERSION = "pccx.contextBundleAudit.v0";
+
+function serializedLength(value) {
+  try {
+    return JSON.stringify(value ?? {}).length;
+  } catch {
+    return 0;
+  }
+}
+
+function countTruncatedItems(value) {
+  if (Array.isArray(value)) {
+    return value.reduce((count, item) => count + countTruncatedItems(item), 0);
+  }
+  if (!value || typeof value !== "object") {
+    return 0;
+  }
+  return (value.truncated === true ? 1 : 0) +
+    Object.values(value).reduce((count, item) => count + countTruncatedItems(item), 0);
+}
+
+function textContainsRedaction(value) {
+  if (typeof value === "string") {
+    return value.includes("[redacted]") || value.includes("[home]");
+  }
+  if (Array.isArray(value)) {
+    return value.some(textContainsRedaction);
+  }
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  return value.redactionApplied === true || Object.values(value).some(textContainsRedaction);
+}
+
+function validationSummaryCount(bundle) {
+  const historyCount = Array.isArray(bundle?.validation?.recentHistory)
+    ? bundle.validation.recentHistory.length
+    : 0;
+  if (historyCount > 0) {
+    return historyCount;
+  }
+  return bundle?.validation?.recent ? 1 : 0;
+}
+
+export function createContextBundleAudit(bundle = {}) {
+  const excludedCategories = [
+    ...(Array.isArray(bundle.excludedPathSegments) ? bundle.excludedPathSegments : []),
+    ...(Array.isArray(bundle.excludedPathPatterns) ? bundle.excludedPathPatterns : []),
+  ];
+  const audit = {
+    version: CONTEXT_BUNDLE_AUDIT_VERSION,
+    contextBundleVersion: bundle?.version ?? "",
+    approximateCharacterCount: serializedLength(bundle),
+    diagnosticCount: Array.isArray(bundle?.diagnostics) ? bundle.diagnostics.length : 0,
+    selectedSymbolSnippetCount: bundle?.symbols?.selectedContext ? 1 : 0,
+    snippetCount: Array.isArray(bundle?.snippets) ? bundle.snippets.length : 0,
+    validationSummaryCount: validationSummaryCount(bundle),
+    launcherStatusEntryCount: bundle?.launcher ? 1 : 0,
+    labStatusEntryCount: Array.isArray(bundle?.pccxLab?.outputs) ? bundle.pccxLab.outputs.length : 0,
+    redactionApplied: textContainsRedaction(bundle),
+    truncationApplied: countTruncatedItems(bundle) > 0,
+    truncatedItemCount: countTruncatedItems(bundle),
+    excludedCategories,
+    safety: {
+      summaryOnly: true,
+      fullLogsExcluded: true,
+      privatePathsExcluded: true,
+      providerCalls: false,
+      networkCalls: false,
+      mcpCalls: false,
+    },
+  };
+  return audit;
+}
+
+export function formatContextBundleAudit(audit) {
+  return [
+    "Context Bundle Audit",
+    `approximateCharacterCount: ${audit.approximateCharacterCount}`,
+    `diagnostics: ${audit.diagnosticCount}`,
+    `selectedSymbolSnippets: ${audit.selectedSymbolSnippetCount}`,
+    `snippets: ${audit.snippetCount}`,
+    `validationSummaries: ${audit.validationSummaryCount}`,
+    `launcherStatusEntries: ${audit.launcherStatusEntryCount}`,
+    `labStatusEntries: ${audit.labStatusEntryCount}`,
+    `redactionApplied: ${audit.redactionApplied ? "yes" : "no"}`,
+    `truncationApplied: ${audit.truncationApplied ? "yes" : "no"}`,
+    `excludedCategories: ${audit.excludedCategories.join(", ")}`,
+  ].join("\n");
+}

--- a/editors/vscode-prototype/src/extension.mjs
+++ b/editors/vscode-prototype/src/extension.mjs
@@ -56,6 +56,10 @@ import {
   createLocalWorkflowStatus,
   formatLocalWorkflowStatus,
 } from "./local-workflow-status.mjs";
+import {
+  createContextBundleAudit,
+  formatContextBundleAudit,
+} from "./context-bundle-audit.mjs";
 
 const EXTENSION_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_DIAGNOSTIC_FILE_ROOT = resolve(EXTENSION_ROOT, "../..");
@@ -89,6 +93,8 @@ export const CLEAR_PATCH_PROPOSAL_PREVIEW_COMMAND =
   "pccxSystemVerilog.clearPatchProposalPreview";
 export const SHOW_LOCAL_WORKFLOW_STATUS_COMMAND =
   "pccxSystemVerilog.showLocalWorkflowStatus";
+export const SHOW_CONTEXT_BUNDLE_AUDIT_COMMAND =
+  "pccxSystemVerilog.showContextBundleAudit";
 export const PCCX_LAB_BACKEND_STATUS_COMMAND =
   "pccxSystemVerilog.showPccxLabBackendStatus";
 
@@ -386,6 +392,9 @@ function appendCommandOutput(outputChannel, commandId, result) {
   }
   if (result.kind === "local-workflow-status") {
     outputChannel.appendLine(formatLocalWorkflowStatus(result.status));
+  }
+  if (result.kind === "context-bundle-audit") {
+    outputChannel.appendLine(formatContextBundleAudit(result.audit));
   }
   if (result.status?.kind === "pccx-lab-backend-status") {
     outputChannel.appendLine(JSON.stringify(result.status, null, 2));
@@ -941,6 +950,33 @@ export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
         };
         vscodeApi?.window?.showInformationMessage?.(
           `Local workflow status: ${status.extensionMode}, validation ${status.recentValidation.latestStatus}.`,
+          result,
+        );
+      } catch (error) {
+        result = { ok: false, commandId, error: error.message };
+        vscodeApi?.window?.showWarningMessage?.(result.error, result);
+      }
+      appendCommandOutput(runtime.outputChannel, commandId, result);
+      return result;
+    }
+
+    if (commandId === SHOW_CONTEXT_BUNDLE_AUDIT_COMMAND) {
+      let result;
+      try {
+        const config = normalizeConfig(rawConfig);
+        const context = collectActiveDocumentContext(vscodeApi, runtime, config);
+        const request = createAssistantRequest(config, context.input, {
+          workspaceRoot: context.workspaceRoot,
+        });
+        const audit = createContextBundleAudit(request.contextBundle);
+        result = {
+          ok: true,
+          commandId,
+          kind: "context-bundle-audit",
+          audit,
+        };
+        vscodeApi?.window?.showInformationMessage?.(
+          `Context bundle audit: ${audit.approximateCharacterCount} character(s), ${audit.diagnosticCount} diagnostic(s).`,
           result,
         );
       } catch (error) {

--- a/editors/vscode-prototype/test/context-bundle-audit.test.mjs
+++ b/editors/vscode-prototype/test/context-bundle-audit.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+
+import {
+  CONTEXT_BUNDLE_AUDIT_VERSION,
+  createContextBundleAudit,
+  formatContextBundleAudit,
+} from "../src/context-bundle-audit.mjs";
+import {
+  buildContextBundle,
+} from "../src/context-bundle.mjs";
+
+function testAuditCountsBoundedContextShape() {
+  const bundle = buildContextBundle(
+    {
+      workspaceRoot: "/repo",
+      selectedFilePath: "/repo/rtl/top.sv",
+      selectedSymbolContext: {
+        version: "pccx.selectedSymbolContext.v0",
+        path: "/repo/rtl/top.sv",
+        symbolText: "top",
+      },
+      activeDiagnostics: [
+        { file: "/repo/rtl/top.sv", message: "TOKEN=hidden" },
+      ],
+      files: [
+        { path: "/repo/rtl/top.sv", text: "module top;\nendmodule\n" },
+      ],
+      recentValidationHistory: [
+        {
+          proposalId: "vscodeAdapterSmoke",
+          status: "failed",
+          stdoutSummary: { lines: ["ok"], lineCount: 1, truncated: false },
+          stderrSummary: { lines: ["failure"], lineCount: 1, truncated: false },
+        },
+      ],
+      pccxLabOutputs: [
+        { label: "fixture", summaryLines: ["TOKEN=hidden"] },
+      ],
+    },
+    {
+      workspaceRoot: "/repo",
+      limits: { maxSnippetLines: 1 },
+    },
+  );
+  const audit = createContextBundleAudit(bundle);
+  const text = formatContextBundleAudit(audit);
+
+  assert.equal(audit.version, CONTEXT_BUNDLE_AUDIT_VERSION);
+  assert.equal(audit.contextBundleVersion, "pccx.contextBundle.v0");
+  assert.ok(audit.approximateCharacterCount > 0);
+  assert.equal(audit.diagnosticCount, 1);
+  assert.equal(audit.selectedSymbolSnippetCount, 1);
+  assert.equal(audit.snippetCount, 1);
+  assert.equal(audit.validationSummaryCount, 1);
+  assert.equal(audit.launcherStatusEntryCount, 0);
+  assert.equal(audit.labStatusEntryCount, 1);
+  assert.equal(audit.redactionApplied, true);
+  assert.equal(audit.truncationApplied, true);
+  assert.ok(audit.excludedCategories.includes("node_modules"));
+  assert.ok(audit.excludedCategories.includes("node_modules/**"));
+  assert.equal(audit.safety.fullLogsExcluded, true);
+  assert.equal(audit.safety.providerCalls, false);
+  assert.match(text, /Context Bundle Audit/);
+  assert.match(text, /validationSummaries: 1/);
+  assert.doesNotMatch(JSON.stringify(audit), /TOKEN=hidden|\/repo/);
+}
+
+function testEmptyAuditIsDeterministicAndSafe() {
+  const audit = createContextBundleAudit({});
+
+  assert.equal(audit.diagnosticCount, 0);
+  assert.equal(audit.snippetCount, 0);
+  assert.equal(audit.validationSummaryCount, 0);
+  assert.equal(audit.redactionApplied, false);
+  assert.equal(audit.truncationApplied, false);
+  assert.deepEqual(audit.excludedCategories, []);
+  assert.equal(audit.safety.networkCalls, false);
+  assert.equal(audit.safety.mcpCalls, false);
+}
+
+testAuditCountsBoundedContextShape();
+testEmptyAuditIsDeterministicAndSafe();
+
+console.log("vscode context bundle audit tests ok");

--- a/editors/vscode-prototype/test/extension-entrypoint.test.mjs
+++ b/editors/vscode-prototype/test/extension-entrypoint.test.mjs
@@ -11,6 +11,7 @@ import {
   FACADE_COMMAND_IDS,
   LIVE_WORKSPACE_NAVIGATION_COMMAND,
   PCCX_LAB_BACKEND_STATUS_COMMAND,
+  SHOW_CONTEXT_BUNDLE_AUDIT_COMMAND,
   SHOW_LOCAL_WORKFLOW_STATUS_COMMAND,
   SHOW_PATCH_PROPOSAL_PREVIEW_COMMAND,
   SHOW_RECENT_VALIDATION_RESULTS_COMMAND,
@@ -1293,6 +1294,72 @@ async function testLocalWorkflowStatusCommandReturnsFixtureOnlyBoundaryState() {
   assert.ok(informationMessages.some(([message]) => /Local workflow status/.test(message)));
 }
 
+async function testContextBundleAuditCommandReturnsBoundedAudit() {
+  const outputLines = [];
+  const informationMessages = [];
+  const document = {
+    uri: { fsPath: "/repo/rtl/top.sv" },
+    languageId: "systemverilog",
+    lineCount: 1,
+    lineAt() {
+      return { text: "module top;" };
+    },
+    getText() {
+      return "top";
+    },
+  };
+  const handler = createCommandHandler(
+    SHOW_CONTEXT_BUNDLE_AUDIT_COMMAND,
+    {
+      workspace: {
+        workspaceFolders: [{ uri: { fsPath: "/repo" } }],
+        getWorkspaceFolder() {
+          return { uri: { fsPath: "/repo" } };
+        },
+      },
+      window: {
+        activeTextEditor: {
+          document,
+          selection: {
+            start: { line: 0, character: 7 },
+            end: { line: 0, character: 10 },
+          },
+        },
+        showInformationMessage(...args) {
+          informationMessages.push(args);
+        },
+      },
+      languages: {
+        getDiagnostics() {
+          return [{ message: "missing endmodule", range: { start: { line: 0 }, end: { line: 0 } } }];
+        },
+      },
+    },
+    {
+      outputChannel: {
+        appendLine(line) {
+          outputLines.push(line);
+        },
+        show() {},
+      },
+    },
+  );
+
+  const result = await handler();
+
+  assert.equal(result.ok, true);
+  assert.equal(result.commandId, SHOW_CONTEXT_BUNDLE_AUDIT_COMMAND);
+  assert.equal(result.kind, "context-bundle-audit");
+  assert.ok(result.audit.approximateCharacterCount > 0);
+  assert.equal(result.audit.diagnosticCount, 1);
+  assert.equal(result.audit.snippetCount, 1);
+  assert.equal(result.audit.safety.providerCalls, false);
+  assert.equal(result.audit.safety.fullLogsExcluded, true);
+  assert.ok(outputLines.some((line) => line.includes("Context Bundle Audit")));
+  assert.ok(informationMessages.some(([message]) => /Context bundle audit/.test(message)));
+  assert.doesNotMatch(JSON.stringify(result.audit), /\/repo/);
+}
+
 async function testPccxLabBackendStatusCommandReturnsStatusOnly() {
   const settings = new Map([
     ["mode", "checkedExample"],
@@ -1365,6 +1432,7 @@ await testApprovedValidationRunnerExecutesAllowlistedProposalWhenEnabled();
 await testValidationResultCacheCommandsShowAndClear();
 await testPatchProposalPreviewCommandsShowAndClearCheckedProposalOnly();
 await testLocalWorkflowStatusCommandReturnsFixtureOnlyBoundaryState();
+await testContextBundleAuditCommandReturnsBoundedAudit();
 await testPccxLabBackendStatusCommandReturnsStatusOnly();
 
 console.log("vscode extension entrypoint tests ok");

--- a/editors/vscode-prototype/test/extension-host-readiness.test.mjs
+++ b/editors/vscode-prototype/test/extension-host-readiness.test.mjs
@@ -111,6 +111,7 @@ async function testReadinessDocsAndCiPolicy() {
   assert.match(`${readme}\n${readiness}`, /showPatchProposalPreview/);
   assert.match(`${readme}\n${readiness}`, /clearPatchProposalPreview/);
   assert.match(`${readme}\n${readiness}`, /showLocalWorkflowStatus/);
+  assert.match(`${readme}\n${readiness}`, /showContextBundleAudit/);
   assert.match(`${readme}\n${readiness}`, /showPccxLabBackendStatus/);
   assert.match(`${readme}\n${readiness}`, /context bundle command/i);
   assert.match(`${readme}\n${readiness}`, /validation command proposal/i);
@@ -174,6 +175,7 @@ async function testRuntimeRunnerIsPinnedAndBounded() {
   assert.match(suite, /showPatchProposalPreview/);
   assert.match(suite, /clearPatchProposalPreview/);
   assert.match(suite, /showLocalWorkflowStatus/);
+  assert.match(suite, /showContextBundleAudit/);
   assert.match(suite, /validationRunner\.enabled/);
   assert.match(suite, /vscodeAdapterSmoke/);
   assert.match(suite, /showPccxLabBackendStatus/);

--- a/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
+++ b/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
@@ -74,6 +74,7 @@ async function run() {
     "pccxSystemVerilog.showPatchProposalPreview",
     "pccxSystemVerilog.clearPatchProposalPreview",
     "pccxSystemVerilog.showLocalWorkflowStatus",
+    "pccxSystemVerilog.showContextBundleAudit",
     "pccxSystemVerilog.showPccxLabBackendStatus",
   ]);
 
@@ -410,6 +411,16 @@ async function run() {
   assert.equal(localWorkflowStatus.status.launcherBoundary.launcherCalls, false);
   assert.equal(localWorkflowStatus.status.safety.providerCalls, false);
   assert.equal(localWorkflowStatus.status.safety.pccxLabExecution, false);
+
+  const contextBundleAudit = await vscode.commands.executeCommand(
+    "pccxSystemVerilog.showContextBundleAudit",
+  );
+  assert.equal(contextBundleAudit.ok, true);
+  assert.equal(contextBundleAudit.kind, "context-bundle-audit");
+  assert.ok(contextBundleAudit.audit.approximateCharacterCount > 0);
+  assert.equal(contextBundleAudit.audit.safety.providerCalls, false);
+  assert.equal(contextBundleAudit.audit.safety.fullLogsExcluded, true);
+  assert.doesNotMatch(JSON.stringify(contextBundleAudit.audit), /\/home\//);
 
   const disabledValidationRun = await vscode.commands.executeCommand(
     "pccxSystemVerilog.runApprovedValidationCommand",

--- a/editors/vscode-prototype/test/extension-manifest.test.mjs
+++ b/editors/vscode-prototype/test/extension-manifest.test.mjs
@@ -24,6 +24,7 @@ const COMMAND_IDS = [
   "pccxSystemVerilog.showPatchProposalPreview",
   "pccxSystemVerilog.clearPatchProposalPreview",
   "pccxSystemVerilog.showLocalWorkflowStatus",
+  "pccxSystemVerilog.showContextBundleAudit",
   "pccxSystemVerilog.showPccxLabBackendStatus",
 ];
 
@@ -127,6 +128,7 @@ async function testDocsKeepExperimentalScope() {
   assert.match(combined, /pccx-lab command\s+descriptor contract/i);
   assert.match(combined, /launcher status contract/i);
   assert.match(combined, /showLocalWorkflowStatus/);
+  assert.match(combined, /showContextBundleAudit/);
   assert.match(combined, /approved validation runner/i);
   assert.match(combined, /allowlisted proposal IDs/i);
   assert.match(combined, /pccx-lab backend status/i);

--- a/editors/vscode-prototype/test/static-boundary.test.mjs
+++ b/editors/vscode-prototype/test/static-boundary.test.mjs
@@ -138,6 +138,7 @@ async function testProposalAndStatusModulesAreDataOnly() {
     resolve(EXTENSION_ROOT, "src/pccx-lab-command-descriptor.mjs"),
     resolve(EXTENSION_ROOT, "src/launcher-status-contract.mjs"),
     resolve(EXTENSION_ROOT, "src/local-workflow-status.mjs"),
+    resolve(EXTENSION_ROOT, "src/context-bundle-audit.mjs"),
     resolve(EXTENSION_ROOT, "src/pccx-lab-status.mjs"),
   ]);
 

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -24,6 +24,7 @@ node editors/vscode-prototype/test/validation-patch-handoff.test.mjs
 node editors/vscode-prototype/test/pccx-lab-command-descriptor.test.mjs
 node editors/vscode-prototype/test/launcher-status-contract.test.mjs
 node editors/vscode-prototype/test/local-workflow-status.test.mjs
+node editors/vscode-prototype/test/context-bundle-audit.test.mjs
 node editors/vscode-prototype/test/validation-result-summary.test.mjs
 node editors/vscode-prototype/test/validation-result-cache.test.mjs
 node editors/vscode-prototype/test/approved-validation-runner.test.mjs


### PR DESCRIPTION
## Summary
- add a local context bundle audit command for the VS Code prototype
- report bounded counts, truncation/redaction indicators, and excluded context categories
- cover the command in manifest, entrypoint, static, readiness, adapter, and opt-in extension-host smoke tests

## Scope
- local prototype command: pccxSystemVerilog.showContextBundleAudit
- summary-only audit data derived from the existing bounded context bundle
- docs update for the local AI/context boundary and extension-host readiness notes

## Non-goals
- no AI provider calls
- no upload, network call, MCP call, LSP server, marketplace flow, or packaging change
- no launcher runtime call and no pccx-lab execution

## Validation
- npm ci --prefix editors/vscode-prototype
- bash scripts/vscode-adapter-smoke.sh
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- python3 -m pytest -q
- git diff --check
- bash scripts/vscode-extension-host-smoke.sh exits 2 by default
- PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh

## Safety notes
- no release/tag created
- no FPGA repository access or edits
- no private instruction material added