### PR TITLE
chore: expand public claim guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,21 @@ jobs:
           import os, re, sys
           PATTERN = re.compile(
               r"(?:\bis\s+|\bnow\s+|\balready\s+|\bcurrently\s+)?"
-              r"(production[- ]ready|timing[- ]closed|fully verified|"
-              r"stable plugin abi|stable lsp|kv260 inference (?:works|works now|is working|is functional))",
+              r"(production[- ]ready|marketplace[- ]ready|"
+              r"(?<!pre-)stable\s+(?:plugin\s+)?(?:api|abi|lsp)|"
+              r"(?<!pre-)stable\s+diagnostics\s+envelope|"
+              r"mcp\s+ready|ai\s+provider\s+ready|"
+              r"kv260\s+inference\s+(?:works|works\s+now|is\s+working|is\s+functional)|"
+              r"20\s*tok/s\s+achieved|timing[- ]closed|"
+              r"autonomous\s+coding\s+product|vibe\s+coding|"
+              r"(?:claude|gpt)\s+directly\s+controls|"
+              r"complete\s+ai\s+integration|fully\s+(?:verified|validated)|"
+              r"ci-covered|approved\s+runner\s+proves)",
               re.IGNORECASE,
           )
           NEGATION = re.compile(
               r"\b(?:no|not|never|avoid|without|forbidden|skip|do not"
-              r"|does not|is not|are not)\b",
+              r"|does not|is not|are not|unsupported)\b",
               re.IGNORECASE,
           )
           SCAN_EXTS = {".md", ".sh", ".yml", ".yaml"}
@@ -44,9 +52,14 @@ jobs:
                   if not any(rel.endswith(ext) for ext in SCAN_EXTS):
                       continue
                   with open(rel, encoding="utf-8", errors="replace") as fh:
-                      for i, line in enumerate(fh, 1):
-                          if PATTERN.search(line) and not NEGATION.search(line):
-                              violations.append(f"{rel}:{i}: {line.rstrip()}")
+                      lines = fh.read().splitlines()
+                      for index, line in enumerate(lines):
+                          context = " ".join(
+                              lines[i]
+                              for i in range(max(0, index - 2), min(len(lines), index + 2))
+                          )
+                          if PATTERN.search(line) and not NEGATION.search(context):
+                              violations.append(f"{rel}:{index + 1}: {line}")
           if violations:
               print("Forbidden positive claims detected:")
               for v in violations:

--- a/editors/vscode-prototype/test/static-boundary.test.mjs
+++ b/editors/vscode-prototype/test/static-boundary.test.mjs
@@ -5,6 +5,14 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 const EXTENSION_ROOT = resolve(ROOT, "editors/vscode-prototype");
+const POSITIVE_CLAIM =
+  /\b(?:production[- ]ready|marketplace[- ]ready|(?<!pre-)stable\s+(?:plugin\s+)?(?:API|ABI|LSP)|(?<!pre-)stable\s+diagnostics\s+envelope|MCP\s+ready|AI\s+provider\s+ready|KV260\s+inference\s+(?:works|works\s+now|is\s+working|is\s+functional)|20\s*tok\/s\s+achieved|timing[- ]closed|autonomous\s+coding\s+product|vibe\s+coding|(?:Claude|GPT)\s+directly\s+controls|complete\s+AI\s+integration|fully\s+(?:validated|verified)|CI-covered|approved\s+runner\s+proves)\b/i;
+const POSITIVE_CLAIM_NEGATION =
+  /\b(?:no|not|never|without|does not|is not|are not|avoid|do not|forbidden|unsupported)\b/i;
+
+function hasPositiveClaimWithoutNegation(line, context) {
+  return POSITIVE_CLAIM.test(line) && !POSITIVE_CLAIM_NEGATION.test(context);
+}
 
 async function readText(path) {
   return readFile(path, "utf8");
@@ -223,13 +231,11 @@ async function testNoPositiveReadinessClaims() {
       allowedExtensions: [".md", ".sh", ".yml", ".yaml", ".py", ".mjs", ".cjs", ".js", ".json"],
     }),
   ].filter((path) => (
+    path !== resolve(ROOT, ".github/workflows/ci.yml") &&
     !path.includes("/package-lock.json") &&
     !path.includes("/tests/") &&
     !path.endsWith("/editors/vscode-prototype/test/static-boundary.test.mjs")
   ));
-  const positiveClaim =
-    /\b(?:production[- ]ready|(?<!pre-)stable API|(?<!pre-)stable ABI|(?<!pre-)stable diagnostics envelope|marketplace-ready|complete AI integration|fully validated|CI-covered|approved runner proves)\b/i;
-  const negation = /\b(?:no|not|never|without|does not|is not|are not|avoid|do not)\b/i;
   const violations = [];
 
   for (const file of files) {
@@ -241,13 +247,43 @@ async function testNoPositiveReadinessClaims() {
         line,
         lines[index + 1] ?? "",
       ].join(" ");
-      if (positiveClaim.test(line) && !negation.test(context)) {
+      if (hasPositiveClaimWithoutNegation(line, context)) {
         violations.push(`${file}:${index + 1}: ${line}`);
       }
     });
   }
 
   assert.deepEqual(violations, []);
+}
+
+function testPositiveClaimGuardCoversRoadmapPhrases() {
+  [
+    "production-ready",
+    "marketplace-ready",
+    "stable API",
+    "stable ABI",
+    "stable LSP",
+    "MCP ready",
+    "AI provider ready",
+    "KV260 inference works",
+    "20 tok/s achieved",
+    "timing closed",
+    "autonomous coding product",
+    "vibe coding",
+    "Claude directly controls",
+    "GPT directly controls",
+  ].forEach((claim) => {
+    assert.equal(hasPositiveClaimWithoutNegation(claim, claim), true);
+  });
+
+  [
+    "not a stable API",
+    "pre-stable API",
+    "no MCP ready claim",
+    "unsupported KV260 inference works claim",
+  ].forEach((claim) => {
+    assert.equal(hasPositiveClaimWithoutNegation(claim, claim), false);
+  });
 }
 
 await testNoDirectAiProviderOrNetworkCalls();
@@ -259,5 +295,6 @@ await testProposalAndStatusModulesAreDataOnly();
 await testApprovedValidationRunnerUsesOnlyAllowlistedExecution();
 await testContextBundleDoesNotSerializePrivateInstructionNames();
 await testNoPositiveReadinessClaims();
+testPositiveClaimGuardCoversRoadmapPhrases();
 
 console.log("vscode static boundary tests ok");


### PR DESCRIPTION
## Summary
- expand the public positive-claim guard in CI and static boundary tests
- cover unsupported readiness and control claims for marketplace, LSP, MCP, AI provider, KV260 inference, token-rate, timing, and direct-control wording
- make the CI scanner use nearby-line context so wrapped negative statements do not fail incorrectly

## Scope
- CI claim-scan regex and context handling
- VS Code prototype static boundary claim regex and regression samples

## Non-goals
- no product, marketplace, LSP, MCP, provider, launcher, or hardware runtime work
- no release/tag
- no FPGA repository access or edits

## Validation
- local CI claim-scan reproduction
- npm ci --prefix editors/vscode-prototype
- bash scripts/vscode-adapter-smoke.sh
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- python3 -m pytest -q
- git diff --check
- bash scripts/vscode-extension-host-smoke.sh exits 2 by default
- PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh