### PR TITLE
test(vscode): expand opt-in extension host smoke coverage

### DIFF
--- a/editors/vscode-prototype/test/extension-host-readiness.test.mjs
+++ b/editors/vscode-prototype/test/extension-host-readiness.test.mjs
@@ -172,6 +172,8 @@ async function testRuntimeRunnerIsPinnedAndBounded() {
   assert.match(suite, /showRecentValidationResults/);
   assert.match(suite, /showValidationCacheStatus/);
   assert.match(suite, /clearValidationResultCache/);
+  assert.match(suite, /clearValidationCache/);
+  assert.match(suite, /recentValidationResultsEmpty/);
   assert.match(suite, /showPatchProposalPreview/);
   assert.match(suite, /clearPatchProposalPreview/);
   assert.match(suite, /showLocalWorkflowStatus/);

--- a/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
+++ b/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
@@ -484,6 +484,29 @@ async function run() {
     assert.equal(cacheStatus.status.latest.status, "passed");
     assert.equal(cacheStatus.status.summaryOnly, true);
     assert.equal(cacheStatus.status.fullLogsExcluded, true);
+
+    const clearValidationCache = await vscode.commands.executeCommand(
+      "pccxSystemVerilog.clearValidationResultCache",
+    );
+    assert.equal(clearValidationCache.ok, true);
+    assert.equal(clearValidationCache.kind, "validation-result-cache-clear");
+    assert.equal(clearValidationCache.clearedCount, 2);
+
+    const emptyCacheStatus = await vscode.commands.executeCommand(
+      "pccxSystemVerilog.showValidationCacheStatus",
+    );
+    assert.equal(emptyCacheStatus.ok, true);
+    assert.equal(emptyCacheStatus.kind, "validation-result-cache-status");
+    assert.equal(emptyCacheStatus.status.count, 0);
+    assert.equal(emptyCacheStatus.status.latest, null);
+
+    const recentValidationResultsEmpty = await vscode.commands.executeCommand(
+      "pccxSystemVerilog.showRecentValidationResults",
+    );
+    assert.equal(recentValidationResultsEmpty.ok, true);
+    assert.equal(recentValidationResultsEmpty.kind, "validation-result-cache");
+    assert.deepEqual(recentValidationResultsEmpty.entries, []);
+    assert.equal(recentValidationResultsEmpty.selected, null);
   } finally {
     await updatePrototypeConfig("validationRunner.enabled", false);
     await updatePrototypeConfig("validationRunner.mode", "disabled");


### PR DESCRIPTION
## Summary
- expand the opt-in Extension Host smoke matrix for validation cache commands
- execute cache clear after a bounded allowlisted validation run
- verify empty cache status and empty recent-results command behavior after clearing

## Scope
- local opt-in runtime smoke suite only
- readiness test assertions that the suite covers the new execution paths

## Non-goals
- no CI runtime smoke enablement
- no product, marketplace, LSP, MCP, provider, launcher, or hardware runtime work
- no release/tag
- no FPGA repository access or edits

## Validation
- node editors/vscode-prototype/test/extension-host-readiness.test.mjs
- npm ci --prefix editors/vscode-prototype
- bash scripts/vscode-adapter-smoke.sh
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- python3 -m pytest -q
- git diff --check
- bash scripts/vscode-extension-host-smoke.sh exits 2 by default
- PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh