### PR TITLE
Add read-only diagnostics handoff consumer boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,13 @@ token-saving context bundle commands with no provider calls.  The
 guarded Extension Host runtime smoke uses only the controlled fixture
 under `editors/vscode-prototype/test/fixtures/live-workspace`.
 
+The VS Code prototype also has a read-only diagnostics handoff consumer
+for the launcher / pccx-lab `pccx.diagnosticsHandoff.v0` JSON shape. It
+parses a checked local fixture and returns deterministic summary data for
+future UI use. It does not execute the launcher, execute pccx-lab, invoke
+the pccx-lab validator, implement MCP or LSP, call providers, or touch
+hardware.
+
 ## Later track (deferred)
 
 - Local coding-assistant mode can propose interactions with `pccx-lab`

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -7,6 +7,8 @@ Two handoff paths are tracked:
 
 1. The `pccx-lab` CLI / core boundary (analysis backend) — **wired**.
 2. The xsim runner / log surfacing path inside `pccx-lab` — **planned**.
+3. The launcher diagnostics handoff JSON consumer — **read-only fixture
+   boundary**.
 
 ---
 
@@ -84,6 +86,28 @@ exit 2 with a message on stderr.
 - This CLI does not implement an LSP server.
 - There is no stable plugin ABI claim.
 - There is no full IDE replacement claim.
+
+---
+
+## launcher diagnostics handoff consumer (read-only)
+
+The VS Code prototype includes a small adapter for
+`pccx.diagnosticsHandoff.v0` launcher diagnostics handoff JSON. The
+adapter reads a local JSON value supplied by tests or future UI code,
+validates the expected field shape, and returns deterministic summary
+data.
+
+The checked fixture lives at
+`docs/examples/diagnostics-handoff/launcher-diagnostics-handoff.example.json`.
+
+This path is data-only. It does not execute `pccx-llm-launcher`, does not
+execute `pccx-lab`, does not invoke the pccx-lab validator command, does
+not spawn shell commands, does not implement MCP or LSP, does not call
+providers, and does not touch hardware.
+
+The pccx-lab validator remains a separate CLI/core boundary. The IDE
+consumer is for future presentation and context use, not for bypassing
+launcher or lab ownership.
 
 ---
 

--- a/docs/examples/diagnostics-handoff/launcher-diagnostics-handoff.example.json
+++ b/docs/examples/diagnostics-handoff/launcher-diagnostics-handoff.example.json
@@ -1,0 +1,223 @@
+{
+  "artifactRefs": [
+    {
+      "artifactId": "launcher_status_contract_fixture",
+      "artifactKind": "json_fixture",
+      "reference": "contracts/fixtures/launcher-ide-status.placeholder.json",
+      "referenceKind": "read_only_local_artifact_reference"
+    },
+    {
+      "artifactId": "model_runtime_descriptor_fixture",
+      "artifactKind": "json_fixture",
+      "reference": "contracts/fixtures/model-runtime-descriptor.gemma3n-e4b-kv260-placeholder.json",
+      "referenceKind": "read_only_local_artifact_reference"
+    }
+  ],
+  "consumer": {
+    "boundary": "cli_core_future_consumer",
+    "id": "pccx-lab",
+    "role": "pccx_lab_future_consumer",
+    "state": "planned"
+  },
+  "createdAt": "1970-01-01T00:00:00Z",
+  "diagnostics": [
+    {
+      "category": "configuration",
+      "diagnosticId": "launcher_target_not_configured",
+      "evidenceState": "evidence_required",
+      "redactionState": "sanitized_summary",
+      "relatedContractRefs": [
+        "pccx.launcherIdeStatus.v0"
+      ],
+      "severity": "warning",
+      "source": "pccx-llm-launcher",
+      "suggestedNextAction": "Keep the handoff read-only until target configuration evidence exists.",
+      "summary": "The handoff records a placeholder target state only.",
+      "title": "Launcher target is not configured"
+    },
+    {
+      "category": "model_descriptor",
+      "diagnosticId": "gemma3n_e4b_descriptor_reference_only",
+      "evidenceState": "evidence_required",
+      "redactionState": "sanitized_summary",
+      "relatedContractRefs": [
+        "pccx.modelDescriptor.v0"
+      ],
+      "severity": "info",
+      "source": "pccx-llm-launcher",
+      "suggestedNextAction": "Collect descriptor and asset evidence before runtime claims.",
+      "summary": "Gemma 3N E4B is represented as descriptor_ref_only with no bundled assets.",
+      "title": "Model descriptor is referenced by id"
+    },
+    {
+      "category": "runtime_descriptor",
+      "diagnosticId": "kv260_runtime_placeholder_not_configured",
+      "evidenceState": "evidence_required",
+      "redactionState": "sanitized_summary",
+      "relatedContractRefs": [
+        "pccx.runtimeDescriptor.v0",
+        "pccx.modelRuntimeCompatibility.v0"
+      ],
+      "severity": "blocked",
+      "source": "pccx-llm-launcher",
+      "suggestedNextAction": "Require pccx-lab/core evidence before enabling runtime integration.",
+      "summary": "The runtime descriptor is planned, unavailable, and not configured.",
+      "title": "KV260 runtime remains placeholder"
+    },
+    {
+      "category": "evidence",
+      "diagnosticId": "hardware_and_measurement_evidence_missing",
+      "evidenceState": "not_measured",
+      "redactionState": "sanitized_summary",
+      "relatedContractRefs": [
+        "pccx.modelRuntimeCompatibility.v0"
+      ],
+      "severity": "blocked",
+      "source": "pccx-llm-launcher",
+      "suggestedNextAction": "Treat all hardware and performance claims as not measured.",
+      "summary": "Compatibility stays provisional until checked evidence exists.",
+      "title": "Hardware and measurement evidence are missing"
+    },
+    {
+      "category": "safety",
+      "diagnosticId": "read_only_privacy_boundary",
+      "evidenceState": "placeholder",
+      "redactionState": "sanitized_summary",
+      "relatedContractRefs": [
+        "pccx.diagnosticsHandoff.v0"
+      ],
+      "severity": "info",
+      "source": "pccx-llm-launcher",
+      "suggestedNextAction": "Keep future consumer behavior explicit and opt-in.",
+      "summary": "The fixture carries no telemetry, upload, write-back, raw logs, prompts, or private paths.",
+      "title": "Read-only privacy boundary is active"
+    }
+  ],
+  "evidenceRefs": [
+    {
+      "evidenceId": "model_descriptor_evidence",
+      "referenceKind": "descriptor_ref_only",
+      "state": "evidence_required"
+    },
+    {
+      "evidenceId": "kv260_hardware_evidence",
+      "referenceKind": "descriptor_ref_only",
+      "state": "evidence_required"
+    },
+    {
+      "evidenceId": "measurement_evidence",
+      "referenceKind": "descriptor_ref_only",
+      "state": "not_measured"
+    }
+  ],
+  "handoffId": "launcher_diagnostics_handoff_gemma3n_e4b_kv260_placeholder",
+  "handoffKind": "read_only_handoff",
+  "issueRefs": [
+    "pccxai/pccx-llm-launcher#5",
+    "pccxai/pccx-llm-launcher#3",
+    "pccxai/pccx-llm-launcher#12"
+  ],
+  "launcherStatusRef": {
+    "coupling": "data_reference_only",
+    "fixture": "contracts/fixtures/launcher-ide-status.placeholder.json",
+    "operationId": "pccxlab.diagnostics.handoff",
+    "referenceKind": "descriptor_ref_only",
+    "schemaVersion": "pccx.launcherIdeStatus.v0"
+  },
+  "limitations": [
+    "Data-only placeholder; no pccx-lab execution is performed.",
+    "No launcher runtime execution, model execution, provider call, or network call is performed.",
+    "No KV260 hardware access is performed.",
+    "No telemetry, automatic upload, or auto write-back is included.",
+    "No raw full logs, prompts, source code, private paths, secrets, tokens, provider configuration, generated blobs, or model weight paths are included.",
+    "The contract is not a versioned compatibility commitment."
+  ],
+  "modelDescriptorRef": {
+    "fixture": "contracts/fixtures/model-runtime-descriptor.gemma3n-e4b-kv260-placeholder.json",
+    "modelId": "gemma3n_e4b_placeholder",
+    "referenceKind": "descriptor_ref_only",
+    "schemaVersion": "pccx.modelDescriptor.v0"
+  },
+  "privacyFlags": {
+    "automaticUpload": false,
+    "generatedBlobsIncluded": false,
+    "modelWeightPathsIncluded": false,
+    "privatePathsIncluded": false,
+    "providerConfigsIncluded": false,
+    "rawFullLogsIncluded": false,
+    "secretsIncluded": false,
+    "telemetryPolicy": "no_telemetry",
+    "tokensIncluded": false,
+    "uploadPolicy": "no_user_data_upload",
+    "userPromptsIncluded": false,
+    "userSourceCodeIncluded": false
+  },
+  "producer": {
+    "execution": "data_only",
+    "id": "pccx-llm-launcher",
+    "role": "launcher_generated_summary"
+  },
+  "runtimeDescriptorRef": {
+    "fixture": "contracts/fixtures/model-runtime-descriptor.gemma3n-e4b-kv260-placeholder.json",
+    "referenceKind": "descriptor_ref_only",
+    "runtimeId": "kv260_pccx_placeholder",
+    "schemaVersion": "pccx.runtimeDescriptor.v0"
+  },
+  "safetyFlags": {
+    "automaticUpload": false,
+    "contractKind": "read_only_handoff",
+    "dataOnly": true,
+    "descriptorPolicy": "descriptor_ref_only",
+    "evidencePolicy": "evidence_required",
+    "executesLauncher": false,
+    "executesPccxLab": false,
+    "hardwarePolicy": "no_hardware_access",
+    "kv260Access": false,
+    "lspImplemented": false,
+    "marketplaceFlow": false,
+    "mcpServerImplemented": false,
+    "modelExecution": false,
+    "networkCalls": false,
+    "providerCalls": false,
+    "readOnly": true,
+    "runtimeExecution": false,
+    "runtimePolicy": "no_runtime_execution",
+    "shellExecution": false,
+    "telemetry": false,
+    "touchesHardware": false,
+    "writeBack": false,
+    "writeBackPolicy": "no_auto_writeback"
+  },
+  "schemaVersion": "pccx.diagnosticsHandoff.v0",
+  "sessionId": "placeholder_session",
+  "targetDevice": {
+    "accessState": "no_hardware_access",
+    "configurationState": "not_configured",
+    "id": "kv260_pccx_placeholder",
+    "label": "KV260 PCCX placeholder"
+  },
+  "targetKind": "kv260",
+  "transport": [
+    {
+      "direction": "launcher_to_pccx_lab_future_consumer",
+      "execution": "no_pccx_lab_execution",
+      "mode": "read_only_handoff",
+      "state": "sketch",
+      "transportKind": "json_file"
+    },
+    {
+      "direction": "launcher_to_pccx_lab_future_consumer",
+      "execution": "no_pccx_lab_execution",
+      "mode": "read_only_handoff",
+      "state": "sketch",
+      "transportKind": "stdout_json"
+    },
+    {
+      "direction": "launcher_to_pccx_lab_future_consumer",
+      "execution": "no_pccx_lab_execution",
+      "mode": "read_only_handoff",
+      "state": "sketch",
+      "transportKind": "read_only_local_artifact_reference"
+    }
+  ]
+}

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -200,6 +200,15 @@ validation summary, lists required future safety properties such as fixed
 args, no shell interpolation, explicit user approval, bounded output, and
 context bundle summary, and does not execute pccx-lab.
 
+`src/diagnostics-handoff-consumer.mjs` is a read-only adapter for the
+launcher diagnostics handoff JSON shape.  It validates the checked
+`pccx.diagnosticsHandoff.v0` fixture as data and returns a deterministic
+summary for future UI use.  It does not invoke `pccx-llm-launcher`, does
+not invoke `pccx-lab`, does not run the pccx-lab validator command, does
+not spawn shell commands, and does not implement MCP or LSP.  The boundary
+is documented in
+[`docs/diagnostics-handoff-consumer.md`](./docs/diagnostics-handoff-consumer.md).
+
 `src/command-handlers.mjs` is the experimental local command-handler
 scaffold.  It maps command ID -> normalized prototype settings -> known
 facade argument array -> facade JSON result -> testable UI action model.

--- a/editors/vscode-prototype/docs/diagnostics-handoff-consumer.md
+++ b/editors/vscode-prototype/docs/diagnostics-handoff-consumer.md
@@ -1,0 +1,62 @@
+# Diagnostics Handoff Consumer
+
+This document describes the VS Code prototype boundary for launcher
+diagnostics handoff JSON. It is an experimental, read-only data consumer.
+It parses a local `pccx.diagnosticsHandoff.v0`-style JSON document and
+returns a deterministic summary for future UI surfaces.
+
+The implementation lives in:
+
+- `src/diagnostics-handoff-consumer.mjs`
+- `test/diagnostics-handoff-consumer.test.mjs`
+- `../../docs/examples/diagnostics-handoff/launcher-diagnostics-handoff.example.json`
+
+## What It Does
+
+The consumer validates:
+
+- required handoff fields
+- diagnostic severity and category values
+- launcher, model, and runtime descriptor references
+- read-only local artifact references
+- JSON file, stdout JSON, and read-only local artifact transport sketches
+- no telemetry, no automatic upload, and no write-back flags
+- no launcher execution, no pccx-lab execution, no shell execution, no
+  provider calls, no runtime calls, no MCP calls, no LSP implementation,
+  and no marketplace flow flags
+
+The summary records diagnostic counts by severity and category, descriptor
+references, transport kinds, limitations, and safety flags. The output is
+deterministic JSON and is suitable for a later UI panel or context bundle
+entry.
+
+## What It Does Not Do
+
+This boundary does not:
+
+- execute `pccx-llm-launcher`
+- execute `pccx-lab`
+- invoke `pccx-lab diagnostics-handoff validate`
+- spawn shell commands
+- call network APIs or model providers
+- touch hardware or model weights
+- implement MCP
+- implement LSP
+- upload telemetry
+- write back to launcher or lab state
+- commit to API or ABI stability
+
+The pccx-lab validator remains a separate CLI/core boundary. The IDE
+consumer reads local JSON as data and should not bypass pccx-lab or
+launcher boundaries.
+
+## Fixture Sync
+
+The checked fixture is copied from the launcher/lab handoff shape and is
+manual for now. It is sanitized: no raw full logs, prompts, source code,
+private paths, secrets, tokens, provider configuration, generated blobs,
+hardware dumps, or model weight paths.
+
+Future work may add UI presentation for this summary. That presentation
+should stay above this adapter layer and should keep pccx-lab as the
+verification/tooling backend.

--- a/editors/vscode-prototype/src/diagnostics-handoff-consumer.mjs
+++ b/editors/vscode-prototype/src/diagnostics-handoff-consumer.mjs
@@ -1,0 +1,530 @@
+export const DIAGNOSTICS_HANDOFF_CONSUMER_VERSION =
+  "pccx.ideDiagnosticsHandoffConsumer.v0";
+export const DIAGNOSTICS_HANDOFF_SCHEMA_VERSION = "pccx.diagnosticsHandoff.v0";
+
+export const DIAGNOSTICS_HANDOFF_SEVERITIES = Object.freeze([
+  "info",
+  "warning",
+  "blocked",
+  "error",
+]);
+
+export const DIAGNOSTICS_HANDOFF_CATEGORIES = Object.freeze([
+  "configuration",
+  "model_descriptor",
+  "runtime_descriptor",
+  "target_device",
+  "evidence",
+  "safety",
+  "diagnostics_handoff",
+]);
+
+const HANDOFF_FIELDS = Object.freeze([
+  "schemaVersion",
+  "handoffId",
+  "handoffKind",
+  "producer",
+  "consumer",
+  "createdAt",
+  "sessionId",
+  "launcherStatusRef",
+  "modelDescriptorRef",
+  "runtimeDescriptorRef",
+  "targetKind",
+  "targetDevice",
+  "diagnostics",
+  "evidenceRefs",
+  "artifactRefs",
+  "privacyFlags",
+  "safetyFlags",
+  "transport",
+  "limitations",
+  "issueRefs",
+]);
+
+const DIAGNOSTIC_FIELDS = Object.freeze([
+  "diagnosticId",
+  "severity",
+  "category",
+  "source",
+  "title",
+  "summary",
+  "relatedContractRefs",
+  "suggestedNextAction",
+  "evidenceState",
+  "redactionState",
+]);
+
+const TRANSPORT_KINDS = Object.freeze([
+  "json_file",
+  "stdout_json",
+  "read_only_local_artifact_reference",
+]);
+
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]/i;
+const HOME_PATH_PATTERN = /(?:\/home\/[^/\s]+|\/Users\/[^/\s]+|[A-Za-z]:\\Users\\)/;
+const MODEL_ARTIFACT_PATTERN =
+  /\.(?:gguf|safetensors|ckpt|pt|pth|onnx|xclbin|bit)(?:\s|$|["'])/i;
+const RAW_ARTIFACT_PATTERN =
+  /\b(?:raw[_-]?full[_-]?logs|hardware[_-]?dump|generated[_-]?blob|bitstream)\b\s*[:=]/i;
+
+const UNSUPPORTED_MARKER_PARTS = Object.freeze([
+  ["production", "ready"],
+  ["marketplace", "ready"],
+  ["stable", "api"],
+  ["stable", "abi"],
+  ["kv260 inference ", "works"],
+  ["gemma 3n e4b runs on ", "kv260"],
+  ["20 tok/s ", "achieved"],
+  ["timing ", "closed"],
+  ["autonomous coding ", "system"],
+]);
+
+function addError(errors, path, message) {
+  errors.push(`${path}: ${message}`);
+}
+
+function isObject(value) {
+  return value && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringField(value, path, errors) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    addError(errors, path, "must be a non-empty string");
+    return "";
+  }
+  if (value.includes("\0") || value.includes("\n") || value.includes("\r")) {
+    addError(errors, path, "must be a single-line string");
+  }
+  return value;
+}
+
+function stringPath(root, path, errors) {
+  let current = root;
+  for (const part of path) {
+    current = isObject(current) ? current[part] : undefined;
+  }
+  return stringField(current, path.join("."), errors);
+}
+
+function boolPath(root, path, expected, errors) {
+  let current = root;
+  for (const part of path) {
+    current = isObject(current) ? current[part] : undefined;
+  }
+  if (typeof current !== "boolean") {
+    addError(errors, path.join("."), "must be a boolean");
+    return false;
+  }
+  if (current !== expected) {
+    addError(errors, path.join("."), `must be ${expected}`);
+  }
+  return current;
+}
+
+function arrayPath(root, path, errors) {
+  let current = root;
+  for (const part of path) {
+    current = isObject(current) ? current[part] : undefined;
+  }
+  if (!Array.isArray(current)) {
+    addError(errors, path.join("."), "must be an array");
+    return [];
+  }
+  return current;
+}
+
+function ensureValue(actual, expected, path, errors) {
+  if (actual !== expected) {
+    addError(errors, path, `must be ${expected}`);
+  }
+}
+
+function ensureAllowed(actual, allowed, path, errors) {
+  if (!allowed.includes(actual)) {
+    addError(errors, path, `must be one of: ${allowed.join(", ")}`);
+  }
+}
+
+function assertSafeSerializedText(handoff, errors) {
+  let text = "";
+  try {
+    text = JSON.stringify(handoff ?? {});
+  } catch {
+    addError(errors, "handoff", "must be JSON-serializable");
+    return;
+  }
+  const lower = text.toLowerCase();
+  if (
+    SECRET_ASSIGNMENT_PATTERN.test(text) ||
+    HOME_PATH_PATTERN.test(text) ||
+    MODEL_ARTIFACT_PATTERN.test(text) ||
+    RAW_ARTIFACT_PATTERN.test(text)
+  ) {
+    addError(
+      errors,
+      "handoff",
+      "must not include secrets, private paths, raw artifacts, or model artifact paths",
+    );
+  }
+  for (const parts of UNSUPPORTED_MARKER_PARTS) {
+    const marker = parts.join("");
+    if (lower.includes(marker)) {
+      addError(errors, "handoff", "must not include unsupported runtime or readiness claims");
+    }
+  }
+}
+
+function zeroCounts(values) {
+  return Object.fromEntries(values.map((value) => [value, 0]));
+}
+
+function validateDiagnostics(handoff, errors) {
+  const diagnostics = arrayPath(handoff, ["diagnostics"], errors);
+  const diagnosticsBySeverity = zeroCounts(DIAGNOSTICS_HANDOFF_SEVERITIES);
+  const diagnosticsByCategory = zeroCounts(DIAGNOSTICS_HANDOFF_CATEGORIES);
+
+  if (diagnostics.length === 0) {
+    addError(errors, "diagnostics", "must contain at least one diagnostic item");
+  }
+
+  diagnostics.forEach((diagnostic, index) => {
+    if (!isObject(diagnostic)) {
+      addError(errors, `diagnostics[${index}]`, "must be an object");
+      return;
+    }
+    for (const field of DIAGNOSTIC_FIELDS) {
+      if (!Object.hasOwn(diagnostic, field)) {
+        addError(errors, `diagnostics[${index}].${field}`, "is required");
+      }
+    }
+    const severity = stringField(diagnostic.severity, `diagnostics[${index}].severity`, errors);
+    const category = stringField(diagnostic.category, `diagnostics[${index}].category`, errors);
+    ensureAllowed(
+      severity,
+      DIAGNOSTICS_HANDOFF_SEVERITIES,
+      `diagnostics[${index}].severity`,
+      errors,
+    );
+    ensureAllowed(
+      category,
+      DIAGNOSTICS_HANDOFF_CATEGORIES,
+      `diagnostics[${index}].category`,
+      errors,
+    );
+    if (Object.hasOwn(diagnosticsBySeverity, severity)) {
+      diagnosticsBySeverity[severity] += 1;
+    }
+    if (Object.hasOwn(diagnosticsByCategory, category)) {
+      diagnosticsByCategory[category] += 1;
+    }
+    if (!Array.isArray(diagnostic.relatedContractRefs) ||
+        diagnostic.relatedContractRefs.length === 0) {
+      addError(errors, `diagnostics[${index}].relatedContractRefs`, "must be a non-empty array");
+    }
+  });
+
+  return {
+    diagnosticCount: diagnostics.length,
+    diagnosticsBySeverity,
+    diagnosticsByCategory,
+  };
+}
+
+function validateReferences(handoff, errors) {
+  const launcherOperationId = stringPath(
+    handoff,
+    ["launcherStatusRef", "operationId"],
+    errors,
+  );
+  const modelId = stringPath(handoff, ["modelDescriptorRef", "modelId"], errors);
+  const runtimeId = stringPath(handoff, ["runtimeDescriptorRef", "runtimeId"], errors);
+  ensureValue(launcherOperationId, "pccxlab.diagnostics.handoff", "launcherStatusRef.operationId", errors);
+  ensureValue(
+    stringPath(handoff, ["launcherStatusRef", "referenceKind"], errors),
+    "descriptor_ref_only",
+    "launcherStatusRef.referenceKind",
+    errors,
+  );
+  ensureValue(
+    stringPath(handoff, ["modelDescriptorRef", "referenceKind"], errors),
+    "descriptor_ref_only",
+    "modelDescriptorRef.referenceKind",
+    errors,
+  );
+  ensureValue(
+    stringPath(handoff, ["runtimeDescriptorRef", "referenceKind"], errors),
+    "descriptor_ref_only",
+    "runtimeDescriptorRef.referenceKind",
+    errors,
+  );
+  return {
+    launcherOperationId,
+    modelId,
+    runtimeId,
+    referenceKind: "descriptor_ref_only",
+  };
+}
+
+function validateArtifacts(handoff, errors) {
+  arrayPath(handoff, ["artifactRefs"], errors).forEach((artifact, index) => {
+    if (!isObject(artifact)) {
+      addError(errors, `artifactRefs[${index}]`, "must be an object");
+      return;
+    }
+    ensureValue(
+      stringField(artifact.referenceKind, `artifactRefs[${index}].referenceKind`, errors),
+      "read_only_local_artifact_reference",
+      `artifactRefs[${index}].referenceKind`,
+      errors,
+    );
+    const reference = stringField(artifact.reference, `artifactRefs[${index}].reference`, errors);
+    if (
+      reference.startsWith("/") ||
+      reference.includes(":\\") ||
+      reference.startsWith("http://") ||
+      reference.startsWith("https://")
+    ) {
+      addError(
+        errors,
+        `artifactRefs[${index}].reference`,
+        "must be a relative read-only local artifact reference",
+      );
+    }
+  });
+}
+
+function validateTransport(handoff, errors) {
+  const kinds = [];
+  arrayPath(handoff, ["transport"], errors).forEach((transport, index) => {
+    if (!isObject(transport)) {
+      addError(errors, `transport[${index}]`, "must be an object");
+      return;
+    }
+    const kind = stringField(transport.transportKind, `transport[${index}].transportKind`, errors);
+    ensureAllowed(kind, TRANSPORT_KINDS, `transport[${index}].transportKind`, errors);
+    ensureValue(
+      stringField(transport.mode, `transport[${index}].mode`, errors),
+      "read_only_handoff",
+      `transport[${index}].mode`,
+      errors,
+    );
+    ensureValue(
+      stringField(transport.execution, `transport[${index}].execution`, errors),
+      "no_pccx_lab_execution",
+      `transport[${index}].execution`,
+      errors,
+    );
+    kinds.push(kind);
+  });
+  return kinds;
+}
+
+function validateSafety(handoff, errors) {
+  ensureValue(
+    stringPath(handoff, ["privacyFlags", "uploadPolicy"], errors),
+    "no_user_data_upload",
+    "privacyFlags.uploadPolicy",
+    errors,
+  );
+  ensureValue(
+    stringPath(handoff, ["privacyFlags", "telemetryPolicy"], errors),
+    "no_telemetry",
+    "privacyFlags.telemetryPolicy",
+    errors,
+  );
+
+  [
+    ["privacyFlags", "automaticUpload"],
+    ["privacyFlags", "rawFullLogsIncluded"],
+    ["privacyFlags", "userPromptsIncluded"],
+    ["privacyFlags", "userSourceCodeIncluded"],
+    ["privacyFlags", "privatePathsIncluded"],
+    ["privacyFlags", "secretsIncluded"],
+    ["privacyFlags", "tokensIncluded"],
+    ["privacyFlags", "providerConfigsIncluded"],
+    ["privacyFlags", "modelWeightPathsIncluded"],
+    ["privacyFlags", "generatedBlobsIncluded"],
+    ["safetyFlags", "executesPccxLab"],
+    ["safetyFlags", "executesLauncher"],
+    ["safetyFlags", "runtimeExecution"],
+    ["safetyFlags", "touchesHardware"],
+    ["safetyFlags", "kv260Access"],
+    ["safetyFlags", "modelExecution"],
+    ["safetyFlags", "networkCalls"],
+    ["safetyFlags", "providerCalls"],
+    ["safetyFlags", "shellExecution"],
+    ["safetyFlags", "mcpServerImplemented"],
+    ["safetyFlags", "lspImplemented"],
+    ["safetyFlags", "marketplaceFlow"],
+    ["safetyFlags", "telemetry"],
+    ["safetyFlags", "automaticUpload"],
+    ["safetyFlags", "writeBack"],
+  ].forEach((path) => boolPath(handoff, path, false, errors));
+
+  [
+    ["safetyFlags", "dataOnly"],
+    ["safetyFlags", "readOnly"],
+  ].forEach((path) => boolPath(handoff, path, true, errors));
+
+  ensureValue(
+    stringPath(handoff, ["safetyFlags", "contractKind"], errors),
+    "read_only_handoff",
+    "safetyFlags.contractKind",
+    errors,
+  );
+  ensureValue(
+    stringPath(handoff, ["safetyFlags", "descriptorPolicy"], errors),
+    "descriptor_ref_only",
+    "safetyFlags.descriptorPolicy",
+    errors,
+  );
+  ensureValue(
+    stringPath(handoff, ["safetyFlags", "runtimePolicy"], errors),
+    "no_runtime_execution",
+    "safetyFlags.runtimePolicy",
+    errors,
+  );
+  ensureValue(
+    stringPath(handoff, ["safetyFlags", "hardwarePolicy"], errors),
+    "no_hardware_access",
+    "safetyFlags.hardwarePolicy",
+    errors,
+  );
+
+  return {
+    dataOnly: true,
+    readOnly: true,
+    fixtureConsumer: true,
+    launcherExecution: false,
+    pccxLabExecution: false,
+    shellExecution: false,
+    providerCalls: false,
+    networkCalls: false,
+    runtimeCalls: false,
+    mcpCalls: false,
+    lspImplemented: false,
+    marketplaceFlow: false,
+    telemetry: false,
+    automaticUpload: false,
+    writeBack: false,
+  };
+}
+
+export function createDiagnosticsHandoffConsumerBoundaryStatus() {
+  return {
+    version: DIAGNOSTICS_HANDOFF_CONSUMER_VERSION,
+    kind: "diagnostics-handoff-consumer-boundary",
+    supportedSchemaVersion: DIAGNOSTICS_HANDOFF_SCHEMA_VERSION,
+    dataOnly: true,
+    readOnly: true,
+    fixtureConsumer: true,
+    validatesLocalJson: true,
+    invokesLauncher: false,
+    invokesPccxLab: false,
+    invokesPccxLabValidator: false,
+    shellExecution: false,
+    providerCalls: false,
+    networkCalls: false,
+    runtimeCalls: false,
+    mcpCalls: false,
+    lspImplemented: false,
+    marketplaceFlow: false,
+    stableApi: false,
+  };
+}
+
+export function consumeDiagnosticsHandoff(handoff = {}) {
+  const errors = [];
+  if (!isObject(handoff)) {
+    throw new Error("diagnostics handoff must be an object");
+  }
+
+  for (const field of HANDOFF_FIELDS) {
+    if (!Object.hasOwn(handoff, field)) {
+      addError(errors, field, "is required");
+    }
+  }
+
+  assertSafeSerializedText(handoff, errors);
+  ensureValue(handoff.schemaVersion, DIAGNOSTICS_HANDOFF_SCHEMA_VERSION, "schemaVersion", errors);
+  ensureValue(handoff.handoffKind, "read_only_handoff", "handoffKind", errors);
+  ensureValue(
+    stringPath(handoff, ["producer", "role"], errors),
+    "launcher_generated_summary",
+    "producer.role",
+    errors,
+  );
+  ensureValue(
+    stringPath(handoff, ["consumer", "role"], errors),
+    "pccx_lab_future_consumer",
+    "consumer.role",
+    errors,
+  );
+  ensureValue(
+    stringPath(handoff, ["targetDevice", "accessState"], errors),
+    "no_hardware_access",
+    "targetDevice.accessState",
+    errors,
+  );
+
+  const diagnosticSummary = validateDiagnostics(handoff, errors);
+  const descriptorRefs = validateReferences(handoff, errors);
+  validateArtifacts(handoff, errors);
+  const transportKinds = validateTransport(handoff, errors);
+  const safety = validateSafety(handoff, errors);
+  const limitations = arrayPath(handoff, ["limitations"], errors).map((item, index) => (
+    stringField(item, `limitations[${index}]`, errors)
+  ));
+
+  if (errors.length > 0) {
+    throw new Error(`invalid diagnostics handoff: ${errors.join("; ")}`);
+  }
+
+  return {
+    version: DIAGNOSTICS_HANDOFF_CONSUMER_VERSION,
+    kind: "diagnostics-handoff-consumer",
+    handoffSchemaVersion: handoff.schemaVersion,
+    handoffId: handoff.handoffId,
+    handoffKind: handoff.handoffKind,
+    producerId: handoff.producer.id,
+    consumerId: handoff.consumer.id,
+    targetKind: handoff.targetKind,
+    ...diagnosticSummary,
+    descriptorRefs,
+    transportKinds,
+    safety,
+    limitations,
+  };
+}
+
+export function validateDiagnosticsHandoff(handoff = {}) {
+  try {
+    return {
+      ok: true,
+      summary: consumeDiagnosticsHandoff(handoff),
+      errors: [],
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      summary: null,
+      errors: error.message.replace(/^invalid diagnostics handoff: /, "").split("; "),
+    };
+  }
+}
+
+export function consumeDiagnosticsHandoffJson(text) {
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error("diagnostics handoff JSON must parse");
+  }
+  return consumeDiagnosticsHandoff(parsed);
+}
+
+export function diagnosticsHandoffConsumerJson(handoff = {}) {
+  return `${JSON.stringify(consumeDiagnosticsHandoff(handoff), null, 2)}\n`;
+}

--- a/editors/vscode-prototype/src/local-workflow-status.mjs
+++ b/editors/vscode-prototype/src/local-workflow-status.mjs
@@ -4,6 +4,9 @@ import {
 import {
   createPccxLabCommandDescriptorStatus,
 } from "./pccx-lab-command-descriptor.mjs";
+import {
+  createDiagnosticsHandoffConsumerBoundaryStatus,
+} from "./diagnostics-handoff-consumer.mjs";
 
 export const LOCAL_WORKFLOW_STATUS_VERSION = "pccx.localWorkflowStatus.v0";
 
@@ -51,6 +54,7 @@ function contextBundleEstimate(input = {}) {
 export function createLocalWorkflowStatus(config = {}, input = {}) {
   const pccxLabBoundary = createPccxLabCommandDescriptorStatus();
   const launcherBoundary = createLauncherStatusContractStatus();
+  const diagnosticsHandoffBoundary = createDiagnosticsHandoffConsumerBoundaryStatus();
   const validationCache = validationStatusFromCache(input.validationResultCache);
   const extensionMode = typeof config.mode === "string" ? config.mode : "checkedExample";
   const validationRunner = config.validationRunner ?? {};
@@ -79,6 +83,14 @@ export function createLocalWorkflowStatus(config = {}, input = {}) {
       runtimeCalls: launcherBoundary.runtimeCalls === true,
       launcherCalls: launcherBoundary.launcherCalls === true,
     },
+    diagnosticsHandoffBoundary: {
+      supportedSchemaVersion: diagnosticsHandoffBoundary.supportedSchemaVersion,
+      fixtureConsumer: diagnosticsHandoffBoundary.fixtureConsumer === true,
+      readOnly: diagnosticsHandoffBoundary.readOnly === true,
+      invokesLauncher: diagnosticsHandoffBoundary.invokesLauncher === true,
+      invokesPccxLab: diagnosticsHandoffBoundary.invokesPccxLab === true,
+      lspImplemented: diagnosticsHandoffBoundary.lspImplemented === true,
+    },
     contextBundle: contextBundleEstimate(input),
     safety: {
       providerCalls: false,
@@ -100,6 +112,7 @@ export function formatLocalWorkflowStatus(status) {
     `recentValidation: ${status.recentValidation.count}/${status.recentValidation.maxSize} latest=${status.recentValidation.latestStatus}`,
     `pccxLabBoundary: ${status.pccxLabBoundary.state} descriptorOnly=${status.pccxLabBoundary.descriptorOnly ? "yes" : "no"}`,
     `launcherBoundary: ${status.launcherBoundary.state} fixtureOnly=${status.launcherBoundary.fixtureOnly ? "yes" : "no"}`,
+    `diagnosticsHandoffBoundary: ${status.diagnosticsHandoffBoundary.supportedSchemaVersion} readOnly=${status.diagnosticsHandoffBoundary.readOnly ? "yes" : "no"}`,
     `contextBundleItems: ${status.contextBundle.itemCount}`,
     "safety: no provider calls, no launcher calls, no pccx-lab execution",
   ].join("\n");

--- a/editors/vscode-prototype/test/diagnostics-handoff-consumer.test.mjs
+++ b/editors/vscode-prototype/test/diagnostics-handoff-consumer.test.mjs
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  DIAGNOSTICS_HANDOFF_CATEGORIES,
+  DIAGNOSTICS_HANDOFF_CONSUMER_VERSION,
+  DIAGNOSTICS_HANDOFF_SCHEMA_VERSION,
+  DIAGNOSTICS_HANDOFF_SEVERITIES,
+  consumeDiagnosticsHandoff,
+  consumeDiagnosticsHandoffJson,
+  createDiagnosticsHandoffConsumerBoundaryStatus,
+  diagnosticsHandoffConsumerJson,
+  validateDiagnosticsHandoff,
+} from "../src/diagnostics-handoff-consumer.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const FIXTURE_PATH = resolve(
+  ROOT,
+  "docs/examples/diagnostics-handoff/launcher-diagnostics-handoff.example.json",
+);
+
+async function fixtureText() {
+  return readFile(FIXTURE_PATH, "utf8");
+}
+
+async function fixture() {
+  return JSON.parse(await fixtureText());
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function assertInvalid(value, pattern) {
+  const result = validateDiagnosticsHandoff(value);
+
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), pattern);
+  assert.throws(() => consumeDiagnosticsHandoff(value), pattern);
+}
+
+async function testValidFixtureSummaryIsDeterministic() {
+  const handoff = await fixture();
+  const summary = consumeDiagnosticsHandoff(handoff);
+  const summaryFromJson = consumeDiagnosticsHandoffJson(await fixtureText());
+  const rendered = diagnosticsHandoffConsumerJson(handoff);
+  const renderedAgain = diagnosticsHandoffConsumerJson(handoff);
+
+  assert.deepEqual(summary, summaryFromJson);
+  assert.equal(rendered, renderedAgain);
+  assert.equal(JSON.parse(rendered).version, DIAGNOSTICS_HANDOFF_CONSUMER_VERSION);
+  assert.equal(summary.version, DIAGNOSTICS_HANDOFF_CONSUMER_VERSION);
+  assert.equal(summary.kind, "diagnostics-handoff-consumer");
+  assert.equal(summary.handoffSchemaVersion, DIAGNOSTICS_HANDOFF_SCHEMA_VERSION);
+  assert.equal(summary.handoffId, "launcher_diagnostics_handoff_gemma3n_e4b_kv260_placeholder");
+  assert.equal(summary.handoffKind, "read_only_handoff");
+  assert.equal(summary.producerId, "pccx-llm-launcher");
+  assert.equal(summary.consumerId, "pccx-lab");
+  assert.equal(summary.targetKind, "kv260");
+  assert.equal(summary.diagnosticCount, 5);
+}
+
+async function testValidFixtureCountsAndReferences() {
+  const summary = consumeDiagnosticsHandoff(await fixture());
+
+  assert.deepEqual(DIAGNOSTICS_HANDOFF_SEVERITIES, [
+    "info",
+    "warning",
+    "blocked",
+    "error",
+  ]);
+  assert.deepEqual(DIAGNOSTICS_HANDOFF_CATEGORIES, [
+    "configuration",
+    "model_descriptor",
+    "runtime_descriptor",
+    "target_device",
+    "evidence",
+    "safety",
+    "diagnostics_handoff",
+  ]);
+  assert.equal(summary.diagnosticsBySeverity.info, 2);
+  assert.equal(summary.diagnosticsBySeverity.warning, 1);
+  assert.equal(summary.diagnosticsBySeverity.blocked, 2);
+  assert.equal(summary.diagnosticsBySeverity.error, 0);
+  assert.equal(summary.diagnosticsByCategory.configuration, 1);
+  assert.equal(summary.diagnosticsByCategory.runtime_descriptor, 1);
+  assert.equal(summary.diagnosticsByCategory.evidence, 1);
+  assert.equal(summary.diagnosticsByCategory.safety, 1);
+  assert.deepEqual(summary.descriptorRefs, {
+    launcherOperationId: "pccxlab.diagnostics.handoff",
+    modelId: "gemma3n_e4b_placeholder",
+    runtimeId: "kv260_pccx_placeholder",
+    referenceKind: "descriptor_ref_only",
+  });
+  assert.deepEqual(summary.transportKinds, [
+    "json_file",
+    "stdout_json",
+    "read_only_local_artifact_reference",
+  ]);
+}
+
+async function testReadOnlySafetyFlagsAreCarriedToSummary() {
+  const summary = consumeDiagnosticsHandoff(await fixture());
+
+  assert.deepEqual(summary.safety, {
+    dataOnly: true,
+    readOnly: true,
+    fixtureConsumer: true,
+    launcherExecution: false,
+    pccxLabExecution: false,
+    shellExecution: false,
+    providerCalls: false,
+    networkCalls: false,
+    runtimeCalls: false,
+    mcpCalls: false,
+    lspImplemented: false,
+    marketplaceFlow: false,
+    telemetry: false,
+    automaticUpload: false,
+    writeBack: false,
+  });
+}
+
+async function testInvalidMissingFieldsAndUnsafeValuesAreRejected() {
+  const missing = await fixture();
+  delete missing.handoffId;
+  assertInvalid(missing, /handoffId: is required/);
+
+  const badSeverity = await fixture();
+  badSeverity.diagnostics[0].severity = "fatal";
+  assertInvalid(badSeverity, /diagnostics\[0\]\.severity: must be one of/);
+
+  const upload = await fixture();
+  upload.privacyFlags.automaticUpload = true;
+  assertInvalid(upload, /privacyFlags\.automaticUpload: must be false/);
+
+  const pathLeak = await fixture();
+  pathLeak.artifactRefs[0].reference = "/home/user/private.log";
+  assertInvalid(pathLeak, /private paths/);
+
+  const claim = await fixture();
+  claim.diagnostics[0].summary = "KV260 inference works";
+  assertInvalid(claim, /unsupported runtime or readiness claims/);
+}
+
+async function testBoundaryStatusIsDataOnlyAndDoesNotInvokeBackends() {
+  const status = createDiagnosticsHandoffConsumerBoundaryStatus();
+
+  assert.equal(status.version, DIAGNOSTICS_HANDOFF_CONSUMER_VERSION);
+  assert.equal(status.kind, "diagnostics-handoff-consumer-boundary");
+  assert.equal(status.supportedSchemaVersion, DIAGNOSTICS_HANDOFF_SCHEMA_VERSION);
+  assert.equal(status.dataOnly, true);
+  assert.equal(status.readOnly, true);
+  assert.equal(status.validatesLocalJson, true);
+  assert.equal(status.invokesLauncher, false);
+  assert.equal(status.invokesPccxLab, false);
+  assert.equal(status.invokesPccxLabValidator, false);
+  assert.equal(status.shellExecution, false);
+  assert.equal(status.providerCalls, false);
+  assert.equal(status.runtimeCalls, false);
+  assert.equal(status.mcpCalls, false);
+  assert.equal(status.lspImplemented, false);
+  assert.equal(status.marketplaceFlow, false);
+  assert.equal(status.stableApi, false);
+}
+
+async function testModuleSourceHasNoExecutionTerms() {
+  const source = await readFile(
+    resolve(ROOT, "editors/vscode-prototype/src/diagnostics-handoff-consumer.mjs"),
+    "utf8",
+  );
+
+  assert.doesNotMatch(source, /node:child_process|\bexecFile\b|\bspawn\s*\(|\bexec\s*\(/);
+  assert.doesNotMatch(source, /\bwriteFile\s*\(|\bappendFile\s*\(|\bunlink\s*\(|\brm\s*\(/);
+  assert.doesNotMatch(source, /\bfetch\s*\(|XMLHttpRequest|WebSocket|node:https|node:http|node:net|node:tls/);
+  assert.doesNotMatch(source, /\b(?:openai|anthropic|gemini)\b/i);
+  assert.doesNotMatch(source, /pccx-lab\s+diagnostics-handoff\s+validate/i);
+  assert.doesNotMatch(source, /pccx-llm-launcher\s+(?:run|status|launch|diagnostics)/i);
+  assert.doesNotMatch(source, /modelcontextprotocol|McpServer|vscode-languageclient|LanguageClient/);
+}
+
+async function testSummaryDoesNotEchoPrivateInputWhenInvalid() {
+  const handoff = clone(await fixture());
+  handoff.artifactRefs[0].reference = "/home/user/private.log";
+  const result = validateDiagnosticsHandoff(handoff);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.summary, null);
+  assert.doesNotMatch(JSON.stringify(result), /\/home\/user/);
+}
+
+await testValidFixtureSummaryIsDeterministic();
+await testValidFixtureCountsAndReferences();
+await testReadOnlySafetyFlagsAreCarriedToSummary();
+await testInvalidMissingFieldsAndUnsafeValuesAreRejected();
+await testBoundaryStatusIsDataOnlyAndDoesNotInvokeBackends();
+await testModuleSourceHasNoExecutionTerms();
+await testSummaryDoesNotEchoPrivateInputWhenInvalid();
+
+console.log("vscode diagnostics handoff consumer tests ok");

--- a/editors/vscode-prototype/test/local-workflow-status.test.mjs
+++ b/editors/vscode-prototype/test/local-workflow-status.test.mjs
@@ -57,6 +57,12 @@ function testLocalWorkflowStatusUsesDeterministicLocalDataOnly() {
   assert.equal(status.launcherBoundary.state, "future");
   assert.equal(status.launcherBoundary.fixtureOnly, true);
   assert.equal(status.launcherBoundary.runtimeCalls, false);
+  assert.equal(status.diagnosticsHandoffBoundary.supportedSchemaVersion, "pccx.diagnosticsHandoff.v0");
+  assert.equal(status.diagnosticsHandoffBoundary.fixtureConsumer, true);
+  assert.equal(status.diagnosticsHandoffBoundary.readOnly, true);
+  assert.equal(status.diagnosticsHandoffBoundary.invokesLauncher, false);
+  assert.equal(status.diagnosticsHandoffBoundary.invokesPccxLab, false);
+  assert.equal(status.diagnosticsHandoffBoundary.lspImplemented, false);
   assert.equal(status.contextBundle.itemCount, 9);
   assert.equal(status.safety.providerCalls, false);
   assert.equal(status.safety.launcherCalls, false);
@@ -73,8 +79,11 @@ function testLocalWorkflowStatusDefaultsAreDisabledAndSafe() {
   assert.equal(status.recentValidation.count, 0);
   assert.equal(status.pccxLabBoundary.executes, false);
   assert.equal(status.launcherBoundary.launcherCalls, false);
+  assert.equal(status.diagnosticsHandoffBoundary.invokesLauncher, false);
+  assert.equal(status.diagnosticsHandoffBoundary.invokesPccxLab, false);
   assert.match(text, /Local Workflow Status/);
   assert.match(text, /validationRunner: disabled/);
+  assert.match(text, /diagnosticsHandoffBoundary: pccx\.diagnosticsHandoff\.v0 readOnly=yes/);
   assert.match(text, /no pccx-lab execution/);
   assert.doesNotMatch(JSON.stringify(status), /\/home\/|TOKEN=|model\.gguf/);
 }

--- a/editors/vscode-prototype/test/static-boundary.test.mjs
+++ b/editors/vscode-prototype/test/static-boundary.test.mjs
@@ -145,6 +145,7 @@ async function testProposalAndStatusModulesAreDataOnly() {
     resolve(EXTENSION_ROOT, "src/validation-patch-handoff.mjs"),
     resolve(EXTENSION_ROOT, "src/pccx-lab-command-descriptor.mjs"),
     resolve(EXTENSION_ROOT, "src/launcher-status-contract.mjs"),
+    resolve(EXTENSION_ROOT, "src/diagnostics-handoff-consumer.mjs"),
     resolve(EXTENSION_ROOT, "src/local-workflow-status.mjs"),
     resolve(EXTENSION_ROOT, "src/context-bundle-audit.mjs"),
     resolve(EXTENSION_ROOT, "src/pccx-lab-status.mjs"),

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -23,6 +23,7 @@ node editors/vscode-prototype/test/patch-proposal-preview.test.mjs
 node editors/vscode-prototype/test/validation-patch-handoff.test.mjs
 node editors/vscode-prototype/test/pccx-lab-command-descriptor.test.mjs
 node editors/vscode-prototype/test/launcher-status-contract.test.mjs
+node editors/vscode-prototype/test/diagnostics-handoff-consumer.test.mjs
 node editors/vscode-prototype/test/local-workflow-status.test.mjs
 node editors/vscode-prototype/test/context-bundle-audit.test.mjs
 node editors/vscode-prototype/test/validation-result-summary.test.mjs


### PR DESCRIPTION
## Summary
- Adds a read-only diagnostics handoff consumer adapter for `pccx.diagnosticsHandoff.v0` data.
- Adds a sanitized launcher-style fixture and deterministic JSON summary output for future IDE UI use.
- Wires the boundary into the local workflow status surface without executing launcher or pccx-lab.

## Scope
- Data-only parser/validator/summary module under the VS Code prototype adapter layer.
- Fixture-based tests for valid and invalid handoff payloads.
- Static tests covering no launcher, pccx-lab, shell, provider, MCP, or LSP execution paths.
- Docs describing the experimental consumer boundary and current limits.

## Non-goals
- No launcher execution.
- No pccx-lab execution or validator invocation.
- No shell execution path in the consumer.
- No provider, model runtime, KV260, MCP, LSP, telemetry, upload, release, tag, packaging, or marketplace flow.
- No API or ABI stability commitment.

## Validation
- `git diff --check`
- `python3 -m pytest -q` — 164 passed
- `bash scripts/vscode-adapter-smoke.sh`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `node -e "const p=require('./editors/vscode-prototype/package.json'); console.log(JSON.stringify(p.scripts||{}))"` — `{}`, so npm test/build scripts are not present

## Safety notes
- The fixture is sanitized and contains no private paths, secrets, tokens, raw logs, user prompts, source code, provider configs, or model weight paths.
- The consumer returns data summaries only and has no file writeback, network, telemetry, launcher, pccx-lab, shell, provider, hardware, MCP, or LSP execution path.
- The opt-in Extension Host smoke was not run because it downloads VS Code test assets when enabled.

## Related
- Follows `pccxai/pccx-llm-launcher#19`
- Follows `pccxai/pccx-lab#30`
- Follows `pccxai/pccx-llm-launcher#20`
