### PR TITLE
Surface diagnostics handoff summary status

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,10 @@ under `editors/vscode-prototype/test/fixtures/live-workspace`.
 The VS Code prototype also has a read-only diagnostics handoff consumer
 for the launcher / pccx-lab `pccx.diagnosticsHandoff.v0` JSON shape. It
 parses a checked local fixture and returns deterministic summary data for
-future UI use. It does not execute the launcher, execute pccx-lab, invoke
-the pccx-lab validator, implement MCP or LSP, call providers, or touch
-hardware.
+future UI use. The `showDiagnosticsHandoffSummary` command surfaces that
+adapter summary as local status data. It does not execute the launcher,
+execute pccx-lab, invoke the pccx-lab validator, implement MCP or LSP,
+call providers, or touch hardware.
 
 ## Later track (deferred)
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -100,6 +100,12 @@ data.
 The checked fixture lives at
 `docs/examples/diagnostics-handoff/launcher-diagnostics-handoff.example.json`.
 
+`pccxSystemVerilog.showDiagnosticsHandoffSummary` is a prototype status
+surface over the adapter output. It consumes the deterministic consumer
+summary as data, returns JSON for tests or future UI code, and writes a
+small local text summary to the prototype output channel. It does not
+read raw handoff JSON in the UI layer.
+
 This path is data-only. It does not execute `pccx-llm-launcher`, does not
 execute `pccx-lab`, does not invoke the pccx-lab validator command, does
 not spawn shell commands, does not implement MCP or LSP, does not call

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -146,6 +146,7 @@ The contributed commands are:
 - `pccxSystemVerilog.showLocalWorkflowStatus`
 - `pccxSystemVerilog.showContextBundleAudit`
 - `pccxSystemVerilog.showPccxLabBackendStatus`
+- `pccxSystemVerilog.showDiagnosticsHandoffSummary`
 
 The prototype-only settings are:
 
@@ -208,6 +209,15 @@ not invoke `pccx-lab`, does not run the pccx-lab validator command, does
 not spawn shell commands, and does not implement MCP or LSP.  The boundary
 is documented in
 [`docs/diagnostics-handoff-consumer.md`](./docs/diagnostics-handoff-consumer.md).
+
+`src/diagnostics-handoff-status-surface.mjs` and
+`pccxSystemVerilog.showDiagnosticsHandoffSummary` expose that existing
+consumer summary as a small local status surface.  The command consumes
+adapter output as data, writes a deterministic summary to the prototype
+output channel, and returns JSON for tests or future UI code.  It does not
+read raw handoff JSON in the UI layer, does not invoke launcher or
+pccx-lab, does not run the pccx-lab validator command, and does not add
+provider, runtime, MCP, LSP, telemetry, upload, or marketplace behavior.
 
 `src/command-handlers.mjs` is the experimental local command-handler
 scaffold.  It maps command ID -> normalized prototype settings -> known
@@ -430,6 +440,7 @@ Now:
 - disabled-by-default approved validation runner boundary
 - recent validation summary and cache status command
 - pccx-lab backend status command
+- diagnostics handoff summary status command
 
 Next:
 
@@ -472,6 +483,8 @@ node editors/vscode-prototype/test/patch-proposal-preview.test.mjs
 node editors/vscode-prototype/test/validation-patch-handoff.test.mjs
 node editors/vscode-prototype/test/pccx-lab-command-descriptor.test.mjs
 node editors/vscode-prototype/test/launcher-status-contract.test.mjs
+node editors/vscode-prototype/test/diagnostics-handoff-consumer.test.mjs
+node editors/vscode-prototype/test/diagnostics-handoff-status-surface.test.mjs
 node editors/vscode-prototype/test/local-workflow-status.test.mjs
 node editors/vscode-prototype/test/context-bundle-audit.test.mjs
 node editors/vscode-prototype/test/validation-result-summary.test.mjs

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -52,6 +52,9 @@ should earn CI promotion separately.
   bundle.
 - pccx-lab backend status smoke.  The command reports the configured
   boundary and does not execute pccx-lab.
+- Diagnostics handoff summary status smoke.  The command reports the
+  existing adapter summary as local data and does not execute launcher,
+  pccx-lab, shell commands, providers, MCP, or LSP.
 - Guard behavior for the local-only Extension Host runtime smoke.
 - Pinned Extension Host activation and command-registration smoke when
   explicitly enabled locally.
@@ -123,12 +126,14 @@ checked-example symbols.  It executes
 `pccxSystemVerilog.showRecentValidationResults`,
 `pccxSystemVerilog.showValidationCacheStatus`,
 `pccxSystemVerilog.clearValidationResultCache`, and
-`pccxSystemVerilog.showPccxLabBackendStatus`, verifying disabled/backend
-`none` status, proposal-only actions, disabled runner blocking behavior,
-one explicitly enabled allowlisted validation run, bounded active-file
-and selected-symbol context, bounded validation-result cache summary
-handoff, status-only pccx-lab boundary data, and no provider/runtime
-calls.  This is not LSP, and there is no LSP provider yet.
+`pccxSystemVerilog.showPccxLabBackendStatus`, and
+`pccxSystemVerilog.showDiagnosticsHandoffSummary`, verifying
+disabled/backend `none` status, proposal-only actions, disabled runner
+blocking behavior, one explicitly enabled allowlisted validation run,
+bounded active-file and selected-symbol context, bounded validation-result
+cache summary handoff, status-only pccx-lab boundary data, diagnostics
+handoff summary data, and no provider/runtime calls.  This is not LSP,
+and there is no LSP provider yet.
 
 ## AI Assistant Boundary
 
@@ -156,6 +161,11 @@ workflow state without pccx-lab execution, launcher calls, provider calls,
 MCP, or LSP.
 `pccxSystemVerilog.showContextBundleAudit` reports local context bundle
 size and safety metadata without uploading context or calling providers.
+`pccxSystemVerilog.showDiagnosticsHandoffSummary` reports the checked
+diagnostics handoff adapter summary as a local status surface. It consumes
+adapter output as data, does not read raw handoff JSON in the UI layer,
+does not execute launcher or pccx-lab, and does not invoke the pccx-lab
+validator command.
 
 `pccxSystemVerilog.proposeValidationCommand` currently proposes only
 allowlisted templates, including the VS Code adapter smoke, editor bridge

--- a/editors/vscode-prototype/docs/diagnostics-handoff-consumer.md
+++ b/editors/vscode-prototype/docs/diagnostics-handoff-consumer.md
@@ -8,7 +8,9 @@ returns a deterministic summary for future UI surfaces.
 The implementation lives in:
 
 - `src/diagnostics-handoff-consumer.mjs`
+- `src/diagnostics-handoff-status-surface.mjs`
 - `test/diagnostics-handoff-consumer.test.mjs`
+- `test/diagnostics-handoff-status-surface.test.mjs`
 - `../../docs/examples/diagnostics-handoff/launcher-diagnostics-handoff.example.json`
 
 ## What It Does
@@ -29,6 +31,13 @@ The summary records diagnostic counts by severity and category, descriptor
 references, transport kinds, limitations, and safety flags. The output is
 deterministic JSON and is suitable for a later UI panel or context bundle
 entry.
+
+`pccxSystemVerilog.showDiagnosticsHandoffSummary` is the first small
+status surface over that summary. It consumes the adapter output as data
+and writes a deterministic text summary to the prototype output channel.
+It is experimental and local-only. It does not read raw handoff JSON in
+the UI layer, does not execute launcher or pccx-lab, and does not invoke
+the pccx-lab validator command.
 
 ## What It Does Not Do
 

--- a/editors/vscode-prototype/package.json
+++ b/editors/vscode-prototype/package.json
@@ -32,7 +32,8 @@
     "onCommand:pccxSystemVerilog.clearPatchProposalPreview",
     "onCommand:pccxSystemVerilog.showLocalWorkflowStatus",
     "onCommand:pccxSystemVerilog.showContextBundleAudit",
-    "onCommand:pccxSystemVerilog.showPccxLabBackendStatus"
+    "onCommand:pccxSystemVerilog.showPccxLabBackendStatus",
+    "onCommand:pccxSystemVerilog.showDiagnosticsHandoffSummary"
   ],
   "contributes": {
     "commands": [
@@ -115,6 +116,10 @@
       {
         "command": "pccxSystemVerilog.showPccxLabBackendStatus",
         "title": "PCCX SystemVerilog: Show pccx-lab Backend Status (Experimental)"
+      },
+      {
+        "command": "pccxSystemVerilog.showDiagnosticsHandoffSummary",
+        "title": "PCCX SystemVerilog: Show Diagnostics Handoff Summary (Experimental)"
       }
     ],
     "configuration": {

--- a/editors/vscode-prototype/src/config.mjs
+++ b/editors/vscode-prototype/src/config.mjs
@@ -48,10 +48,15 @@ export const PCCX_LAB_COMMAND_IDS = Object.freeze([
   "pccxSystemVerilog.showPccxLabBackendStatus",
 ]);
 
+export const DIAGNOSTICS_HANDOFF_COMMAND_IDS = Object.freeze([
+  "pccxSystemVerilog.showDiagnosticsHandoffSummary",
+]);
+
 export const COMMAND_IDS = Object.freeze([
   ...FACADE_COMMAND_IDS,
   ...AI_COMMAND_IDS,
   ...PCCX_LAB_COMMAND_IDS,
+  ...DIAGNOSTICS_HANDOFF_COMMAND_IDS,
 ]);
 
 export const MODES = Object.freeze(["checkedExample", "liveWorkspace"]);

--- a/editors/vscode-prototype/src/diagnostics-handoff-status-surface.mjs
+++ b/editors/vscode-prototype/src/diagnostics-handoff-status-surface.mjs
@@ -1,0 +1,393 @@
+import {
+  DIAGNOSTICS_HANDOFF_CATEGORIES,
+  DIAGNOSTICS_HANDOFF_CONSUMER_VERSION,
+  DIAGNOSTICS_HANDOFF_SCHEMA_VERSION,
+  DIAGNOSTICS_HANDOFF_SEVERITIES,
+  createDiagnosticsHandoffConsumerBoundaryStatus,
+} from "./diagnostics-handoff-consumer.mjs";
+
+export const DIAGNOSTICS_HANDOFF_STATUS_SURFACE_VERSION =
+  "pccx.ideDiagnosticsHandoffStatusSurface.v0";
+
+export const DEFAULT_DIAGNOSTICS_HANDOFF_CONSUMER_SUMMARY = Object.freeze({
+  version: DIAGNOSTICS_HANDOFF_CONSUMER_VERSION,
+  kind: "diagnostics-handoff-consumer",
+  handoffSchemaVersion: DIAGNOSTICS_HANDOFF_SCHEMA_VERSION,
+  handoffId: "launcher_diagnostics_handoff_gemma3n_e4b_kv260_placeholder",
+  handoffKind: "read_only_handoff",
+  producerId: "pccx-llm-launcher",
+  consumerId: "pccx-lab",
+  targetKind: "kv260",
+  diagnosticCount: 5,
+  diagnosticsBySeverity: Object.freeze({
+    info: 2,
+    warning: 1,
+    blocked: 2,
+    error: 0,
+  }),
+  diagnosticsByCategory: Object.freeze({
+    configuration: 1,
+    model_descriptor: 1,
+    runtime_descriptor: 1,
+    target_device: 0,
+    evidence: 1,
+    safety: 1,
+    diagnostics_handoff: 0,
+  }),
+  descriptorRefs: Object.freeze({
+    launcherOperationId: "pccxlab.diagnostics.handoff",
+    modelId: "gemma3n_e4b_placeholder",
+    runtimeId: "kv260_pccx_placeholder",
+    referenceKind: "descriptor_ref_only",
+  }),
+  transportKinds: Object.freeze([
+    "json_file",
+    "stdout_json",
+    "read_only_local_artifact_reference",
+  ]),
+  safety: Object.freeze({
+    dataOnly: true,
+    readOnly: true,
+    fixtureConsumer: true,
+    launcherExecution: false,
+    pccxLabExecution: false,
+    shellExecution: false,
+    providerCalls: false,
+    networkCalls: false,
+    runtimeCalls: false,
+    mcpCalls: false,
+    lspImplemented: false,
+    marketplaceFlow: false,
+    telemetry: false,
+    automaticUpload: false,
+    writeBack: false,
+  }),
+  limitations: Object.freeze([
+    "Data-only placeholder; no pccx-lab execution is performed.",
+    "No launcher runtime execution, model execution, provider call, or network call is performed.",
+    "No KV260 hardware access is performed.",
+    "No telemetry, automatic upload, or auto write-back is included.",
+    "No raw full logs, prompts, source code, private paths, secrets, tokens, provider configuration, generated blobs, or model weight paths are included.",
+    "The contract is not a versioned compatibility commitment.",
+  ]),
+});
+
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]/i;
+const PRIVATE_PATH_PATTERN = /(?:\/home\/[^/\s]+|\/Users\/[^/\s]+|[A-Za-z]:\\Users\\)/;
+const MODEL_ARTIFACT_PATTERN =
+  /\.(?:gguf|safetensors|ckpt|pt|pth|onnx|xclbin|bit)(?:\s|$|["'])/i;
+const UNSUPPORTED_MARKER_PARTS = Object.freeze([
+  ["production", "ready"],
+  ["marketplace", "ready"],
+  ["stable", "api"],
+  ["stable", "abi"],
+  ["kv260 inference ", "works"],
+  ["gemma 3n e4b runs on ", "kv260"],
+  ["20 tok/s ", "achieved"],
+  ["timing ", "closed"],
+  ["autonomous coding ", "system"],
+]);
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function isObject(value) {
+  return value && typeof value === "object" && !Array.isArray(value);
+}
+
+function addError(errors, path, message) {
+  errors.push(`${path}: ${message}`);
+}
+
+function stringField(value, path, errors) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    addError(errors, path, "must be a non-empty string");
+    return "";
+  }
+  if (value.includes("\0") || value.includes("\n") || value.includes("\r")) {
+    addError(errors, path, "must be a single-line string");
+  }
+  return value;
+}
+
+function countField(value, path, errors) {
+  if (!Number.isInteger(value) || value < 0) {
+    addError(errors, path, "must be a non-negative integer");
+    return 0;
+  }
+  return value;
+}
+
+function validateCountMap(value, keys, path, errors) {
+  if (!isObject(value)) {
+    addError(errors, path, "must be an object");
+    return Object.fromEntries(keys.map((key) => [key, 0]));
+  }
+  return Object.fromEntries(keys.map((key) => [
+    key,
+    countField(value[key], `${path}.${key}`, errors),
+  ]));
+}
+
+function boolField(value, expected, path, errors) {
+  if (typeof value !== "boolean") {
+    addError(errors, path, "must be a boolean");
+    return false;
+  }
+  if (value !== expected) {
+    addError(errors, path, `must be ${expected}`);
+  }
+  return value;
+}
+
+function assertSafeSummaryText(summary, errors) {
+  let text = "";
+  try {
+    text = JSON.stringify(summary ?? {});
+  } catch {
+    addError(errors, "summary", "must be JSON-serializable");
+    return;
+  }
+  const lower = text.toLowerCase();
+  if (
+    SECRET_ASSIGNMENT_PATTERN.test(text) ||
+    PRIVATE_PATH_PATTERN.test(text) ||
+    MODEL_ARTIFACT_PATTERN.test(text)
+  ) {
+    addError(errors, "summary", "must not include secrets, private paths, or model artifact paths");
+  }
+  for (const parts of UNSUPPORTED_MARKER_PARTS) {
+    if (lower.includes(parts.join(""))) {
+      addError(errors, "summary", "must not include unsupported runtime or readiness claims");
+    }
+  }
+}
+
+function normalizeConsumerSummary(summary = DEFAULT_DIAGNOSTICS_HANDOFF_CONSUMER_SUMMARY) {
+  const errors = [];
+  if (!isObject(summary)) {
+    throw new Error("diagnostics handoff summary must be an object");
+  }
+
+  assertSafeSummaryText(summary, errors);
+  if (summary.version !== DIAGNOSTICS_HANDOFF_CONSUMER_VERSION) {
+    addError(errors, "version", `must be ${DIAGNOSTICS_HANDOFF_CONSUMER_VERSION}`);
+  }
+  if (summary.kind !== "diagnostics-handoff-consumer") {
+    addError(errors, "kind", "must be diagnostics-handoff-consumer");
+  }
+  if (summary.handoffSchemaVersion !== DIAGNOSTICS_HANDOFF_SCHEMA_VERSION) {
+    addError(errors, "handoffSchemaVersion", `must be ${DIAGNOSTICS_HANDOFF_SCHEMA_VERSION}`);
+  }
+  if (summary.handoffKind !== "read_only_handoff") {
+    addError(errors, "handoffKind", "must be read_only_handoff");
+  }
+
+  const diagnosticCount = countField(summary.diagnosticCount, "diagnosticCount", errors);
+  const diagnosticsBySeverity = validateCountMap(
+    summary.diagnosticsBySeverity,
+    DIAGNOSTICS_HANDOFF_SEVERITIES,
+    "diagnosticsBySeverity",
+    errors,
+  );
+  const diagnosticsByCategory = validateCountMap(
+    summary.diagnosticsByCategory,
+    DIAGNOSTICS_HANDOFF_CATEGORIES,
+    "diagnosticsByCategory",
+    errors,
+  );
+  const severityTotal = Object.values(diagnosticsBySeverity).reduce((sum, count) => sum + count, 0);
+  const categoryTotal = Object.values(diagnosticsByCategory).reduce((sum, count) => sum + count, 0);
+  if (severityTotal !== diagnosticCount) {
+    addError(errors, "diagnosticsBySeverity", "must add up to diagnosticCount");
+  }
+  if (categoryTotal !== diagnosticCount) {
+    addError(errors, "diagnosticsByCategory", "must add up to diagnosticCount");
+  }
+
+  const safety = isObject(summary.safety) ? summary.safety : {};
+  const normalizedSafety = {
+    dataOnly: boolField(safety.dataOnly, true, "safety.dataOnly", errors),
+    readOnly: boolField(safety.readOnly, true, "safety.readOnly", errors),
+    fixtureConsumer: boolField(safety.fixtureConsumer, true, "safety.fixtureConsumer", errors),
+    launcherExecution: boolField(safety.launcherExecution, false, "safety.launcherExecution", errors),
+    pccxLabExecution: boolField(safety.pccxLabExecution, false, "safety.pccxLabExecution", errors),
+    shellExecution: boolField(safety.shellExecution, false, "safety.shellExecution", errors),
+    providerCalls: boolField(safety.providerCalls, false, "safety.providerCalls", errors),
+    networkCalls: boolField(safety.networkCalls, false, "safety.networkCalls", errors),
+    runtimeCalls: boolField(safety.runtimeCalls, false, "safety.runtimeCalls", errors),
+    mcpCalls: boolField(safety.mcpCalls, false, "safety.mcpCalls", errors),
+    lspImplemented: boolField(safety.lspImplemented, false, "safety.lspImplemented", errors),
+    marketplaceFlow: boolField(safety.marketplaceFlow, false, "safety.marketplaceFlow", errors),
+    telemetry: boolField(safety.telemetry, false, "safety.telemetry", errors),
+    automaticUpload: boolField(safety.automaticUpload, false, "safety.automaticUpload", errors),
+    writeBack: boolField(safety.writeBack, false, "safety.writeBack", errors),
+  };
+
+  const descriptorRefs = isObject(summary.descriptorRefs) ? summary.descriptorRefs : {};
+  const transportKinds = Array.isArray(summary.transportKinds)
+    ? summary.transportKinds.map((kind, index) => stringField(kind, `transportKinds[${index}]`, errors))
+    : [];
+  if (!Array.isArray(summary.transportKinds)) {
+    addError(errors, "transportKinds", "must be an array");
+  }
+  const limitations = Array.isArray(summary.limitations)
+    ? summary.limitations.map((item, index) => stringField(item, `limitations[${index}]`, errors))
+    : [];
+  if (!Array.isArray(summary.limitations)) {
+    addError(errors, "limitations", "must be an array");
+  }
+
+  const normalized = {
+    version: summary.version,
+    kind: summary.kind,
+    handoffSchemaVersion: summary.handoffSchemaVersion,
+    handoffId: stringField(summary.handoffId, "handoffId", errors),
+    handoffKind: summary.handoffKind,
+    producerId: stringField(summary.producerId, "producerId", errors),
+    consumerId: stringField(summary.consumerId, "consumerId", errors),
+    targetKind: stringField(summary.targetKind, "targetKind", errors),
+    diagnosticCount,
+    diagnosticsBySeverity,
+    diagnosticsByCategory,
+    descriptorRefs: {
+      launcherOperationId: stringField(
+        descriptorRefs.launcherOperationId,
+        "descriptorRefs.launcherOperationId",
+        errors,
+      ),
+      modelId: stringField(descriptorRefs.modelId, "descriptorRefs.modelId", errors),
+      runtimeId: stringField(descriptorRefs.runtimeId, "descriptorRefs.runtimeId", errors),
+      referenceKind: stringField(descriptorRefs.referenceKind, "descriptorRefs.referenceKind", errors),
+    },
+    transportKinds,
+    safety: normalizedSafety,
+    limitations,
+  };
+
+  if (errors.length > 0) {
+    throw new Error(`invalid diagnostics handoff summary: ${errors.join("; ")}`);
+  }
+
+  return normalized;
+}
+
+export function createDiagnosticsHandoffStatusSurface(
+  consumerSummary = DEFAULT_DIAGNOSTICS_HANDOFF_CONSUMER_SUMMARY,
+) {
+  const summary = normalizeConsumerSummary(consumerSummary);
+  const boundary = createDiagnosticsHandoffConsumerBoundaryStatus();
+  const severity = summary.diagnosticsBySeverity;
+  const displaySummary = [
+    `${summary.diagnosticCount} diagnostic item(s)`,
+    `${severity.blocked} blocked`,
+    `${severity.warning} warning`,
+    "read-only",
+  ].join(", ");
+
+  return {
+    version: DIAGNOSTICS_HANDOFF_STATUS_SURFACE_VERSION,
+    kind: "diagnostics-handoff-status-surface",
+    source: {
+      kind: summary.kind,
+      version: summary.version,
+      adapterOutput: true,
+      rawHandoffParsedByUi: false,
+    },
+    readiness: {
+      status: "available",
+      summaryAvailable: true,
+      localOnly: true,
+      experimental: true,
+    },
+    handoff: {
+      schemaVersion: summary.handoffSchemaVersion,
+      handoffId: summary.handoffId,
+      handoffKind: summary.handoffKind,
+      producerId: summary.producerId,
+      consumerId: summary.consumerId,
+      targetKind: summary.targetKind,
+    },
+    diagnostics: {
+      count: summary.diagnosticCount,
+      bySeverity: summary.diagnosticsBySeverity,
+      byCategory: summary.diagnosticsByCategory,
+    },
+    descriptorRefs: summary.descriptorRefs,
+    transportKinds: summary.transportKinds,
+    limitations: summary.limitations,
+    safety: {
+      dataOnly: true,
+      readOnly: true,
+      localOnly: true,
+      launcherExecution: false,
+      pccxLabExecution: false,
+      pccxLabValidatorInvocation: false,
+      shellExecution: false,
+      providerCalls: false,
+      networkCalls: false,
+      runtimeCalls: false,
+      mcpCalls: false,
+      lspImplemented: false,
+      marketplaceFlow: false,
+      telemetry: false,
+      automaticUpload: false,
+      writeBack: false,
+    },
+    boundary: {
+      version: boundary.version,
+      supportedSchemaVersion: boundary.supportedSchemaVersion,
+      dataOnly: boundary.dataOnly === true,
+      readOnly: boundary.readOnly === true,
+      invokesLauncher: boundary.invokesLauncher === true,
+      invokesPccxLab: boundary.invokesPccxLab === true,
+      invokesPccxLabValidator: boundary.invokesPccxLabValidator === true,
+      shellExecution: boundary.shellExecution === true,
+      providerCalls: boundary.providerCalls === true,
+      runtimeCalls: boundary.runtimeCalls === true,
+      mcpCalls: boundary.mcpCalls === true,
+      lspImplemented: boundary.lspImplemented === true,
+      marketplaceFlow: boundary.marketplaceFlow === true,
+    },
+    display: {
+      title: "Diagnostics Handoff Summary",
+      summary: displaySummary,
+      detailLines: [
+        `schema: ${summary.handoffSchemaVersion}`,
+        `handoff: ${summary.handoffId}`,
+        `target: ${summary.targetKind}`,
+        `descriptorRefs: model=${summary.descriptorRefs.modelId} runtime=${summary.descriptorRefs.runtimeId}`,
+        `transport: ${summary.transportKinds.join(", ")}`,
+        "safety: data-only, read-only, local-only",
+      ],
+    },
+  };
+}
+
+export function diagnosticsHandoffStatusSurfaceJson(
+  consumerSummary = DEFAULT_DIAGNOSTICS_HANDOFF_CONSUMER_SUMMARY,
+) {
+  return `${JSON.stringify(createDiagnosticsHandoffStatusSurface(consumerSummary), null, 2)}\n`;
+}
+
+export function formatDiagnosticsHandoffStatusSurface(surface) {
+  const status = surface ?? createDiagnosticsHandoffStatusSurface();
+  return [
+    status.display?.title ?? "Diagnostics Handoff Summary",
+    `schema: ${status.handoff?.schemaVersion ?? ""}`,
+    `handoff: ${status.handoff?.handoffId ?? ""}`,
+    `target: ${status.handoff?.targetKind ?? ""}`,
+    `diagnostics: ${status.diagnostics?.count ?? 0}`,
+    `severity: info=${status.diagnostics?.bySeverity?.info ?? 0} warning=${status.diagnostics?.bySeverity?.warning ?? 0} blocked=${status.diagnostics?.bySeverity?.blocked ?? 0} error=${status.diagnostics?.bySeverity?.error ?? 0}`,
+    `transport: ${(status.transportKinds ?? []).join(", ")}`,
+    `readOnly: ${status.safety?.readOnly ? "yes" : "no"}`,
+    `dataOnly: ${status.safety?.dataOnly ? "yes" : "no"}`,
+    "execution: no launcher, no pccx-lab, no shell, no provider/runtime/MCP/LSP",
+  ].join("\n");
+}
+
+export function cloneDefaultDiagnosticsHandoffConsumerSummary() {
+  return clone(DEFAULT_DIAGNOSTICS_HANDOFF_CONSUMER_SUMMARY);
+}

--- a/editors/vscode-prototype/src/extension.mjs
+++ b/editors/vscode-prototype/src/extension.mjs
@@ -60,6 +60,10 @@ import {
   createContextBundleAudit,
   formatContextBundleAudit,
 } from "./context-bundle-audit.mjs";
+import {
+  createDiagnosticsHandoffStatusSurface,
+  formatDiagnosticsHandoffStatusSurface,
+} from "./diagnostics-handoff-status-surface.mjs";
 
 const EXTENSION_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_DIAGNOSTIC_FILE_ROOT = resolve(EXTENSION_ROOT, "../..");
@@ -97,6 +101,8 @@ export const SHOW_CONTEXT_BUNDLE_AUDIT_COMMAND =
   "pccxSystemVerilog.showContextBundleAudit";
 export const PCCX_LAB_BACKEND_STATUS_COMMAND =
   "pccxSystemVerilog.showPccxLabBackendStatus";
+export const SHOW_DIAGNOSTICS_HANDOFF_SUMMARY_COMMAND =
+  "pccxSystemVerilog.showDiagnosticsHandoffSummary";
 
 const NAVIGATION_LOCATION_COMMAND_IDS = Object.freeze([
   CHECKED_EXAMPLE_NAVIGATION_COMMAND,
@@ -395,6 +401,9 @@ function appendCommandOutput(outputChannel, commandId, result) {
   }
   if (result.kind === "context-bundle-audit") {
     outputChannel.appendLine(formatContextBundleAudit(result.audit));
+  }
+  if (result.kind === "diagnostics-handoff-status") {
+    outputChannel.appendLine(formatDiagnosticsHandoffStatusSurface(result.surface));
   }
   if (result.status?.kind === "pccx-lab-backend-status") {
     outputChannel.appendLine(JSON.stringify(result.status, null, 2));
@@ -977,6 +986,29 @@ export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
         };
         vscodeApi?.window?.showInformationMessage?.(
           `Context bundle audit: ${audit.approximateCharacterCount} character(s), ${audit.diagnosticCount} diagnostic(s).`,
+          result,
+        );
+      } catch (error) {
+        result = { ok: false, commandId, error: error.message };
+        vscodeApi?.window?.showWarningMessage?.(result.error, result);
+      }
+      appendCommandOutput(runtime.outputChannel, commandId, result);
+      return result;
+    }
+
+    if (commandId === SHOW_DIAGNOSTICS_HANDOFF_SUMMARY_COMMAND) {
+      let result;
+      try {
+        const surface = createDiagnosticsHandoffStatusSurface(runtime.diagnosticsHandoffSummary);
+        runtime.recentDiagnosticsHandoffStatus = surface;
+        result = {
+          ok: true,
+          commandId,
+          kind: "diagnostics-handoff-status",
+          surface,
+        };
+        vscodeApi?.window?.showInformationMessage?.(
+          `Diagnostics handoff summary: ${surface.display.summary}.`,
           result,
         );
       } catch (error) {

--- a/editors/vscode-prototype/src/local-workflow-status.mjs
+++ b/editors/vscode-prototype/src/local-workflow-status.mjs
@@ -7,6 +7,9 @@ import {
 import {
   createDiagnosticsHandoffConsumerBoundaryStatus,
 } from "./diagnostics-handoff-consumer.mjs";
+import {
+  createDiagnosticsHandoffStatusSurface,
+} from "./diagnostics-handoff-status-surface.mjs";
 
 export const LOCAL_WORKFLOW_STATUS_VERSION = "pccx.localWorkflowStatus.v0";
 
@@ -55,6 +58,9 @@ export function createLocalWorkflowStatus(config = {}, input = {}) {
   const pccxLabBoundary = createPccxLabCommandDescriptorStatus();
   const launcherBoundary = createLauncherStatusContractStatus();
   const diagnosticsHandoffBoundary = createDiagnosticsHandoffConsumerBoundaryStatus();
+  const diagnosticsHandoffSurface = createDiagnosticsHandoffStatusSurface(
+    input.diagnosticsHandoffSummary,
+  );
   const validationCache = validationStatusFromCache(input.validationResultCache);
   const extensionMode = typeof config.mode === "string" ? config.mode : "checkedExample";
   const validationRunner = config.validationRunner ?? {};
@@ -90,6 +96,10 @@ export function createLocalWorkflowStatus(config = {}, input = {}) {
       invokesLauncher: diagnosticsHandoffBoundary.invokesLauncher === true,
       invokesPccxLab: diagnosticsHandoffBoundary.invokesPccxLab === true,
       lspImplemented: diagnosticsHandoffBoundary.lspImplemented === true,
+      statusSurfaceVersion: diagnosticsHandoffSurface.version,
+      surfaceStatus: diagnosticsHandoffSurface.readiness.status,
+      summaryAvailable: diagnosticsHandoffSurface.readiness.summaryAvailable === true,
+      diagnosticCount: diagnosticsHandoffSurface.diagnostics.count,
     },
     contextBundle: contextBundleEstimate(input),
     safety: {
@@ -113,6 +123,7 @@ export function formatLocalWorkflowStatus(status) {
     `pccxLabBoundary: ${status.pccxLabBoundary.state} descriptorOnly=${status.pccxLabBoundary.descriptorOnly ? "yes" : "no"}`,
     `launcherBoundary: ${status.launcherBoundary.state} fixtureOnly=${status.launcherBoundary.fixtureOnly ? "yes" : "no"}`,
     `diagnosticsHandoffBoundary: ${status.diagnosticsHandoffBoundary.supportedSchemaVersion} readOnly=${status.diagnosticsHandoffBoundary.readOnly ? "yes" : "no"}`,
+    `diagnosticsHandoffSummary: ${status.diagnosticsHandoffBoundary.surfaceStatus} diagnostics=${status.diagnosticsHandoffBoundary.diagnosticCount}`,
     `contextBundleItems: ${status.contextBundle.itemCount}`,
     "safety: no provider calls, no launcher calls, no pccx-lab execution",
   ].join("\n");

--- a/editors/vscode-prototype/test/diagnostics-handoff-status-surface.test.mjs
+++ b/editors/vscode-prototype/test/diagnostics-handoff-status-surface.test.mjs
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  DIAGNOSTICS_HANDOFF_STATUS_SURFACE_VERSION,
+  cloneDefaultDiagnosticsHandoffConsumerSummary,
+  createDiagnosticsHandoffStatusSurface,
+  diagnosticsHandoffStatusSurfaceJson,
+  formatDiagnosticsHandoffStatusSurface,
+} from "../src/diagnostics-handoff-status-surface.mjs";
+import {
+  DIAGNOSTICS_HANDOFF_SCHEMA_VERSION,
+  consumeDiagnosticsHandoff,
+} from "../src/diagnostics-handoff-consumer.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const FIXTURE_PATH = resolve(
+  ROOT,
+  "docs/examples/diagnostics-handoff/launcher-diagnostics-handoff.example.json",
+);
+
+async function fixture() {
+  return JSON.parse(await readFile(FIXTURE_PATH, "utf8"));
+}
+
+async function adapterSummary() {
+  return consumeDiagnosticsHandoff(await fixture());
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+async function testDefaultSurfaceMatchesAdapterSummary() {
+  const summary = await adapterSummary();
+
+  assert.deepEqual(cloneDefaultDiagnosticsHandoffConsumerSummary(), summary);
+}
+
+async function testSurfaceConsumesAdapterOutputAsData() {
+  const summary = await adapterSummary();
+  const surface = createDiagnosticsHandoffStatusSurface(summary);
+
+  assert.equal(surface.version, DIAGNOSTICS_HANDOFF_STATUS_SURFACE_VERSION);
+  assert.equal(surface.kind, "diagnostics-handoff-status-surface");
+  assert.equal(surface.source.kind, "diagnostics-handoff-consumer");
+  assert.equal(surface.source.adapterOutput, true);
+  assert.equal(surface.source.rawHandoffParsedByUi, false);
+  assert.equal(surface.handoff.schemaVersion, DIAGNOSTICS_HANDOFF_SCHEMA_VERSION);
+  assert.equal(surface.handoff.handoffId, summary.handoffId);
+  assert.equal(surface.handoff.targetKind, "kv260");
+  assert.equal(surface.diagnostics.count, 5);
+  assert.deepEqual(surface.diagnostics.bySeverity, summary.diagnosticsBySeverity);
+  assert.deepEqual(surface.diagnostics.byCategory, summary.diagnosticsByCategory);
+  assert.deepEqual(surface.descriptorRefs, summary.descriptorRefs);
+  assert.deepEqual(surface.transportKinds, summary.transportKinds);
+  assert.equal(surface.readiness.status, "available");
+  assert.equal(surface.readiness.localOnly, true);
+}
+
+async function testSafetyFlagsRemainDataOnly() {
+  const surface = createDiagnosticsHandoffStatusSurface(await adapterSummary());
+
+  assert.equal(surface.safety.dataOnly, true);
+  assert.equal(surface.safety.readOnly, true);
+  assert.equal(surface.safety.localOnly, true);
+  assert.equal(surface.safety.launcherExecution, false);
+  assert.equal(surface.safety.pccxLabExecution, false);
+  assert.equal(surface.safety.pccxLabValidatorInvocation, false);
+  assert.equal(surface.safety.shellExecution, false);
+  assert.equal(surface.safety.providerCalls, false);
+  assert.equal(surface.safety.networkCalls, false);
+  assert.equal(surface.safety.runtimeCalls, false);
+  assert.equal(surface.safety.mcpCalls, false);
+  assert.equal(surface.safety.lspImplemented, false);
+  assert.equal(surface.safety.marketplaceFlow, false);
+  assert.equal(surface.safety.telemetry, false);
+  assert.equal(surface.safety.automaticUpload, false);
+  assert.equal(surface.safety.writeBack, false);
+  assert.equal(surface.boundary.invokesLauncher, false);
+  assert.equal(surface.boundary.invokesPccxLab, false);
+  assert.equal(surface.boundary.invokesPccxLabValidator, false);
+}
+
+async function testDeterministicJsonAndTextOutput() {
+  const summary = await adapterSummary();
+  const rendered = diagnosticsHandoffStatusSurfaceJson(summary);
+  const renderedAgain = diagnosticsHandoffStatusSurfaceJson(summary);
+  const surface = JSON.parse(rendered);
+  const text = formatDiagnosticsHandoffStatusSurface(surface);
+
+  assert.equal(rendered, renderedAgain);
+  assert.match(text, /Diagnostics Handoff Summary/);
+  assert.match(text, /schema: pccx\.diagnosticsHandoff\.v0/);
+  assert.match(text, /diagnostics: 5/);
+  assert.match(text, /readOnly: yes/);
+  assert.match(text, /dataOnly: yes/);
+  assert.match(text, /execution: no launcher, no pccx-lab, no shell/);
+}
+
+async function testRejectsRawHandoffAndUnsafeSummaryData() {
+  await assert.rejects(
+    async () => createDiagnosticsHandoffStatusSurface(await fixture()),
+    /kind: must be diagnostics-handoff-consumer/,
+  );
+
+  const missing = clone(await adapterSummary());
+  delete missing.descriptorRefs.runtimeId;
+  assert.throws(
+    () => createDiagnosticsHandoffStatusSurface(missing),
+    /descriptorRefs\.runtimeId: must be a non-empty string/,
+  );
+
+  const unsafe = clone(await adapterSummary());
+  unsafe.limitations[0] = "/home/user/private.log";
+  assert.throws(
+    () => createDiagnosticsHandoffStatusSurface(unsafe),
+    /private paths/,
+  );
+
+  const executing = clone(await adapterSummary());
+  executing.safety.pccxLabExecution = true;
+  assert.throws(
+    () => createDiagnosticsHandoffStatusSurface(executing),
+    /safety\.pccxLabExecution: must be false/,
+  );
+}
+
+async function testModuleSourceHasNoExecutionTerms() {
+  const source = await readFile(
+    resolve(ROOT, "editors/vscode-prototype/src/diagnostics-handoff-status-surface.mjs"),
+    "utf8",
+  );
+
+  assert.doesNotMatch(source, /node:child_process|\bexecFile\b|\bspawn\s*\(|\bexec\s*\(/);
+  assert.doesNotMatch(source, /\bwriteFile\s*\(|\bappendFile\s*\(|\bunlink\s*\(|\brm\s*\(/);
+  assert.doesNotMatch(source, /\bfetch\s*\(|XMLHttpRequest|WebSocket|node:https|node:http|node:net|node:tls/);
+  assert.doesNotMatch(source, /\b(?:openai|anthropic|gemini)\b/i);
+  assert.doesNotMatch(source, /pccx-lab\s+diagnostics-handoff\s+validate/i);
+  assert.doesNotMatch(source, /pccx-llm-launcher\s+(?:run|status|launch|diagnostics)/i);
+  assert.doesNotMatch(source, /modelcontextprotocol|McpServer|vscode-languageclient|LanguageClient/);
+}
+
+await testDefaultSurfaceMatchesAdapterSummary();
+await testSurfaceConsumesAdapterOutputAsData();
+await testSafetyFlagsRemainDataOnly();
+await testDeterministicJsonAndTextOutput();
+await testRejectsRawHandoffAndUnsafeSummaryData();
+await testModuleSourceHasNoExecutionTerms();
+
+console.log("vscode diagnostics handoff status surface tests ok");

--- a/editors/vscode-prototype/test/extension-entrypoint.test.mjs
+++ b/editors/vscode-prototype/test/extension-entrypoint.test.mjs
@@ -12,6 +12,7 @@ import {
   LIVE_WORKSPACE_NAVIGATION_COMMAND,
   PCCX_LAB_BACKEND_STATUS_COMMAND,
   SHOW_CONTEXT_BUNDLE_AUDIT_COMMAND,
+  SHOW_DIAGNOSTICS_HANDOFF_SUMMARY_COMMAND,
   SHOW_LOCAL_WORKFLOW_STATUS_COMMAND,
   SHOW_PATCH_PROPOSAL_PREVIEW_COMMAND,
   SHOW_RECENT_VALIDATION_RESULTS_COMMAND,
@@ -1360,6 +1361,65 @@ async function testContextBundleAuditCommandReturnsBoundedAudit() {
   assert.doesNotMatch(JSON.stringify(result.audit), /\/repo/);
 }
 
+async function testDiagnosticsHandoffSummaryCommandReturnsDataOnlySurface() {
+  const outputLines = [];
+  const informationMessages = [];
+  const facadeCalls = [];
+  const handler = createCommandHandler(
+    SHOW_DIAGNOSTICS_HANDOFF_SUMMARY_COMMAND,
+    {
+      window: {
+        showInformationMessage(...args) {
+          informationMessages.push(args);
+        },
+        showWarningMessage() {
+          throw new Error("diagnostics handoff summary should not warn for the default surface");
+        },
+      },
+    },
+    {
+      outputChannel: {
+        appendLine(line) {
+          outputLines.push(line);
+        },
+        show() {},
+      },
+      async runFacade(...args) {
+        facadeCalls.push(args);
+        throw new Error("diagnostics handoff summary must not call the facade");
+      },
+    },
+  );
+
+  const result = await handler();
+  const renderedAgain = await handler();
+
+  assert.equal(result.ok, true);
+  assert.equal(result.commandId, SHOW_DIAGNOSTICS_HANDOFF_SUMMARY_COMMAND);
+  assert.equal(result.kind, "diagnostics-handoff-status");
+  assert.equal(result.surface.kind, "diagnostics-handoff-status-surface");
+  assert.equal(result.surface.source.adapterOutput, true);
+  assert.equal(result.surface.source.rawHandoffParsedByUi, false);
+  assert.equal(result.surface.diagnostics.count, 5);
+  assert.equal(result.surface.safety.dataOnly, true);
+  assert.equal(result.surface.safety.readOnly, true);
+  assert.equal(result.surface.safety.launcherExecution, false);
+  assert.equal(result.surface.safety.pccxLabExecution, false);
+  assert.equal(result.surface.safety.pccxLabValidatorInvocation, false);
+  assert.equal(result.surface.safety.shellExecution, false);
+  assert.equal(result.surface.safety.providerCalls, false);
+  assert.equal(result.surface.safety.runtimeCalls, false);
+  assert.equal(result.surface.safety.mcpCalls, false);
+  assert.equal(result.surface.safety.lspImplemented, false);
+  assert.equal(result.surface.safety.marketplaceFlow, false);
+  assert.deepEqual(result.surface, renderedAgain.surface);
+  assert.equal(facadeCalls.length, 0);
+  assert.ok(outputLines.some((line) => line.includes("Diagnostics Handoff Summary")));
+  assert.ok(outputLines.some((line) => line.includes("execution: no launcher, no pccx-lab")));
+  assert.ok(informationMessages.some(([message]) => /Diagnostics handoff summary/.test(message)));
+  assert.doesNotMatch(JSON.stringify(result.surface), /\/home\/|TOKEN=|\.gguf|\.safetensors/);
+}
+
 async function testPccxLabBackendStatusCommandReturnsStatusOnly() {
   const settings = new Map([
     ["mode", "checkedExample"],
@@ -1433,6 +1493,7 @@ await testValidationResultCacheCommandsShowAndClear();
 await testPatchProposalPreviewCommandsShowAndClearCheckedProposalOnly();
 await testLocalWorkflowStatusCommandReturnsFixtureOnlyBoundaryState();
 await testContextBundleAuditCommandReturnsBoundedAudit();
+await testDiagnosticsHandoffSummaryCommandReturnsDataOnlySurface();
 await testPccxLabBackendStatusCommandReturnsStatusOnly();
 
 console.log("vscode extension entrypoint tests ok");

--- a/editors/vscode-prototype/test/extension-host-readiness.test.mjs
+++ b/editors/vscode-prototype/test/extension-host-readiness.test.mjs
@@ -113,6 +113,7 @@ async function testReadinessDocsAndCiPolicy() {
   assert.match(`${readme}\n${readiness}`, /showLocalWorkflowStatus/);
   assert.match(`${readme}\n${readiness}`, /showContextBundleAudit/);
   assert.match(`${readme}\n${readiness}`, /showPccxLabBackendStatus/);
+  assert.match(`${readme}\n${readiness}`, /showDiagnosticsHandoffSummary/);
   assert.match(`${readme}\n${readiness}`, /context bundle command/i);
   assert.match(`${readme}\n${readiness}`, /validation command proposal/i);
   assert.match(`${readme}\n${readiness}`, /patch proposal contract/i);
@@ -181,6 +182,7 @@ async function testRuntimeRunnerIsPinnedAndBounded() {
   assert.match(suite, /validationRunner\.enabled/);
   assert.match(suite, /vscodeAdapterSmoke/);
   assert.match(suite, /showPccxLabBackendStatus/);
+  assert.match(suite, /showDiagnosticsHandoffSummary/);
   assert.match(suite, /providerCallsImplemented/);
   assert.match(suite, /getDiagnostics/);
   assert.match(suite, /DiagnosticSeverity\.Error/);

--- a/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
+++ b/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
@@ -76,6 +76,7 @@ async function run() {
     "pccxSystemVerilog.showLocalWorkflowStatus",
     "pccxSystemVerilog.showContextBundleAudit",
     "pccxSystemVerilog.showPccxLabBackendStatus",
+    "pccxSystemVerilog.showDiagnosticsHandoffSummary",
   ]);
 
   const manifest = readManifest();
@@ -522,6 +523,23 @@ async function run() {
   assert.equal(pccxLabStatus.status.executes, false);
   assert.equal(pccxLabStatus.status.backendCommandExecuted, false);
   assert.ok(pccxLabStatus.status.futureControlledOperations.includes("diagnostics"));
+
+  const diagnosticsHandoffStatus = await vscode.commands.executeCommand(
+    "pccxSystemVerilog.showDiagnosticsHandoffSummary",
+  );
+  assert.equal(diagnosticsHandoffStatus.ok, true);
+  assert.equal(diagnosticsHandoffStatus.kind, "diagnostics-handoff-status");
+  assert.equal(diagnosticsHandoffStatus.surface.kind, "diagnostics-handoff-status-surface");
+  assert.equal(diagnosticsHandoffStatus.surface.source.adapterOutput, true);
+  assert.equal(diagnosticsHandoffStatus.surface.source.rawHandoffParsedByUi, false);
+  assert.equal(diagnosticsHandoffStatus.surface.safety.launcherExecution, false);
+  assert.equal(diagnosticsHandoffStatus.surface.safety.pccxLabExecution, false);
+  assert.equal(diagnosticsHandoffStatus.surface.safety.pccxLabValidatorInvocation, false);
+  assert.equal(diagnosticsHandoffStatus.surface.safety.shellExecution, false);
+  assert.equal(diagnosticsHandoffStatus.surface.safety.providerCalls, false);
+  assert.equal(diagnosticsHandoffStatus.surface.safety.runtimeCalls, false);
+  assert.equal(diagnosticsHandoffStatus.surface.safety.mcpCalls, false);
+  assert.equal(diagnosticsHandoffStatus.surface.safety.lspImplemented, false);
 
   const extensionModule = await importExtensionEntrypoint();
   assert.equal(typeof extensionModule.deactivate, "function");

--- a/editors/vscode-prototype/test/extension-manifest.test.mjs
+++ b/editors/vscode-prototype/test/extension-manifest.test.mjs
@@ -26,6 +26,7 @@ const COMMAND_IDS = [
   "pccxSystemVerilog.showLocalWorkflowStatus",
   "pccxSystemVerilog.showContextBundleAudit",
   "pccxSystemVerilog.showPccxLabBackendStatus",
+  "pccxSystemVerilog.showDiagnosticsHandoffSummary",
 ];
 
 async function readText(path) {
@@ -132,6 +133,7 @@ async function testDocsKeepExperimentalScope() {
   assert.match(combined, /approved validation runner/i);
   assert.match(combined, /allowlisted proposal IDs/i);
   assert.match(combined, /pccx-lab backend status/i);
+  assert.match(combined, /showDiagnosticsHandoffSummary/);
   assert.match(combined, /no AI provider calls/i);
   assert.match(combined, /no MCP server implementation/i);
 }

--- a/editors/vscode-prototype/test/local-workflow-status.test.mjs
+++ b/editors/vscode-prototype/test/local-workflow-status.test.mjs
@@ -63,6 +63,9 @@ function testLocalWorkflowStatusUsesDeterministicLocalDataOnly() {
   assert.equal(status.diagnosticsHandoffBoundary.invokesLauncher, false);
   assert.equal(status.diagnosticsHandoffBoundary.invokesPccxLab, false);
   assert.equal(status.diagnosticsHandoffBoundary.lspImplemented, false);
+  assert.equal(status.diagnosticsHandoffBoundary.surfaceStatus, "available");
+  assert.equal(status.diagnosticsHandoffBoundary.summaryAvailable, true);
+  assert.equal(status.diagnosticsHandoffBoundary.diagnosticCount, 5);
   assert.equal(status.contextBundle.itemCount, 9);
   assert.equal(status.safety.providerCalls, false);
   assert.equal(status.safety.launcherCalls, false);
@@ -81,9 +84,12 @@ function testLocalWorkflowStatusDefaultsAreDisabledAndSafe() {
   assert.equal(status.launcherBoundary.launcherCalls, false);
   assert.equal(status.diagnosticsHandoffBoundary.invokesLauncher, false);
   assert.equal(status.diagnosticsHandoffBoundary.invokesPccxLab, false);
+  assert.equal(status.diagnosticsHandoffBoundary.surfaceStatus, "available");
+  assert.equal(status.diagnosticsHandoffBoundary.summaryAvailable, true);
   assert.match(text, /Local Workflow Status/);
   assert.match(text, /validationRunner: disabled/);
   assert.match(text, /diagnosticsHandoffBoundary: pccx\.diagnosticsHandoff\.v0 readOnly=yes/);
+  assert.match(text, /diagnosticsHandoffSummary: available diagnostics=5/);
   assert.match(text, /no pccx-lab execution/);
   assert.doesNotMatch(JSON.stringify(status), /\/home\/|TOKEN=|model\.gguf/);
 }

--- a/editors/vscode-prototype/test/static-boundary.test.mjs
+++ b/editors/vscode-prototype/test/static-boundary.test.mjs
@@ -146,6 +146,7 @@ async function testProposalAndStatusModulesAreDataOnly() {
     resolve(EXTENSION_ROOT, "src/pccx-lab-command-descriptor.mjs"),
     resolve(EXTENSION_ROOT, "src/launcher-status-contract.mjs"),
     resolve(EXTENSION_ROOT, "src/diagnostics-handoff-consumer.mjs"),
+    resolve(EXTENSION_ROOT, "src/diagnostics-handoff-status-surface.mjs"),
     resolve(EXTENSION_ROOT, "src/local-workflow-status.mjs"),
     resolve(EXTENSION_ROOT, "src/context-bundle-audit.mjs"),
     resolve(EXTENSION_ROOT, "src/pccx-lab-status.mjs"),

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -24,6 +24,7 @@ node editors/vscode-prototype/test/validation-patch-handoff.test.mjs
 node editors/vscode-prototype/test/pccx-lab-command-descriptor.test.mjs
 node editors/vscode-prototype/test/launcher-status-contract.test.mjs
 node editors/vscode-prototype/test/diagnostics-handoff-consumer.test.mjs
+node editors/vscode-prototype/test/diagnostics-handoff-status-surface.test.mjs
 node editors/vscode-prototype/test/local-workflow-status.test.mjs
 node editors/vscode-prototype/test/context-bundle-audit.test.mjs
 node editors/vscode-prototype/test/validation-result-summary.test.mjs


### PR DESCRIPTION
## Summary
- Adds `pccxSystemVerilog.showDiagnosticsHandoffSummary` for a small VS Code prototype status surface over diagnostics handoff summary data.
- Adds `diagnostics-handoff-status-surface.mjs`, which consumes the existing diagnostics handoff consumer summary as data and returns deterministic JSON/text status output.
- Extends local workflow status and docs to report diagnostics handoff summary availability.

## Scope
- Data-only status surface and command registration.
- Tests for deterministic command output, adapter-summary consumption, and safety flags.
- Manifest, Extension Host smoke expectations, README, and handoff docs updates.

## Non-goals
- No pccx-llm-launcher execution.
- No pccx-lab execution or pccx-lab validator invocation.
- No shell execution path in the diagnostics handoff UI/status layer.
- No provider, model runtime, KV260 runtime, MCP, LSP, telemetry, upload, release, tag, packaging, or marketplace flow.
- No API or ABI stability commitment.

## Validation
- `git diff --check`
- `python3 -m pytest -q` — 164 passed
- `bash scripts/vscode-adapter-smoke.sh`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh` — ran because dependencies and VS Code 1.90.2 test runtime were already present locally
- Targeted Node tests:
  - `node editors/vscode-prototype/test/diagnostics-handoff-status-surface.test.mjs`
  - `node editors/vscode-prototype/test/local-workflow-status.test.mjs`
  - `node editors/vscode-prototype/test/extension-manifest.test.mjs`
  - `node editors/vscode-prototype/test/extension-entrypoint.test.mjs`
  - `node editors/vscode-prototype/test/extension-host-readiness.test.mjs`
  - `node editors/vscode-prototype/test/static-boundary.test.mjs`
- `node -e "const p=require('./editors/vscode-prototype/package.json'); console.log(JSON.stringify(p.scripts||{}))"` — `{}`, so npm test/build scripts are not present

## Safety notes
- The command consumes the existing diagnostics handoff consumer summary as data and does not parse raw handoff JSON in the UI layer.
- No launcher, pccx-lab, pccx-lab validator, shell, provider, network, runtime, hardware, MCP, LSP, telemetry, upload, or writeback path was added.
- No release or tag was created.

## Related
- Follows `pccxai/systemverilog-ide#52`
- Follows `pccxai/pccx-llm-launcher#19`
- Follows `pccxai/pccx-lab#30`
