### PR TITLE
Add diagnostics handoff data to context bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,10 @@ The VS Code prototype also has a read-only diagnostics handoff consumer
 for the launcher / pccx-lab `pccx.diagnosticsHandoff.v0` JSON shape. It
 parses a checked local fixture and returns deterministic summary data for
 future UI use. The `showDiagnosticsHandoffSummary` command surfaces that
-adapter summary as local status data. It does not execute the launcher,
-execute pccx-lab, invoke the pccx-lab validator, implement MCP or LSP,
-call providers, or touch hardware.
+adapter summary as local status data, and the local context bundle can
+carry the same bounded summary as read-only context. It does not execute
+the launcher, execute pccx-lab, invoke the pccx-lab validator, implement
+MCP or LSP, call providers, or touch hardware.
 
 ## Later track (deferred)
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -106,6 +106,12 @@ summary as data, returns JSON for tests or future UI code, and writes a
 small local text summary to the prototype output channel. It does not
 read raw handoff JSON in the UI layer.
 
+The local AI/context bundle can include the same diagnostics handoff
+summary as bounded context. It records the schema and handoff IDs,
+diagnostic counts, descriptor references, transport kinds, and read-only
+safety flags. Missing or invalid handoff data remains local unavailable
+or invalid context and does not trigger execution.
+
 This path is data-only. It does not execute `pccx-llm-launcher`, does not
 execute `pccx-lab`, does not invoke the pccx-lab validator command, does
 not spawn shell commands, does not implement MCP or LSP, does not call

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -301,7 +301,13 @@ code, duration/timestamps, working-directory kind, command kind, bounded
 stdout/stderr summaries, truncation/redaction flags, failure hints, and
 safety metadata.  It does not include full logs, raw shell command
 strings, raw absolute private paths, generated artifacts, or bulk file
-content.  The selected-symbol
+content.  The bundle can also include the diagnostics handoff summary
+section from `src/diagnostics-handoff-status-surface.mjs` as read-only
+adapter data.  That section carries counts, descriptor references,
+transport kinds, and safety flags only; missing or invalid handoff data is
+reported as unavailable/invalid context and does not trigger launcher,
+pccx-lab, validator, shell, provider, runtime, MCP, LSP, telemetry,
+upload, or write-back behavior.  The selected-symbol
 context extracts simple SystemVerilog-like lexical cues such as the symbol
 text, current line, and nearby module/package/interface/parameter/function
 or task declaration; it is not full semantic analysis.  The bundle

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -44,6 +44,10 @@ should earn CI promotion separately.
   runtime calls reported as unimplemented.
 - Selected-symbol context smoke for the context bundle.  The selected
   symbol context is lexical and bounded, not full semantic analysis.
+- Diagnostics handoff summary context smoke.  The context bundle carries
+  the existing adapter summary as bounded read-only context and does not
+  execute launcher, pccx-lab, validator commands, shell commands,
+  providers, MCP, or LSP.
 - Validation command proposal smoke.  The command returns data only and
   does not execute validation commands.
 - Approved validation runner smoke.  The command blocks by default,
@@ -166,6 +170,10 @@ diagnostics handoff adapter summary as a local status surface. It consumes
 adapter output as data, does not read raw handoff JSON in the UI layer,
 does not execute launcher or pccx-lab, and does not invoke the pccx-lab
 validator command.
+The same summary can flow into `pccxSystemVerilog.buildAIContextBundle`
+as a bounded `diagnosticsHandoff` context section. Missing or invalid
+handoff data is kept as local unavailable/invalid context and does not
+start a backend command.
 
 `pccxSystemVerilog.proposeValidationCommand` currently proposes only
 allowlisted templates, including the VS Code adapter smoke, editor bridge

--- a/editors/vscode-prototype/docs/diagnostics-handoff-consumer.md
+++ b/editors/vscode-prototype/docs/diagnostics-handoff-consumer.md
@@ -39,6 +39,13 @@ It is experimental and local-only. It does not read raw handoff JSON in
 the UI layer, does not execute launcher or pccx-lab, and does not invoke
 the pccx-lab validator command.
 
+`pccxSystemVerilog.buildAIContextBundle` can include a bounded
+`diagnosticsHandoff` section from the same status surface. That context
+section is summary-only: schema ID, handoff ID, diagnostic counts,
+descriptor references, transport kinds, and read-only safety flags.
+Missing or invalid handoff data is represented as unavailable/invalid
+context instead of executing a backend command.
+
 ## What It Does Not Do
 
 This boundary does not:

--- a/editors/vscode-prototype/src/context-bundle-audit.mjs
+++ b/editors/vscode-prototype/src/context-bundle-audit.mjs
@@ -57,6 +57,7 @@ export function createContextBundleAudit(bundle = {}) {
     validationSummaryCount: validationSummaryCount(bundle),
     launcherStatusEntryCount: bundle?.launcher ? 1 : 0,
     labStatusEntryCount: Array.isArray(bundle?.pccxLab?.outputs) ? bundle.pccxLab.outputs.length : 0,
+    diagnosticsHandoffEntryCount: bundle?.diagnosticsHandoff?.summaryAvailable === true ? 1 : 0,
     redactionApplied: textContainsRedaction(bundle),
     truncationApplied: countTruncatedItems(bundle) > 0,
     truncatedItemCount: countTruncatedItems(bundle),
@@ -68,6 +69,7 @@ export function createContextBundleAudit(bundle = {}) {
       providerCalls: false,
       networkCalls: false,
       mcpCalls: false,
+      diagnosticsHandoffReadOnly: bundle?.diagnosticsHandoff?.safety?.readOnly === true,
     },
   };
   return audit;
@@ -83,6 +85,7 @@ export function formatContextBundleAudit(audit) {
     `validationSummaries: ${audit.validationSummaryCount}`,
     `launcherStatusEntries: ${audit.launcherStatusEntryCount}`,
     `labStatusEntries: ${audit.labStatusEntryCount}`,
+    `diagnosticsHandoffEntries: ${audit.diagnosticsHandoffEntryCount}`,
     `redactionApplied: ${audit.redactionApplied ? "yes" : "no"}`,
     `truncationApplied: ${audit.truncationApplied ? "yes" : "no"}`,
     `excludedCategories: ${audit.excludedCategories.join(", ")}`,

--- a/editors/vscode-prototype/src/context-bundle.mjs
+++ b/editors/vscode-prototype/src/context-bundle.mjs
@@ -1,5 +1,13 @@
 import { isAbsolute, relative } from "node:path";
 
+import {
+  DIAGNOSTICS_HANDOFF_CATEGORIES,
+  DIAGNOSTICS_HANDOFF_SEVERITIES,
+} from "./diagnostics-handoff-consumer.mjs";
+import {
+  createDiagnosticsHandoffStatusSurface,
+} from "./diagnostics-handoff-status-surface.mjs";
+
 export const CONTEXT_BUNDLE_VERSION = "pccx.contextBundle.v0";
 export const CONTEXT_BUNDLE_SOURCE = "pccx-systemverilog-ide";
 
@@ -12,6 +20,9 @@ export const DEFAULT_CONTEXT_BUNDLE_LIMITS = Object.freeze({
   maxRecentValidationResults: 5,
   maxTextCharacters: 4000,
 });
+
+export const CONTEXT_BUNDLE_DIAGNOSTICS_HANDOFF_VERSION =
+  "pccx.contextBundleDiagnosticsHandoff.v0";
 
 const EXCLUDED_PATH_SEGMENTS = new Set([
   ".git",
@@ -512,6 +523,176 @@ function normalizeRecentValidationHistory(history, limits) {
     .slice(0, limits.maxRecentValidationResults);
 }
 
+function diagnosticsHandoffSafetyBase() {
+  return {
+    dataOnly: true,
+    readOnly: true,
+    localOnly: true,
+    launcherExecution: false,
+    pccxLabExecution: false,
+    pccxLabValidatorInvocation: false,
+    shellExecution: false,
+    providerCalls: false,
+    networkCalls: false,
+    runtimeCalls: false,
+    mcpCalls: false,
+    lspImplemented: false,
+    marketplaceFlow: false,
+    telemetry: false,
+    automaticUpload: false,
+    writeBack: false,
+  };
+}
+
+function missingDiagnosticsHandoffContext(status = "notAvailable", reason = "") {
+  return {
+    version: CONTEXT_BUNDLE_DIAGNOSTICS_HANDOFF_VERSION,
+    kind: "diagnostics-handoff-context",
+    status,
+    summaryAvailable: false,
+    source: {
+      adapterOutput: false,
+      rawHandoffParsedByUi: false,
+    },
+    handoff: null,
+    diagnostics: {
+      count: 0,
+      bySeverity: {},
+      byCategory: {},
+    },
+    descriptorRefs: null,
+    transportKinds: [],
+    limitations: [],
+    safety: diagnosticsHandoffSafetyBase(),
+    reason,
+  };
+}
+
+function normalizeCountMap(value, keys) {
+  return Object.fromEntries(keys.map((key) => {
+    const count = value?.[key];
+    return [key, Math.max(0, Math.floor(clampNumber(count)))];
+  }));
+}
+
+function normalizeDiagnosticsHandoffStatusSurface(surface, limits) {
+  return {
+    version: CONTEXT_BUNDLE_DIAGNOSTICS_HANDOFF_VERSION,
+    kind: "diagnostics-handoff-context",
+    status: scrubText(surface.readiness?.status ?? "available", 80),
+    summaryAvailable: surface.readiness?.summaryAvailable === true,
+    source: {
+      adapterOutput: surface.source?.adapterOutput === true,
+      rawHandoffParsedByUi: surface.source?.rawHandoffParsedByUi === true,
+    },
+    handoff: surface.handoff
+      ? {
+          schemaVersion: scrubText(surface.handoff.schemaVersion ?? "", 120),
+          handoffId: scrubText(surface.handoff.handoffId ?? "", 160),
+          handoffKind: scrubText(surface.handoff.handoffKind ?? "", 120),
+          producerId: scrubText(surface.handoff.producerId ?? "", 120),
+          consumerId: scrubText(surface.handoff.consumerId ?? "", 120),
+          targetKind: scrubText(surface.handoff.targetKind ?? "", 120),
+        }
+      : null,
+    diagnostics: {
+      count: Math.max(0, Math.floor(clampNumber(surface.diagnostics?.count))),
+      bySeverity: normalizeCountMap(
+        surface.diagnostics?.bySeverity,
+        DIAGNOSTICS_HANDOFF_SEVERITIES,
+      ),
+      byCategory: normalizeCountMap(
+        surface.diagnostics?.byCategory,
+        DIAGNOSTICS_HANDOFF_CATEGORIES,
+      ),
+    },
+    descriptorRefs: surface.descriptorRefs
+      ? {
+          launcherOperationId: scrubText(surface.descriptorRefs.launcherOperationId ?? "", 160),
+          modelId: scrubText(surface.descriptorRefs.modelId ?? "", 160),
+          runtimeId: scrubText(surface.descriptorRefs.runtimeId ?? "", 160),
+          referenceKind: scrubText(surface.descriptorRefs.referenceKind ?? "", 120),
+        }
+      : null,
+    transportKinds: Array.isArray(surface.transportKinds)
+      ? surface.transportKinds.map((kind) => scrubText(kind, 120)).slice(0, 4)
+      : [],
+    limitations: Array.isArray(surface.limitations)
+      ? surface.limitations.map((item) => scrubText(item, 500)).slice(0, 4)
+      : [],
+    safety: {
+      ...diagnosticsHandoffSafetyBase(),
+      dataOnly: surface.safety?.dataOnly === true,
+      readOnly: surface.safety?.readOnly === true,
+      localOnly: surface.safety?.localOnly === true,
+      launcherExecution: surface.safety?.launcherExecution === true,
+      pccxLabExecution: surface.safety?.pccxLabExecution === true,
+      pccxLabValidatorInvocation: surface.safety?.pccxLabValidatorInvocation === true,
+      shellExecution: surface.safety?.shellExecution === true,
+      providerCalls: surface.safety?.providerCalls === true,
+      networkCalls: surface.safety?.networkCalls === true,
+      runtimeCalls: surface.safety?.runtimeCalls === true,
+      mcpCalls: surface.safety?.mcpCalls === true,
+      lspImplemented: surface.safety?.lspImplemented === true,
+      marketplaceFlow: surface.safety?.marketplaceFlow === true,
+      telemetry: surface.safety?.telemetry === true,
+      automaticUpload: surface.safety?.automaticUpload === true,
+      writeBack: surface.safety?.writeBack === true,
+    },
+  };
+}
+
+function assertDiagnosticsHandoffContextSafety(context) {
+  const safety = context.safety ?? {};
+  if (
+    safety.dataOnly !== true ||
+    safety.readOnly !== true ||
+    safety.launcherExecution === true ||
+    safety.pccxLabExecution === true ||
+    safety.pccxLabValidatorInvocation === true ||
+    safety.shellExecution === true ||
+    safety.providerCalls === true ||
+    safety.networkCalls === true ||
+    safety.runtimeCalls === true ||
+    safety.mcpCalls === true ||
+    safety.lspImplemented === true ||
+    safety.marketplaceFlow === true ||
+    safety.telemetry === true ||
+    safety.automaticUpload === true ||
+    safety.writeBack === true ||
+    context.source?.rawHandoffParsedByUi === true
+  ) {
+    throw new Error("diagnostics handoff context must remain data-only and read-only");
+  }
+}
+
+function normalizeDiagnosticsHandoffContext(input, limits) {
+  const suppliedSurface = input?.diagnosticsHandoffStatus ??
+    input?.diagnosticsHandoff?.statusSurface ??
+    null;
+  const suppliedSummary = input?.diagnosticsHandoffSummary ??
+    input?.diagnosticsHandoff?.consumerSummary ??
+    null;
+
+  if (!suppliedSurface && !suppliedSummary) {
+    return missingDiagnosticsHandoffContext();
+  }
+
+  try {
+    const surface = suppliedSurface?.kind === "diagnostics-handoff-status-surface"
+      ? suppliedSurface
+      : createDiagnosticsHandoffStatusSurface(suppliedSummary);
+    const context = normalizeDiagnosticsHandoffStatusSurface(surface, limits);
+    assertDiagnosticsHandoffContextSafety(context);
+    return context;
+  } catch (error) {
+    return missingDiagnosticsHandoffContext(
+      "invalid",
+      scrubText(error.message, limits.maxTextCharacters),
+    );
+  }
+}
+
 export function buildContextBundle(input = {}, options = {}) {
   const limits = mergeLimits(options.limits);
   const workspaceRoot = options.workspaceRoot ?? input.workspaceRoot ?? null;
@@ -579,6 +760,7 @@ export function buildContextBundle(input = {}, options = {}) {
         .map((entry) => normalizeLogSummary(entry, limits))
         .slice(0, limits.maxFiles),
     },
+    diagnosticsHandoff: normalizeDiagnosticsHandoffContext(input, limits),
     excludedPathSegments: [...EXCLUDED_PATH_SEGMENTS].sort(),
     excludedPathPatterns: [...EXCLUDED_PATH_PATTERNS],
     redaction: {
@@ -616,7 +798,20 @@ export function summarizeContextBundle(bundle) {
           recentHistoryCount: Array.isArray(bundle.validation.recentHistory)
             ? bundle.validation.recentHistory.length
             : 0,
-        }
+      }
       : null,
+    diagnosticsHandoff: bundle?.diagnosticsHandoff?.summaryAvailable
+      ? {
+          status: bundle.diagnosticsHandoff.status,
+          schemaVersion: bundle.diagnosticsHandoff.handoff?.schemaVersion ?? "",
+          diagnosticCount: bundle.diagnosticsHandoff.diagnostics?.count ?? 0,
+          blockedCount: bundle.diagnosticsHandoff.diagnostics?.bySeverity?.blocked ?? 0,
+          readOnly: bundle.diagnosticsHandoff.safety?.readOnly === true,
+        }
+      : {
+          status: bundle?.diagnosticsHandoff?.status ?? "notAvailable",
+          diagnosticCount: 0,
+          readOnly: bundle?.diagnosticsHandoff?.safety?.readOnly === true,
+        },
   };
 }

--- a/editors/vscode-prototype/src/extension.mjs
+++ b/editors/vscode-prototype/src/extension.mjs
@@ -596,6 +596,17 @@ function contextConfiguration(config) {
   };
 }
 
+function diagnosticsHandoffStatusFromRuntime(runtime = {}) {
+  if (runtime.recentDiagnosticsHandoffStatus?.kind === "diagnostics-handoff-status-surface") {
+    return runtime.recentDiagnosticsHandoffStatus;
+  }
+  try {
+    return createDiagnosticsHandoffStatusSurface(runtime.diagnosticsHandoffSummary);
+  } catch {
+    return null;
+  }
+}
+
 function collectActiveDiagnostics(vscodeApi, runtime, document) {
   if (!document?.uri) {
     return [];
@@ -687,6 +698,7 @@ function collectActiveDocumentContext(vscodeApi, runtime, config) {
       recentCommandStatus: runtime.recentCommandStatus ?? null,
       recentValidation: recentValidationHistory[0] ?? runtime.recentValidationSummary ?? null,
       recentValidationHistory,
+      diagnosticsHandoffStatus: diagnosticsHandoffStatusFromRuntime(runtime),
     },
   };
 }

--- a/editors/vscode-prototype/test/context-bundle-audit.test.mjs
+++ b/editors/vscode-prototype/test/context-bundle-audit.test.mjs
@@ -8,6 +8,9 @@ import {
 import {
   buildContextBundle,
 } from "../src/context-bundle.mjs";
+import {
+  cloneDefaultDiagnosticsHandoffConsumerSummary,
+} from "../src/diagnostics-handoff-status-surface.mjs";
 
 function testAuditCountsBoundedContextShape() {
   const bundle = buildContextBundle(
@@ -36,6 +39,7 @@ function testAuditCountsBoundedContextShape() {
       pccxLabOutputs: [
         { label: "fixture", summaryLines: ["TOKEN=hidden"] },
       ],
+      diagnosticsHandoffSummary: cloneDefaultDiagnosticsHandoffConsumerSummary(),
     },
     {
       workspaceRoot: "/repo",
@@ -54,14 +58,17 @@ function testAuditCountsBoundedContextShape() {
   assert.equal(audit.validationSummaryCount, 1);
   assert.equal(audit.launcherStatusEntryCount, 0);
   assert.equal(audit.labStatusEntryCount, 1);
+  assert.equal(audit.diagnosticsHandoffEntryCount, 1);
   assert.equal(audit.redactionApplied, true);
   assert.equal(audit.truncationApplied, true);
   assert.ok(audit.excludedCategories.includes("node_modules"));
   assert.ok(audit.excludedCategories.includes("node_modules/**"));
   assert.equal(audit.safety.fullLogsExcluded, true);
   assert.equal(audit.safety.providerCalls, false);
+  assert.equal(audit.safety.diagnosticsHandoffReadOnly, true);
   assert.match(text, /Context Bundle Audit/);
   assert.match(text, /validationSummaries: 1/);
+  assert.match(text, /diagnosticsHandoffEntries: 1/);
   assert.doesNotMatch(JSON.stringify(audit), /TOKEN=hidden|\/repo/);
 }
 
@@ -71,6 +78,7 @@ function testEmptyAuditIsDeterministicAndSafe() {
   assert.equal(audit.diagnosticCount, 0);
   assert.equal(audit.snippetCount, 0);
   assert.equal(audit.validationSummaryCount, 0);
+  assert.equal(audit.diagnosticsHandoffEntryCount, 0);
   assert.equal(audit.redactionApplied, false);
   assert.equal(audit.truncationApplied, false);
   assert.deepEqual(audit.excludedCategories, []);

--- a/editors/vscode-prototype/test/context-bundle.test.mjs
+++ b/editors/vscode-prototype/test/context-bundle.test.mjs
@@ -1,10 +1,15 @@
 import assert from "node:assert/strict";
 
 import {
+  CONTEXT_BUNDLE_DIAGNOSTICS_HANDOFF_VERSION,
   CONTEXT_BUNDLE_VERSION,
   buildContextBundle,
   summarizeContextBundle,
 } from "../src/context-bundle.mjs";
+import {
+  cloneDefaultDiagnosticsHandoffConsumerSummary,
+  createDiagnosticsHandoffStatusSurface,
+} from "../src/diagnostics-handoff-status-surface.mjs";
 
 const SECRET_KEY_PATTERN =
   /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b/i;
@@ -258,6 +263,7 @@ function fixtureInput() {
         redactionApplied: false,
       },
     ],
+    diagnosticsHandoffSummary: cloneDefaultDiagnosticsHandoffConsumerSummary(),
     pccxLabOutputs: [
       {
         flow: "problems from-check",
@@ -326,6 +332,27 @@ function testStableBoundedShape() {
   assert.equal(bundle.recentCommand.facade.mode, "example");
   assert.equal(bundle.pccxLab.outputs.length, 1);
   assert.deepEqual(bundle.pccxLab.outputs[0].lines, ["[redacted]"]);
+  assert.equal(bundle.diagnosticsHandoff.version, CONTEXT_BUNDLE_DIAGNOSTICS_HANDOFF_VERSION);
+  assert.equal(bundle.diagnosticsHandoff.kind, "diagnostics-handoff-context");
+  assert.equal(bundle.diagnosticsHandoff.status, "available");
+  assert.equal(bundle.diagnosticsHandoff.summaryAvailable, true);
+  assert.equal(bundle.diagnosticsHandoff.source.adapterOutput, true);
+  assert.equal(bundle.diagnosticsHandoff.source.rawHandoffParsedByUi, false);
+  assert.equal(bundle.diagnosticsHandoff.handoff.schemaVersion, "pccx.diagnosticsHandoff.v0");
+  assert.equal(bundle.diagnosticsHandoff.handoff.handoffKind, "read_only_handoff");
+  assert.equal(bundle.diagnosticsHandoff.diagnostics.count, 5);
+  assert.equal(bundle.diagnosticsHandoff.diagnostics.bySeverity.blocked, 2);
+  assert.equal(bundle.diagnosticsHandoff.descriptorRefs.referenceKind, "descriptor_ref_only");
+  assert.equal(bundle.diagnosticsHandoff.safety.dataOnly, true);
+  assert.equal(bundle.diagnosticsHandoff.safety.readOnly, true);
+  assert.equal(bundle.diagnosticsHandoff.safety.launcherExecution, false);
+  assert.equal(bundle.diagnosticsHandoff.safety.pccxLabExecution, false);
+  assert.equal(bundle.diagnosticsHandoff.safety.pccxLabValidatorInvocation, false);
+  assert.equal(bundle.diagnosticsHandoff.safety.shellExecution, false);
+  assert.equal(bundle.diagnosticsHandoff.safety.providerCalls, false);
+  assert.equal(bundle.diagnosticsHandoff.safety.runtimeCalls, false);
+  assert.equal(bundle.diagnosticsHandoff.safety.mcpCalls, false);
+  assert.equal(bundle.diagnosticsHandoff.safety.lspImplemented, false);
   assert.ok(bundle.excludedPathPatterns.includes("agent-instruction-files"));
   assert.equal(bundle.redaction.assignmentPolicy, "secret-like-lines-redacted");
   assert.deepEqual(summarizeContextBundle(bundle), {
@@ -345,6 +372,13 @@ function testStableBoundedShape() {
       status: "failed",
       label: "VS Code adapter smoke",
       recentHistoryCount: 2,
+    },
+    diagnosticsHandoff: {
+      status: "available",
+      schemaVersion: "pccx.diagnosticsHandoff.v0",
+      diagnosticCount: 5,
+      blockedCount: 2,
+      readOnly: true,
     },
   });
 }
@@ -606,6 +640,49 @@ function testNoActiveEditorContextShape() {
   assert.deepEqual(bundle.snippets, []);
   assert.equal(bundle.recentCommand, null);
   assert.equal(bundle.configuration.mode, "unknown");
+  assert.equal(bundle.diagnosticsHandoff.status, "notAvailable");
+  assert.equal(bundle.diagnosticsHandoff.summaryAvailable, false);
+  assert.equal(bundle.diagnosticsHandoff.safety.readOnly, true);
+  assert.equal(bundle.diagnosticsHandoff.safety.launcherExecution, false);
+}
+
+function testDiagnosticsHandoffStatusSurfaceInputIsAccepted() {
+  const surface = createDiagnosticsHandoffStatusSurface(
+    cloneDefaultDiagnosticsHandoffConsumerSummary(),
+  );
+  const bundle = buildContextBundle({ diagnosticsHandoffStatus: surface }, {});
+
+  assert.equal(bundle.diagnosticsHandoff.status, "available");
+  assert.equal(bundle.diagnosticsHandoff.source.adapterOutput, true);
+  assert.equal(bundle.diagnosticsHandoff.source.rawHandoffParsedByUi, false);
+  assert.equal(bundle.diagnosticsHandoff.diagnostics.count, 5);
+  assert.deepEqual(summarizeContextBundle(bundle).diagnosticsHandoff, {
+    status: "available",
+    schemaVersion: "pccx.diagnosticsHandoff.v0",
+    diagnosticCount: 5,
+    blockedCount: 2,
+    readOnly: true,
+  });
+}
+
+function testInvalidDiagnosticsHandoffDataIsSafeAndBounded() {
+  const unsafeSurface = createDiagnosticsHandoffStatusSurface(
+    cloneDefaultDiagnosticsHandoffConsumerSummary(),
+  );
+  unsafeSurface.safety.pccxLabExecution = true;
+  unsafeSurface.limitations = ["/home/user/private.log"];
+  const bundle = buildContextBundle(
+    { diagnosticsHandoffStatus: unsafeSurface },
+    { limits: { maxTextCharacters: 80 } },
+  );
+  const serialized = JSON.stringify(bundle.diagnosticsHandoff);
+
+  assert.equal(bundle.diagnosticsHandoff.status, "invalid");
+  assert.equal(bundle.diagnosticsHandoff.summaryAvailable, false);
+  assert.equal(bundle.diagnosticsHandoff.source.rawHandoffParsedByUi, false);
+  assert.equal(bundle.diagnosticsHandoff.safety.pccxLabExecution, false);
+  assert.doesNotMatch(serialized, /\/home\/user/);
+  assert.match(bundle.diagnosticsHandoff.reason, /data-only and read-only/);
 }
 
 testStableBoundedShape();
@@ -618,5 +695,7 @@ testValidationHistoryIsSummaryOnlyAndBounded();
 testNoSecretValuesOrSecretLikeKeys();
 testNoAbsoluteHomePathLeakage();
 testNoActiveEditorContextShape();
+testDiagnosticsHandoffStatusSurfaceInputIsAccepted();
+testInvalidDiagnosticsHandoffDataIsSafeAndBounded();
 
 console.log("vscode context bundle tests ok");

--- a/editors/vscode-prototype/test/extension-entrypoint.test.mjs
+++ b/editors/vscode-prototype/test/extension-entrypoint.test.mjs
@@ -919,6 +919,20 @@ async function testAIContextBundleCommandUsesActiveEditorSelectionAndDiagnostics
   assert.equal(result.contextBundle.symbols.declarations.length, 1);
   assert.equal(result.contextBundle.symbols.declarations[0].path, "rtl/top.sv");
   assert.equal(result.contextBundle.recentCommand.commandId, "pccxSystemVerilog.publishCheckedExampleDiagnostics");
+  assert.equal(result.contextBundle.diagnosticsHandoff.status, "available");
+  assert.equal(result.contextBundle.diagnosticsHandoff.summaryAvailable, true);
+  assert.equal(result.contextBundle.diagnosticsHandoff.source.adapterOutput, true);
+  assert.equal(result.contextBundle.diagnosticsHandoff.source.rawHandoffParsedByUi, false);
+  assert.equal(result.contextBundle.diagnosticsHandoff.diagnostics.count, 5);
+  assert.equal(result.contextBundle.diagnosticsHandoff.safety.readOnly, true);
+  assert.equal(result.contextBundle.diagnosticsHandoff.safety.launcherExecution, false);
+  assert.equal(result.contextBundle.diagnosticsHandoff.safety.pccxLabExecution, false);
+  assert.equal(result.contextBundle.diagnosticsHandoff.safety.pccxLabValidatorInvocation, false);
+  assert.equal(result.contextBundle.diagnosticsHandoff.safety.shellExecution, false);
+  assert.equal(result.contextBundle.diagnosticsHandoff.safety.providerCalls, false);
+  assert.equal(result.contextBundle.diagnosticsHandoff.safety.runtimeCalls, false);
+  assert.equal(result.contextSummary.diagnosticsHandoff.status, "available");
+  assert.equal(result.contextSummary.diagnosticsHandoff.diagnosticCount, 5);
   assert.doesNotMatch(JSON.stringify(result.contextBundle), /\/repo/);
 }
 

--- a/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
+++ b/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
@@ -354,6 +354,19 @@ async function run() {
     contextResult.contextBundle.recentCommand.commandId,
     "pccxSystemVerilog.showLiveWorkspaceNavigation",
   );
+  assert.equal(contextResult.contextBundle.diagnosticsHandoff.status, "available");
+  assert.equal(contextResult.contextBundle.diagnosticsHandoff.summaryAvailable, true);
+  assert.equal(contextResult.contextBundle.diagnosticsHandoff.source.adapterOutput, true);
+  assert.equal(contextResult.contextBundle.diagnosticsHandoff.source.rawHandoffParsedByUi, false);
+  assert.equal(contextResult.contextBundle.diagnosticsHandoff.safety.launcherExecution, false);
+  assert.equal(contextResult.contextBundle.diagnosticsHandoff.safety.pccxLabExecution, false);
+  assert.equal(contextResult.contextBundle.diagnosticsHandoff.safety.pccxLabValidatorInvocation, false);
+  assert.equal(contextResult.contextBundle.diagnosticsHandoff.safety.shellExecution, false);
+  assert.equal(contextResult.contextBundle.diagnosticsHandoff.safety.providerCalls, false);
+  assert.equal(contextResult.contextBundle.diagnosticsHandoff.safety.runtimeCalls, false);
+  assert.equal(contextResult.contextBundle.diagnosticsHandoff.safety.mcpCalls, false);
+  assert.equal(contextResult.contextBundle.diagnosticsHandoff.safety.lspImplemented, false);
+  assert.equal(contextResult.contextSummary.diagnosticsHandoff.diagnosticCount, 5);
   assert.doesNotMatch(JSON.stringify(contextResult.contextBundle), /\/home\//);
   assert.ok(contextResult.contextBundle.excludedPathPatterns.includes("node_modules/**"));
   assert.doesNotMatch(JSON.stringify(contextResult.contextBundle), /AGENTS\.md/);
@@ -473,6 +486,8 @@ async function run() {
       summaryOnly: true,
       fullLogsExcluded: true,
     });
+    assert.equal(postValidationContext.contextBundle.diagnosticsHandoff.summaryAvailable, true);
+    assert.equal(postValidationContext.contextBundle.diagnosticsHandoff.safety.readOnly, true);
 
     const cacheStatus = await vscode.commands.executeCommand(
       "pccxSystemVerilog.showValidationCacheStatus",


### PR DESCRIPTION
## Summary
- Adds a bounded `diagnosticsHandoff` section to the local AI/context bundle output.
- Reuses the existing diagnostics handoff status surface / adapter summary boundary instead of parsing raw handoff JSON in context code.
- Extends context bundle audit and Extension Host smoke coverage for the read-only handoff context section.

## Scope
- Data-only context bundle integration for diagnostics handoff summary data.
- Safe missing/invalid handoff handling as local unavailable/invalid context.
- Tests for deterministic summary data, safety flags, no backend execution, and no private path leakage.
- Docs describing the section as experimental read-only context.

## Non-goals
- No pccx-llm-launcher execution.
- No pccx-lab execution or pccx-lab validator invocation.
- No shell execution path in diagnostics handoff context code.
- No provider, model runtime, KV260 runtime, MCP, LSP, telemetry, upload, writeback, release, tag, packaging, or marketplace flow.
- No API or ABI stability commitment.

## Validation
- `git diff --check`
- `python3 -m pytest -q` — 164 passed
- `bash scripts/vscode-adapter-smoke.sh`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh` — ran because dependencies and VS Code 1.90.2 test runtime were already present locally
- Targeted Node tests:
  - `node editors/vscode-prototype/test/context-bundle.test.mjs`
  - `node editors/vscode-prototype/test/ai-assistant-boundary.test.mjs`
  - `node editors/vscode-prototype/test/context-bundle-audit.test.mjs`
  - `node editors/vscode-prototype/test/extension-entrypoint.test.mjs`
  - `node editors/vscode-prototype/test/extension-host-readiness.test.mjs`
  - `node editors/vscode-prototype/test/static-boundary.test.mjs`
- `node -e "const p=require('./editors/vscode-prototype/package.json'); console.log(JSON.stringify(p.scripts||{}))"` — `{}`, so npm test/build scripts are not present

## Safety notes
- Context bundle code consumes the existing status surface / adapter summary output as data.
- Missing or invalid handoff input becomes bounded unavailable/invalid context and does not trigger any command.
- No launcher, pccx-lab, pccx-lab validator, shell, provider, network, runtime, hardware, MCP, LSP, telemetry, upload, or writeback path was added.
- No release or tag was created.

## Related
- Follows `pccxai/systemverilog-ide#52`
- Follows `pccxai/systemverilog-ide#53`
- Follows `pccxai/pccx-llm-launcher#19`
- Follows `pccxai/pccx-lab#30`
