### PR TITLE
Add diagnostics handoff context to validation proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ carry the same bounded summary as read-only context. It does not execute
 the launcher, execute pccx-lab, invoke the pccx-lab validator, implement
 MCP or LSP, call providers, or touch hardware.
 
+Validation command proposals can also include a small preflight context
+derived from that normalized context-bundle `diagnosticsHandoff` section.
+The proposal data reports available, unavailable, or invalid handoff
+status plus bounded notes for local UI display. It does not parse raw
+handoff JSON in the proposal layer and does not add any execution path.
+
 ## Later track (deferred)
 
 - Local coding-assistant mode can propose interactions with `pccx-lab`

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -112,6 +112,14 @@ diagnostic counts, descriptor references, transport kinds, and read-only
 safety flags. Missing or invalid handoff data remains local unavailable
 or invalid context and does not trigger execution.
 
+Validation command proposals may reuse only that normalized context
+bundle section as proposal preflight data. The proposal output can show
+that the handoff summary is available, unavailable, or invalid, and it
+keeps issue/preflight notes bounded for local UI or context display. The
+proposal layer does not parse raw handoff JSON and does not add launcher,
+pccx-lab, validator, shell, provider, runtime, MCP, LSP, marketplace,
+telemetry, upload, or write-back flows.
+
 This path is data-only. It does not execute `pccx-llm-launcher`, does not
 execute `pccx-lab`, does not invoke the pccx-lab validator command, does
 not spawn shell commands, does not implement MCP or LSP, does not call

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -380,8 +380,13 @@ providers.
 `pccxSystemVerilog.proposeValidationCommand` returns allowlisted
 validation command proposals as JSON data.  The proposal includes
 allowlisted proposal IDs, argument-array templates, reasons, risk levels, and
-explicit user approval requirements.  It does not spawn a process, call
-pccx-lab, call an AI provider, write files, or run git operations.
+explicit user approval requirements.  It can also include experimental
+local diagnostics handoff preflight context derived from the normalized
+context-bundle `diagnosticsHandoff` section.  That context reports
+available, unavailable, or invalid handoff status and bounded notes for UI
+display.  It does not parse raw handoff JSON in the proposal layer, spawn
+a process, call pccx-lab, call an AI provider, write files, or run git
+operations.
 
 `pccxSystemVerilog.runApprovedValidationCommand` is a separate approved
 validation runner boundary.  It is disabled by default; execution requires

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -178,8 +178,11 @@ start a backend command.
 `pccxSystemVerilog.proposeValidationCommand` currently proposes only
 allowlisted templates, including the VS Code adapter smoke, editor bridge
 smoke, example drift check, pytest baseline, and opt-in Extension Host
-smoke.  The command returns JSON data with reasons, risk levels, and a
-required user approval marker; it does not execute the command.
+smoke.  The command returns JSON data with reasons, risk levels, a
+required user approval marker, and optional diagnostics handoff preflight
+context from the normalized context bundle section.  It reports handoff
+context as available, unavailable, or invalid with bounded notes; it does
+not parse raw handoff JSON in the proposal layer or execute the command.
 
 `pccxSystemVerilog.runApprovedValidationCommand` is a separate approved
 validation runner.  It is disabled unless

--- a/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
+++ b/editors/vscode-prototype/docs/LIVE_WORKSPACE_AND_AI_BOUNDARY.md
@@ -155,9 +155,13 @@ SystemVerilog resolution.
 Validation command proposals use allowlisted templates such as the VS Code
 adapter smoke, editor bridge smoke, example drift check, pytest baseline,
 and the opt-in Extension Host smoke.  They include reasons, risk levels,
-and a required user approval marker.  The command returns JSON data only:
-it does not spawn a process, call pccx-lab, call an AI provider, write
-files, or run git commands.
+and a required user approval marker.  They may include diagnostics
+handoff preflight context from the normalized context-bundle
+`diagnosticsHandoff` section.  That proposal context is summary-only and
+bounded: it reports available, unavailable, or invalid handoff status plus
+short preflight/issue notes.  The command returns JSON data only: it does
+not parse raw handoff JSON in the proposal layer, spawn a process, call
+pccx-lab, call an AI provider, write files, or run git commands.
 
 The approved validation runner re-resolves proposal IDs through an
 internal allowlist.  Runnable initial IDs are `vscodeAdapterSmoke`,

--- a/editors/vscode-prototype/docs/diagnostics-handoff-consumer.md
+++ b/editors/vscode-prototype/docs/diagnostics-handoff-consumer.md
@@ -46,6 +46,13 @@ descriptor references, transport kinds, and read-only safety flags.
 Missing or invalid handoff data is represented as unavailable/invalid
 context instead of executing a backend command.
 
+`pccxSystemVerilog.proposeValidationCommand` can reuse the normalized
+context-bundle `diagnosticsHandoff` section as proposal preflight data.
+It reports available, unavailable, or invalid handoff status and bounded
+notes for local proposal UI. The proposal code does not parse raw handoff
+JSON and does not execute launcher, pccx-lab, validator, shell, provider,
+runtime, MCP, LSP, marketplace, telemetry, upload, or write-back flows.
+
 ## What It Does Not Do
 
 This boundary does not:

--- a/editors/vscode-prototype/src/extension.mjs
+++ b/editors/vscode-prototype/src/extension.mjs
@@ -347,6 +347,7 @@ function appendCommandOutput(outputChannel, commandId, result) {
       kind: result.kind,
       proposalCount: result.proposals?.length ?? 0,
       execution: result.execution,
+      diagnosticsHandoff: result.diagnosticsHandoffContext?.status ?? "unavailable",
     }, null, 2));
   }
   if (result.kind === "approved-validation-result") {
@@ -774,10 +775,17 @@ export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
     if (commandId === VALIDATION_PROPOSAL_COMMAND) {
       let result;
       try {
+        const request = createAssistantRequest(rawConfig, {
+          diagnosticsHandoffStatus: diagnosticsHandoffStatusFromRuntime(runtime),
+        });
         result = {
           ok: true,
           commandId,
-          ...createValidationCommandProposal(input),
+          ...createValidationCommandProposal({
+            contextBundle: {
+              diagnosticsHandoff: request.contextBundle.diagnosticsHandoff,
+            },
+          }),
         };
       } catch (error) {
         result = { ok: false, commandId, error: error.message };

--- a/editors/vscode-prototype/src/validation-proposals.mjs
+++ b/editors/vscode-prototype/src/validation-proposals.mjs
@@ -1,4 +1,8 @@
 export const VALIDATION_PROPOSAL_VERSION = "pccx.validationCommandProposal.v0";
+export const VALIDATION_PROPOSAL_DIAGNOSTICS_HANDOFF_CONTEXT_VERSION =
+  "pccx.validationProposalDiagnosticsHandoffContext.v0";
+export const VALIDATION_PROPOSAL_PREFLIGHT_VERSION =
+  "pccx.validationProposalPreflight.v0";
 
 export const VALIDATION_PROPOSAL_CATEGORIES = Object.freeze([
   "vscodeAdapterSmoke",
@@ -96,6 +100,223 @@ const PROPOSALS = Object.freeze([
   }),
 ]);
 
+const DIAGNOSTICS_HANDOFF_SOURCE = "contextBundle.diagnosticsHandoff";
+const MAX_PREFLIGHT_NOTES = 4;
+const MAX_ISSUE_NOTES = 3;
+const MAX_NOTE_CHARACTERS = 240;
+const MAX_SUMMARY_CHARACTERS = 320;
+const HANDOFF_SEVERITIES = Object.freeze(["info", "warning", "blocked", "error"]);
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]/i;
+const HOME_PATH_PATTERN = /(?:\/home\/[^/\s]+|\/Users\/[^/\s]+|[A-Za-z]:\\Users\\)/g;
+
+function scrubLine(value, maxCharacters = MAX_NOTE_CHARACTERS) {
+  if (typeof value !== "string" || maxCharacters <= 0) {
+    return "";
+  }
+  const cleaned = value
+    .replace(/\0/g, "")
+    .replace(/[\r\n]+/g, " ")
+    .replace(HOME_PATH_PATTERN, "[home]")
+    .trim();
+  return (SECRET_ASSIGNMENT_PATTERN.test(cleaned) ? "[redacted]" : cleaned)
+    .slice(0, maxCharacters)
+    .trim();
+}
+
+function boundedNotes(values, limit) {
+  const seen = new Set();
+  const notes = [];
+  for (const value of values) {
+    const note = scrubLine(value);
+    if (note.length === 0 || seen.has(note)) {
+      continue;
+    }
+    seen.add(note);
+    notes.push(note);
+    if (notes.length >= limit) {
+      break;
+    }
+  }
+  return notes;
+}
+
+function count(value) {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function severityCounts(context) {
+  return Object.fromEntries(HANDOFF_SEVERITIES.map((severity) => [
+    severity,
+    count(context?.diagnostics?.bySeverity?.[severity]),
+  ]));
+}
+
+function diagnosticsHandoffSafetyBase() {
+  return {
+    dataOnly: true,
+    readOnly: true,
+    proposalOnly: true,
+    launcherExecution: false,
+    pccxLabExecution: false,
+    pccxLabValidatorInvocation: false,
+    shellExecution: false,
+    providerCalls: false,
+    networkCalls: false,
+    runtimeCalls: false,
+    mcpCalls: false,
+    lspImplemented: false,
+    marketplaceFlow: false,
+    telemetry: false,
+    automaticUpload: false,
+    writeBack: false,
+  };
+}
+
+function isSafeDiagnosticsHandoffContext(context) {
+  const safety = context?.safety ?? {};
+  return context?.kind === "diagnostics-handoff-context" &&
+    context?.source?.rawHandoffParsedByUi !== true &&
+    safety.dataOnly === true &&
+    safety.readOnly === true &&
+    safety.launcherExecution !== true &&
+    safety.pccxLabExecution !== true &&
+    safety.pccxLabValidatorInvocation !== true &&
+    safety.shellExecution !== true &&
+    safety.providerCalls !== true &&
+    safety.networkCalls !== true &&
+    safety.runtimeCalls !== true &&
+    safety.mcpCalls !== true &&
+    safety.lspImplemented !== true &&
+    safety.marketplaceFlow !== true &&
+    safety.telemetry !== true &&
+    safety.automaticUpload !== true &&
+    safety.writeBack !== true;
+}
+
+function diagnosticsHandoffContextFromInput(input = {}) {
+  return input?.contextBundle?.diagnosticsHandoff ??
+    input?.diagnosticsHandoffContext ??
+    null;
+}
+
+function unavailableDiagnosticsHandoffContext(reason = "") {
+  return {
+    version: VALIDATION_PROPOSAL_DIAGNOSTICS_HANDOFF_CONTEXT_VERSION,
+    source: DIAGNOSTICS_HANDOFF_SOURCE,
+    status: "unavailable",
+    sourceStatus: "notAvailable",
+    summaryAvailable: false,
+    summary: "Diagnostics handoff context unavailable in the local context bundle.",
+    diagnostics: {
+      count: 0,
+      bySeverity: Object.fromEntries(HANDOFF_SEVERITIES.map((severity) => [severity, 0])),
+    },
+    preflightNotes: boundedNotes([
+      "No diagnostics handoff summary is available from the local context bundle.",
+      "Validation proposals remain allowlisted, proposal-only data.",
+      reason,
+    ], MAX_PREFLIGHT_NOTES),
+    issueNotes: boundedNotes([reason], MAX_ISSUE_NOTES),
+    safety: diagnosticsHandoffSafetyBase(),
+  };
+}
+
+function invalidDiagnosticsHandoffContext(context, reason = "") {
+  return {
+    version: VALIDATION_PROPOSAL_DIAGNOSTICS_HANDOFF_CONTEXT_VERSION,
+    source: DIAGNOSTICS_HANDOFF_SOURCE,
+    status: "invalid",
+    sourceStatus: scrubLine(context?.status ?? "invalid", 80) || "invalid",
+    summaryAvailable: false,
+    summary: "Diagnostics handoff context invalid or unsafe in the local context bundle.",
+    diagnostics: {
+      count: 0,
+      bySeverity: Object.fromEntries(HANDOFF_SEVERITIES.map((severity) => [severity, 0])),
+    },
+    preflightNotes: boundedNotes([
+      "Diagnostics handoff context was rejected before proposal display.",
+      "Validation proposals remain allowlisted, proposal-only data.",
+      "Invalid handoff context does not trigger launcher, pccx-lab, validator, shell, provider, runtime, MCP, LSP, marketplace, telemetry, upload, or write-back flows.",
+    ], MAX_PREFLIGHT_NOTES),
+    issueNotes: boundedNotes([
+      reason,
+      context?.reason,
+      "Diagnostics handoff context must stay data-only and read-only.",
+    ], MAX_ISSUE_NOTES),
+    safety: diagnosticsHandoffSafetyBase(),
+  };
+}
+
+function availableDiagnosticsHandoffContext(context) {
+  const bySeverity = severityCounts(context);
+  const diagnosticCount = count(context?.diagnostics?.count);
+  const schemaVersion = scrubLine(context?.handoff?.schemaVersion ?? "", 120);
+  const summary = scrubLine(
+    `Diagnostics handoff context available: ${diagnosticCount} diagnostic item(s), ` +
+      `${bySeverity.blocked} blocked, ${bySeverity.warning} warning, ${bySeverity.error} error.`,
+    MAX_SUMMARY_CHARACTERS,
+  );
+  const limitationNotes = Array.isArray(context?.limitations) ? context.limitations : [];
+
+  return {
+    version: VALIDATION_PROPOSAL_DIAGNOSTICS_HANDOFF_CONTEXT_VERSION,
+    source: DIAGNOSTICS_HANDOFF_SOURCE,
+    status: "available",
+    sourceStatus: scrubLine(context?.status ?? "available", 80) || "available",
+    summaryAvailable: true,
+    schemaVersion,
+    summary,
+    diagnostics: {
+      count: diagnosticCount,
+      bySeverity,
+    },
+    preflightNotes: boundedNotes([
+      "Diagnostics handoff summary is available from the local context bundle.",
+      schemaVersion ? `Schema ${schemaVersion}; read-only summary data only.` : "",
+      "Validation proposals remain proposal-only until an approved validation runner accepts an allowlisted proposal ID.",
+      ...limitationNotes,
+    ], MAX_PREFLIGHT_NOTES),
+    issueNotes: boundedNotes([
+      bySeverity.blocked > 0
+        ? `${bySeverity.blocked} blocked handoff diagnostic(s) are present in the summary.`
+        : "",
+      bySeverity.warning > 0
+        ? `${bySeverity.warning} warning handoff diagnostic(s) are present in the summary.`
+        : "",
+      bySeverity.error > 0
+        ? `${bySeverity.error} error handoff diagnostic(s) are present in the summary.`
+        : "",
+    ], MAX_ISSUE_NOTES),
+    safety: diagnosticsHandoffSafetyBase(),
+  };
+}
+
+export function createValidationDiagnosticsHandoffContext(input = {}) {
+  const context = diagnosticsHandoffContextFromInput(input);
+  if (!context) {
+    return unavailableDiagnosticsHandoffContext();
+  }
+  if (context.kind !== "diagnostics-handoff-context") {
+    return unavailableDiagnosticsHandoffContext(
+      "Validation proposals accept only the normalized context bundle diagnosticsHandoff section.",
+    );
+  }
+  if (!isSafeDiagnosticsHandoffContext(context)) {
+    return invalidDiagnosticsHandoffContext(
+      context,
+      "Diagnostics handoff context failed data-only/read-only safety checks.",
+    );
+  }
+  if (context.status === "invalid") {
+    return invalidDiagnosticsHandoffContext(context, context.reason);
+  }
+  if (context.status === "available" && context.summaryAvailable === true) {
+    return availableDiagnosticsHandoffContext(context);
+  }
+  return unavailableDiagnosticsHandoffContext(context.reason);
+}
+
 function cloneCommand(command) {
   if (!command) {
     return null;
@@ -107,7 +328,29 @@ function cloneCommand(command) {
   };
 }
 
-function cloneProposal(proposal) {
+function proposalStatus(proposal, diagnosticsHandoffContext) {
+  return {
+    proposalOnly: true,
+    commandAvailable: Boolean(proposal.command),
+    placeholder: proposal.placeholder === true,
+    diagnosticsHandoff: diagnosticsHandoffContext.status,
+  };
+}
+
+function proposalPreflight(diagnosticsHandoffContext) {
+  return {
+    version: VALIDATION_PROPOSAL_PREFLIGHT_VERSION,
+    diagnosticsHandoff: {
+      source: diagnosticsHandoffContext.source,
+      status: diagnosticsHandoffContext.status,
+      summaryAvailable: diagnosticsHandoffContext.summaryAvailable,
+      summary: diagnosticsHandoffContext.summary,
+      issueNoteCount: diagnosticsHandoffContext.issueNotes.length,
+    },
+  };
+}
+
+function cloneProposal(proposal, diagnosticsHandoffContext) {
   return {
     id: proposal.id,
     category: proposal.category,
@@ -118,24 +361,31 @@ function cloneProposal(proposal) {
     riskLevel: proposal.riskLevel,
     runnerPolicy: proposal.runnerPolicy ?? "allowlisted",
     runnerBlockedReason: proposal.runnerBlockedReason ?? "",
+    status: proposalStatus(proposal, diagnosticsHandoffContext),
+    preflight: proposalPreflight(diagnosticsHandoffContext),
+    reasonContext: {
+      diagnosticsHandoff: diagnosticsHandoffContext.summary,
+    },
     requiresUserApproval: true,
     executes: false,
   };
 }
 
-export function listValidationCommandProposals() {
-  return PROPOSALS.map(cloneProposal);
+export function listValidationCommandProposals(input = {}) {
+  const diagnosticsHandoffContext = createValidationDiagnosticsHandoffContext(input);
+  return PROPOSALS.map((proposal) => cloneProposal(proposal, diagnosticsHandoffContext));
 }
 
-export function findValidationCommandProposalById(proposalId) {
+export function findValidationCommandProposalById(proposalId, input = {}) {
   if (typeof proposalId !== "string" || proposalId.trim().length === 0) {
     return null;
   }
   const proposal = PROPOSALS.find((item) => item.id === proposalId);
-  return proposal ? cloneProposal(proposal) : null;
+  return proposal ? cloneProposal(proposal, createValidationDiagnosticsHandoffContext(input)) : null;
 }
 
-export function createValidationCommandProposal(_input = {}) {
+export function createValidationCommandProposal(input = {}) {
+  const diagnosticsHandoffContext = createValidationDiagnosticsHandoffContext(input);
   return {
     version: VALIDATION_PROPOSAL_VERSION,
     kind: "validation-command-proposal",
@@ -145,8 +395,13 @@ export function createValidationCommandProposal(_input = {}) {
     requiresUserApproval: true,
     providerCalls: false,
     runtimeCalls: false,
+    diagnosticsHandoffContext,
+    safety: {
+      ...diagnosticsHandoffSafetyBase(),
+      proposalOnly: true,
+    },
     commandSource: "allowlistedTemplates",
-    proposals: listValidationCommandProposals(),
+    proposals: PROPOSALS.map((proposal) => cloneProposal(proposal, diagnosticsHandoffContext)),
     disallowedActions: [
       "executeCommand",
       "spawnProcess",

--- a/editors/vscode-prototype/test/extension-entrypoint.test.mjs
+++ b/editors/vscode-prototype/test/extension-entrypoint.test.mjs
@@ -948,8 +948,18 @@ async function testValidationProposalCommandReturnsDataOnly() {
   assert.equal(result.executes, false);
   assert.equal(result.providerCalls, false);
   assert.equal(result.runtimeCalls, false);
+  assert.equal(result.diagnosticsHandoffContext.status, "available");
+  assert.equal(result.diagnosticsHandoffContext.summaryAvailable, true);
+  assert.equal(result.diagnosticsHandoffContext.diagnostics.count, 5);
+  assert.equal(result.diagnosticsHandoffContext.safety.launcherExecution, false);
+  assert.equal(result.diagnosticsHandoffContext.safety.pccxLabExecution, false);
+  assert.equal(result.diagnosticsHandoffContext.safety.pccxLabValidatorInvocation, false);
+  assert.equal(result.diagnosticsHandoffContext.safety.shellExecution, false);
   assert.ok(result.proposals.some((proposal) => (
     proposal.command?.argv?.join(" ") === "bash scripts/vscode-adapter-smoke.sh"
+  )));
+  assert.ok(result.proposals.every((proposal) => (
+    proposal.preflight.diagnosticsHandoff.status === "available"
   )));
   assert.doesNotMatch(JSON.stringify(result), /git push/);
 }

--- a/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
+++ b/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
@@ -382,6 +382,15 @@ async function run() {
   assert.equal(validationProposal.executes, false);
   assert.equal(validationProposal.providerCalls, false);
   assert.equal(validationProposal.runtimeCalls, false);
+  assert.equal(validationProposal.diagnosticsHandoffContext.status, "available");
+  assert.equal(validationProposal.diagnosticsHandoffContext.summaryAvailable, true);
+  assert.equal(validationProposal.diagnosticsHandoffContext.safety.launcherExecution, false);
+  assert.equal(validationProposal.diagnosticsHandoffContext.safety.pccxLabExecution, false);
+  assert.equal(
+    validationProposal.diagnosticsHandoffContext.safety.pccxLabValidatorInvocation,
+    false,
+  );
+  assert.equal(validationProposal.diagnosticsHandoffContext.safety.shellExecution, false);
   assert.ok(validationProposal.proposals.some((proposal) => (
     proposal.id === "vscodeAdapterSmoke"
   )));
@@ -390,6 +399,9 @@ async function run() {
   )));
   assert.ok(validationProposal.proposals.some((proposal) => (
     proposal.command?.env?.PCCX_RUN_EXTENSION_HOST_SMOKE === "1"
+  )));
+  assert.ok(validationProposal.proposals.every((proposal) => (
+    proposal.preflight.diagnosticsHandoff.status === "available"
   )));
 
   const patchPreview = await vscode.commands.executeCommand(

--- a/editors/vscode-prototype/test/validation-proposals.test.mjs
+++ b/editors/vscode-prototype/test/validation-proposals.test.mjs
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
 
 import {
+  VALIDATION_PROPOSAL_DIAGNOSTICS_HANDOFF_CONTEXT_VERSION,
   VALIDATION_PROPOSAL_CATEGORIES,
+  VALIDATION_PROPOSAL_PREFLIGHT_VERSION,
   VALIDATION_PROPOSAL_VERSION,
+  createValidationDiagnosticsHandoffContext,
   createValidationCommandProposal,
   findValidationCommandProposalById,
   listValidationCommandProposals,
@@ -11,8 +14,52 @@ import {
   PCCX_LAB_BACKEND_STATUS_VERSION,
   createPccxLabBackendStatus,
 } from "../src/pccx-lab-status.mjs";
+import {
+  buildContextBundle,
+} from "../src/context-bundle.mjs";
+import {
+  cloneDefaultDiagnosticsHandoffConsumerSummary,
+  createDiagnosticsHandoffStatusSurface,
+} from "../src/diagnostics-handoff-status-surface.mjs";
 
 const SHELL_CONTROL_PATTERN = /(?:&&|\|\||;|`|\$\(|>|<)/;
+const UNSUPPORTED_READINESS_PATTERN = new RegExp([
+  ["production", "-ready"],
+  ["marketplace", "-ready"],
+  ["stable", " API"],
+  ["stable", " ABI"],
+  ["MCP", " ready"],
+  ["AI provider", " ready"],
+  ["KV260 inference", " works"],
+  ["provider", " ready"],
+  ["runtime", " ready"],
+  ["LSP", " ready"],
+].map((parts) => parts.join("")).join("|"), "i");
+
+function assertBoundedDiagnosticsHandoffContext(context) {
+  assert.equal(context.version, VALIDATION_PROPOSAL_DIAGNOSTICS_HANDOFF_CONTEXT_VERSION);
+  assert.equal(context.source, "contextBundle.diagnosticsHandoff");
+  assert.ok(["available", "unavailable", "invalid"].includes(context.status));
+  assert.ok(context.preflightNotes.length <= 4);
+  assert.ok(context.issueNotes.length <= 3);
+  assert.ok(context.preflightNotes.every((note) => note.length <= 240));
+  assert.ok(context.issueNotes.every((note) => note.length <= 240));
+  assert.equal(context.safety.dataOnly, true);
+  assert.equal(context.safety.readOnly, true);
+  assert.equal(context.safety.proposalOnly, true);
+  assert.equal(context.safety.launcherExecution, false);
+  assert.equal(context.safety.pccxLabExecution, false);
+  assert.equal(context.safety.pccxLabValidatorInvocation, false);
+  assert.equal(context.safety.shellExecution, false);
+  assert.equal(context.safety.providerCalls, false);
+  assert.equal(context.safety.runtimeCalls, false);
+  assert.equal(context.safety.mcpCalls, false);
+  assert.equal(context.safety.lspImplemented, false);
+  assert.equal(context.safety.marketplaceFlow, false);
+  assert.equal(context.safety.telemetry, false);
+  assert.equal(context.safety.automaticUpload, false);
+  assert.equal(context.safety.writeBack, false);
+}
 
 function testValidationProposalIsDataOnly() {
   const proposal = createValidationCommandProposal({
@@ -27,6 +74,14 @@ function testValidationProposalIsDataOnly() {
   assert.equal(proposal.requiresUserApproval, true);
   assert.equal(proposal.providerCalls, false);
   assert.equal(proposal.runtimeCalls, false);
+  assert.equal(proposal.diagnosticsHandoffContext.status, "unavailable");
+  assertBoundedDiagnosticsHandoffContext(proposal.diagnosticsHandoffContext);
+  assert.equal(proposal.safety.launcherExecution, false);
+  assert.equal(proposal.safety.pccxLabExecution, false);
+  assert.equal(proposal.safety.pccxLabValidatorInvocation, false);
+  assert.equal(proposal.safety.shellExecution, false);
+  assert.equal(proposal.safety.providerCalls, false);
+  assert.equal(proposal.safety.runtimeCalls, false);
   assert.deepEqual(
     proposal.proposals.map((item) => item.category),
     VALIDATION_PROPOSAL_CATEGORIES,
@@ -45,6 +100,13 @@ function testValidationProposalIsDataOnly() {
   );
   assert.ok(proposal.proposals.every((item) => item.requiresUserApproval === true));
   assert.ok(proposal.proposals.every((item) => item.executes === false));
+  assert.ok(proposal.proposals.every((item) => item.status.proposalOnly === true));
+  assert.ok(proposal.proposals.every((item) => (
+    item.status.diagnosticsHandoff === "unavailable"
+  )));
+  assert.ok(proposal.proposals.every((item) => (
+    item.preflight.version === VALIDATION_PROPOSAL_PREFLIGHT_VERSION
+  )));
   assert.ok(proposal.disallowedActions.includes("commit"));
   assert.ok(proposal.disallowedActions.includes("release"));
   assert.doesNotMatch(JSON.stringify(proposal), /git push|rm -rf/);
@@ -70,6 +132,94 @@ function testValidationCommandsAreAllowlistedArgumentArrays() {
   assert.doesNotMatch(flattened.join("\n"), /\b(?:git|gh)\s+(?:push|commit|merge|release|tag)\b/i);
 }
 
+function testDiagnosticsHandoffAvailableContextImprovesProposalPreflight() {
+  const contextBundle = buildContextBundle({
+    diagnosticsHandoffSummary: cloneDefaultDiagnosticsHandoffConsumerSummary(),
+  });
+  const first = createValidationCommandProposal({ contextBundle });
+  const second = createValidationCommandProposal({ contextBundle });
+  const context = first.diagnosticsHandoffContext;
+  const serialized = JSON.stringify(first);
+
+  assert.deepEqual(first, second);
+  assertBoundedDiagnosticsHandoffContext(context);
+  assert.equal(context.status, "available");
+  assert.equal(context.sourceStatus, "available");
+  assert.equal(context.summaryAvailable, true);
+  assert.equal(context.schemaVersion, "pccx.diagnosticsHandoff.v0");
+  assert.equal(context.diagnostics.count, 5);
+  assert.equal(context.diagnostics.bySeverity.blocked, 2);
+  assert.match(context.summary, /5 diagnostic item\(s\), 2 blocked, 1 warning, 0 error/);
+  assert.ok(context.preflightNotes.some((note) => /local context bundle/.test(note)));
+  assert.ok(context.issueNotes.some((note) => /2 blocked/.test(note)));
+  assert.ok(first.proposals.every((proposal) => (
+    proposal.status.diagnosticsHandoff === "available" &&
+    proposal.preflight.diagnosticsHandoff.status === "available" &&
+    proposal.preflight.diagnosticsHandoff.summary === context.summary &&
+    proposal.reasonContext.diagnosticsHandoff === context.summary
+  )));
+  assert.doesNotMatch(serialized, UNSUPPORTED_READINESS_PATTERN);
+  assert.doesNotMatch(serialized, /pccx-lab diagnostics-handoff validate/i);
+  assert.doesNotMatch(serialized, /pccx-llm-launcher\s+(?:run|status|launch|diagnostics)/i);
+  assert.doesNotMatch(serialized, /launcher_diagnostics_handoff_gemma3n_e4b_kv260_placeholder/);
+}
+
+function testDiagnosticsHandoffUnavailableContextIsExplicit() {
+  const contextBundle = buildContextBundle({});
+  const proposal = createValidationCommandProposal({ contextBundle });
+  const context = proposal.diagnosticsHandoffContext;
+
+  assertBoundedDiagnosticsHandoffContext(context);
+  assert.equal(context.status, "unavailable");
+  assert.equal(context.sourceStatus, "notAvailable");
+  assert.equal(context.summaryAvailable, false);
+  assert.match(context.summary, /unavailable/);
+  assert.ok(context.preflightNotes.some((note) => /No diagnostics handoff summary/.test(note)));
+  assert.ok(proposal.proposals.every((item) => (
+    item.preflight.diagnosticsHandoff.status === "unavailable"
+  )));
+}
+
+function testDiagnosticsHandoffInvalidContextIsExplicitAndSafe() {
+  const unsafeSurface = createDiagnosticsHandoffStatusSurface(
+    cloneDefaultDiagnosticsHandoffConsumerSummary(),
+  );
+  unsafeSurface.safety.pccxLabExecution = true;
+  unsafeSurface.limitations = ["/home/user/private.log"];
+  const contextBundle = buildContextBundle(
+    { diagnosticsHandoffStatus: unsafeSurface },
+    { limits: { maxTextCharacters: 80 } },
+  );
+  const proposal = createValidationCommandProposal({ contextBundle });
+  const context = proposal.diagnosticsHandoffContext;
+  const serialized = JSON.stringify(proposal);
+
+  assertBoundedDiagnosticsHandoffContext(context);
+  assert.equal(context.status, "invalid");
+  assert.equal(context.summaryAvailable, false);
+  assert.match(context.summary, /invalid or unsafe/);
+  assert.ok(context.issueNotes.some((note) => /data-only/.test(note)));
+  assert.ok(proposal.proposals.every((item) => (
+    item.status.diagnosticsHandoff === "invalid" &&
+    item.preflight.diagnosticsHandoff.status === "invalid"
+  )));
+  assert.doesNotMatch(serialized, /\/home\/user/);
+  assert.equal(proposal.safety.pccxLabExecution, false);
+}
+
+function testRawHandoffJsonIsNotParsedByValidationProposalCode() {
+  const proposal = createValidationCommandProposal({
+    diagnosticsHandoff: {
+      schemaVersion: "pccx.diagnosticsHandoff.v0",
+      handoffId: "raw_handoff_should_not_flow",
+      diagnostics: [{ severity: "blocked" }],
+    },
+  });
+
+  assert.equal(proposal.diagnosticsHandoffContext.status, "unavailable");
+  assert.doesNotMatch(JSON.stringify(proposal), /raw_handoff_should_not_flow/);
+}
+
 function testValidationProposalsCanBeResolvedByStableId() {
   const proposals = listValidationCommandProposals();
   const adapter = findValidationCommandProposalById("vscodeAdapterSmoke");
@@ -78,7 +228,20 @@ function testValidationProposalsCanBeResolvedByStableId() {
   assert.equal(adapter.id, "vscodeAdapterSmoke");
   assert.equal(adapter.command.argv[0], "bash");
   assert.equal(adapter.command.argv[1], "scripts/vscode-adapter-smoke.sh");
+  assert.equal(adapter.preflight.diagnosticsHandoff.status, "unavailable");
   assert.equal(findValidationCommandProposalById("bash scripts/vscode-adapter-smoke.sh"), null);
+}
+
+function testValidationDiagnosticsHandoffContextRejectsNonBundleShape() {
+  const context = createValidationDiagnosticsHandoffContext({
+    diagnosticsHandoffContext: {
+      kind: "diagnostics-handoff-status-surface",
+      readiness: { status: "available" },
+    },
+  });
+
+  assert.equal(context.status, "unavailable");
+  assert.ok(context.issueNotes.some((note) => /normalized context bundle/.test(note)));
 }
 
 function testPccxLabStatusIsStatusOnly() {
@@ -103,7 +266,12 @@ function testPccxLabStatusIsStatusOnly() {
 
 testValidationProposalIsDataOnly();
 testValidationCommandsAreAllowlistedArgumentArrays();
+testDiagnosticsHandoffAvailableContextImprovesProposalPreflight();
+testDiagnosticsHandoffUnavailableContextIsExplicit();
+testDiagnosticsHandoffInvalidContextIsExplicitAndSafe();
+testRawHandoffJsonIsNotParsedByValidationProposalCode();
 testValidationProposalsCanBeResolvedByStableId();
+testValidationDiagnosticsHandoffContextRejectsNonBundleShape();
 testPccxLabStatusIsStatusOnly();
 
 console.log("vscode validation proposal and pccx-lab status tests ok");


### PR DESCRIPTION
## Scope
- Adds diagnostics handoff-aware context to validation command proposal output.
- Reuses the normalized `contextBundle.diagnosticsHandoff` section instead of parsing raw handoff JSON in proposal code.
- Represents handoff states as available, unavailable, or invalid with bounded preflight and issue notes.
- Adds proposal/status/preflight fields while keeping allowlisted command templates unchanged.
- Updates local docs to describe this as experimental local proposal context.

## Non-goals
- Does not execute `pccx-llm-launcher`.
- Does not execute `pccx-lab`.
- Does not invoke the pccx-lab diagnostics handoff validator.
- Does not add shell execution paths or new approved-runner commands.
- Does not add provider, runtime, KV260, MCP, LSP, marketplace, telemetry, upload, write-back, release, or tag flows.

## Validation
- `git diff --check`
- `python3 -m pytest -q` (164 passed)
- `bash scripts/vscode-adapter-smoke.sh`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `node editors/vscode-prototype/test/validation-proposals.test.mjs`
- `node editors/vscode-prototype/test/context-bundle.test.mjs`
- `node editors/vscode-prototype/test/diagnostics-handoff-consumer.test.mjs`
- `node editors/vscode-prototype/test/diagnostics-handoff-status-surface.test.mjs`
- `node editors/vscode-prototype/test/static-boundary.test.mjs`
- `PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh` (existing pinned VS Code 1.90.2 runtime)

## Safety Boundaries
- Proposal output remains proposal-only and data-only.
- Handoff context is sourced from the normalized context bundle section.
- Raw diagnostics handoff JSON is not parsed in validation proposal code.
- Available, unavailable, and invalid handoff states are deterministic and bounded.
- Safety flags remain false for launcher execution, pccx-lab execution, validator invocation, shell execution, provider calls, runtime calls, MCP, LSP, marketplace flow, telemetry, upload, and write-back.
