### PR TITLE
Add validation proposal preflight audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,11 @@ derived from that normalized context-bundle `diagnosticsHandoff` section.
 The proposal data reports available, unavailable, or invalid handoff
 status plus bounded notes for local UI display. It does not parse raw
 handoff JSON in the proposal layer and does not add any execution path.
+The prototype also has a validation proposal preflight audit command that
+checks a proposal ID and fixed command template before the approved runner
+handoff. That audit returns bounded JSON/text status only; it does not
+execute launcher, pccx-lab, validator, shell, provider, runtime, MCP, LSP,
+marketplace, telemetry, upload, or write-back flows.
 
 ## Later track (deferred)
 

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -148,6 +148,11 @@ references, recent command status, current mode, validation summaries, and
 bounded snippets by path/range instead of whole workspaces.  Any command
 proposal or validation proposal must remain proposal-only until an
 editor/user-controlled executor accepts an allowlisted proposal ID.
+Validation proposal preflight audit sits before that approved runner
+handoff and returns bounded status only: it checks proposal ID, fixed
+command shape, existing allowlist membership, blocked launcher/pccx-lab
+or shell paths, unsupported execution wording, and diagnostics handoff
+context-only handling without executing commands.
 Patch proposals are also contract-only: they may describe reviewed edits
 with repository-relative paths and bounded hunk previews, but they do not
 apply changes or execute commands.
@@ -160,9 +165,10 @@ Launcher status contracts are also status-only and do not call
 pccx-llm-launcher, include model paths, include board logs, or make device
 performance claims.
 Approved validation execution must use fixed argument arrays, bounded
-output, an explicit user-approved command invocation, and no shell
-interpolation.  pccx-lab command execution remains future/prepared in
-this prototype.
+output, an explicit user-approved command invocation, no shell
+interpolation, and a passing preflight audit immediately before the
+runner reaches execution.  pccx-lab command execution remains
+future/prepared in this prototype.
 
 `problems` converts local diagnostics and log records into editor-friendly
 problem records.  `index` provides scanner-based module/package/interface

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -120,6 +120,14 @@ proposal layer does not parse raw handoff JSON and does not add launcher,
 pccx-lab, validator, shell, provider, runtime, MCP, LSP, marketplace,
 telemetry, upload, or write-back flows.
 
+Validation proposal preflight audit is the next bounded data-only handoff
+before the approved runner path. It re-checks the proposal ID, fixed
+command template, existing approved-runner allowlist membership, blocked
+launcher/pccx-lab/shell paths, pccx-lab diagnostics handoff validator
+wording, unsupported execution wording, and diagnostics handoff
+context-only handling. The audit returns bounded JSON/text status and
+does not execute commands or expand the runner allowlist.
+
 This path is data-only. It does not execute `pccx-llm-launcher`, does not
 execute `pccx-lab`, does not invoke the pccx-lab validator command, does
 not spawn shell commands, does not implement MCP or LSP, does not call
@@ -382,7 +390,9 @@ python -m pccx_ide_cli problems from-xsim-log fixtures/xsim/mixed.log --format t
   boundary.  The current VS Code prototype only has boundary types,
   status/context commands, and tests: no AI provider calls, no local chat
   backend runtime calls, no MCP server implementation, and no direct
-  execution of command or validation proposals.
+  execution of command or validation proposals.  Validation proposal
+  preflight audit remains a bounded review step before any approved
+  runner invocation.
 
 These are intentionally unresolved while both sides mature.
 

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -388,12 +388,25 @@ display.  It does not parse raw handoff JSON in the proposal layer, spawn
 a process, call pccx-lab, call an AI provider, write files, or run git
 operations.
 
+`pccxSystemVerilog.auditValidationProposalPreflight` is a review-only
+preflight audit between proposal display and the approved runner handoff.
+It accepts a proposal ID or checked proposal-shaped data, re-resolves the
+existing proposal allowlist, and returns bounded JSON/text explaining
+whether the proposal is eligible for the existing approved runner path.
+It checks for missing or unknown IDs, malformed command shape, raw shell
+strings, launcher commands, pccx-lab commands, pccx-lab diagnostics
+handoff validator invocation, provider/runtime/KV260/MCP/LSP/marketplace
+execution wording, and diagnostics handoff data appearing as execution
+input.  The audit does not execute commands and does not broaden the
+runner allowlist.
+
 `pccxSystemVerilog.runApprovedValidationCommand` is a separate approved
 validation runner boundary.  It is disabled by default; execution requires
 `pccxSystemVerilog.validationRunner.enabled=true` and
 `pccxSystemVerilog.validationRunner.mode=allowlisted`.  The command
 accepts proposal IDs only, not raw command strings, and re-resolves those
-IDs through the internal allowlist before execution.  Initial runnable IDs
+IDs through the internal allowlist and preflight audit before execution.
+Initial runnable IDs
 are `vscodeAdapterSmoke`, `editorBridgeSmoke`, `exampleDriftCheck`, and
 `pytestBaseline`.  `extensionHostSmokeOptIn` remains proposal-only from
 inside the runner.  The runner uses fixed executable and argument arrays
@@ -447,6 +460,7 @@ Now:
 - AI assistant status command and bounded context bundle command
 - selected-symbol context
 - validation command proposal
+- validation proposal preflight audit
 - patch proposal contract
 - disabled-by-default approved validation runner boundary
 - recent validation summary and cache status command
@@ -472,10 +486,11 @@ Later:
 1. Inspect checked-example or explicit live workspace diagnostics and navigation.
 2. Build a selected-symbol AI context bundle for the active editor state.
 3. Propose a validation command as data with `pccxSystemVerilog.proposeValidationCommand`.
-4. User approves an allowlisted validation proposal ID.
-5. Run `pccxSystemVerilog.runApprovedValidationCommand` only after the runner is explicitly enabled.
-6. Inspect the bounded validation cache status and feed the summary back into the context bundle.
-7. Future local coding-assistant mode can propose a patch or next validation step, but does not execute either directly.
+4. Audit the proposal handoff with `pccxSystemVerilog.auditValidationProposalPreflight`.
+5. User approves an allowlisted validation proposal ID.
+6. Run `pccxSystemVerilog.runApprovedValidationCommand` only after the runner is explicitly enabled.
+7. Inspect the bounded validation cache status and feed the summary back into the context bundle.
+8. Future local coding-assistant mode can propose a patch or next validation step, but does not execute either directly.
 
 ## Local Smoke
 
@@ -489,6 +504,7 @@ node editors/vscode-prototype/test/context-bundle.test.mjs
 node editors/vscode-prototype/test/selected-symbol-context.test.mjs
 node editors/vscode-prototype/test/ai-assistant-boundary.test.mjs
 node editors/vscode-prototype/test/validation-proposals.test.mjs
+node editors/vscode-prototype/test/validation-proposal-preflight-audit.test.mjs
 node editors/vscode-prototype/test/patch-proposal-contract.test.mjs
 node editors/vscode-prototype/test/patch-proposal-preview.test.mjs
 node editors/vscode-prototype/test/validation-patch-handoff.test.mjs

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -126,18 +126,20 @@ checked-example symbols.  It executes
 `pccxSystemVerilog.showAIAssistantStatus`,
 `pccxSystemVerilog.buildAIContextBundle`,
 `pccxSystemVerilog.proposeValidationCommand`, and
+`pccxSystemVerilog.auditValidationProposalPreflight`,
 `pccxSystemVerilog.runApprovedValidationCommand`,
 `pccxSystemVerilog.showRecentValidationResults`,
 `pccxSystemVerilog.showValidationCacheStatus`,
 `pccxSystemVerilog.clearValidationResultCache`, and
 `pccxSystemVerilog.showPccxLabBackendStatus`, and
 `pccxSystemVerilog.showDiagnosticsHandoffSummary`, verifying
-disabled/backend `none` status, proposal-only actions, disabled runner
-blocking behavior, one explicitly enabled allowlisted validation run,
-bounded active-file and selected-symbol context, bounded validation-result
-cache summary handoff, status-only pccx-lab boundary data, diagnostics
-handoff summary data, and no provider/runtime calls.  This is not LSP,
-and there is no LSP provider yet.
+disabled/backend `none` status, proposal-only actions, validation
+proposal preflight audit data, disabled runner blocking behavior, one
+explicitly enabled allowlisted validation run, bounded active-file and
+selected-symbol context, bounded validation-result cache summary handoff,
+status-only pccx-lab boundary data, diagnostics handoff summary data, and
+no provider/runtime calls.  This is not LSP, and there is no LSP provider
+yet.
 
 ## AI Assistant Boundary
 

--- a/editors/vscode-prototype/package.json
+++ b/editors/vscode-prototype/package.json
@@ -24,6 +24,7 @@
     "onCommand:pccxSystemVerilog.showAIAssistantStatus",
     "onCommand:pccxSystemVerilog.buildAIContextBundle",
     "onCommand:pccxSystemVerilog.proposeValidationCommand",
+    "onCommand:pccxSystemVerilog.auditValidationProposalPreflight",
     "onCommand:pccxSystemVerilog.runApprovedValidationCommand",
     "onCommand:pccxSystemVerilog.showRecentValidationResults",
     "onCommand:pccxSystemVerilog.showValidationCacheStatus",
@@ -80,6 +81,10 @@
       {
         "command": "pccxSystemVerilog.proposeValidationCommand",
         "title": "PCCX SystemVerilog: Propose Validation Command (Experimental)"
+      },
+      {
+        "command": "pccxSystemVerilog.auditValidationProposalPreflight",
+        "title": "PCCX SystemVerilog: Audit Validation Proposal Preflight (Experimental)"
       },
       {
         "command": "pccxSystemVerilog.runApprovedValidationCommand",

--- a/editors/vscode-prototype/src/approved-validation-runner.mjs
+++ b/editors/vscode-prototype/src/approved-validation-runner.mjs
@@ -7,6 +7,9 @@ import {
   createValidationResultSummary,
   summarizeOutputText,
 } from "./validation-result-summary.mjs";
+import {
+  createValidationProposalPreflightAudit,
+} from "./validation-proposal-preflight-audit.mjs";
 
 export const APPROVED_VALIDATION_RESULT_VERSION = "pccx.approvedValidationResult.v0";
 
@@ -76,6 +79,7 @@ function blockedResult(proposalId, proposal, reason, options = {}) {
   const result = {
     ...safeBaseResult(proposalId, proposal),
     blockedReason: reason,
+    preflightAudit: options.preflightAudit ?? null,
     startedAt: options.startedAt ?? "",
     finishedAt: options.finishedAt ?? "",
     durationMs: durationMs(startedMs, finishedMs),
@@ -241,6 +245,24 @@ export async function runApprovedValidationProposal(input, rawConfig = {}, optio
     );
   }
 
+  const preflightAudit = createValidationProposalPreflightAudit(input);
+  if (!preflightAudit.eligibleForApprovedRunner) {
+    const finishedMs = options.clock?.now?.() ?? Date.now();
+    return blockedResult(
+      proposalId,
+      proposal,
+      preflightAudit.blockedReason || "validation proposal preflight audit failed",
+      {
+        maxOutputLines,
+        startedMs,
+        finishedMs,
+        startedAt,
+        finishedAt: nowIso(options.clock ?? Date),
+        preflightAudit,
+      },
+    );
+  }
+
   let executable;
   let args;
   try {
@@ -253,6 +275,7 @@ export async function runApprovedValidationProposal(input, rawConfig = {}, optio
       finishedMs,
       startedAt,
       finishedAt: nowIso(options.clock ?? Date),
+      preflightAudit,
     });
   }
 
@@ -288,6 +311,7 @@ export async function runApprovedValidationProposal(input, rawConfig = {}, optio
     startedAt,
     finishedAt: nowIso(options.clock ?? Date),
     durationMs: durationMs(startedMs, finishedMs),
+    preflightAudit,
     ok: status === "passed",
     safety: {
       allowlisted: true,

--- a/editors/vscode-prototype/src/config.mjs
+++ b/editors/vscode-prototype/src/config.mjs
@@ -34,6 +34,7 @@ export const AI_COMMAND_IDS = Object.freeze([
   "pccxSystemVerilog.showAIAssistantStatus",
   "pccxSystemVerilog.buildAIContextBundle",
   "pccxSystemVerilog.proposeValidationCommand",
+  "pccxSystemVerilog.auditValidationProposalPreflight",
   "pccxSystemVerilog.runApprovedValidationCommand",
   "pccxSystemVerilog.showRecentValidationResults",
   "pccxSystemVerilog.showValidationCacheStatus",

--- a/editors/vscode-prototype/src/extension.mjs
+++ b/editors/vscode-prototype/src/extension.mjs
@@ -36,7 +36,12 @@ import {
 } from "./selected-symbol-context.mjs";
 import {
   createValidationCommandProposal,
+  listValidationCommandProposals,
 } from "./validation-proposals.mjs";
+import {
+  createValidationProposalPreflightAudit,
+  formatValidationProposalPreflightAudit,
+} from "./validation-proposal-preflight-audit.mjs";
 import {
   runApprovedValidationProposal,
 } from "./approved-validation-runner.mjs";
@@ -83,6 +88,8 @@ export const AI_CONTEXT_BUNDLE_COMMAND =
   "pccxSystemVerilog.buildAIContextBundle";
 export const VALIDATION_PROPOSAL_COMMAND =
   "pccxSystemVerilog.proposeValidationCommand";
+export const AUDIT_VALIDATION_PREFLIGHT_COMMAND =
+  "pccxSystemVerilog.auditValidationProposalPreflight";
 export const APPROVED_VALIDATION_RUNNER_COMMAND =
   "pccxSystemVerilog.runApprovedValidationCommand";
 export const SHOW_RECENT_VALIDATION_RESULTS_COMMAND =
@@ -295,6 +302,15 @@ function patchProposalQuickPickItems(proposals) {
   }));
 }
 
+function validationPreflightQuickPickItems(proposals) {
+  return proposals.map((proposal) => ({
+    label: proposal.label,
+    description: [proposal.runnerPolicy, proposal.riskLevel, proposal.id].filter(Boolean).join(" "),
+    detail: proposal.reason,
+    proposalId: proposal.id,
+  }));
+}
+
 function validationOutputChannelFromRuntime(runtime = {}) {
   return runtime.validationOutputChannel ?? runtime.outputChannel;
 }
@@ -349,6 +365,9 @@ function appendCommandOutput(outputChannel, commandId, result) {
       execution: result.execution,
       diagnosticsHandoff: result.diagnosticsHandoffContext?.status ?? "unavailable",
     }, null, 2));
+  }
+  if (result.kind === "validation-proposal-preflight-audit") {
+    outputChannel.appendLine(formatValidationProposalPreflightAudit(result));
   }
   if (result.kind === "approved-validation-result") {
     outputChannel.appendLine(JSON.stringify({
@@ -787,6 +806,51 @@ export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
             },
           }),
         };
+      } catch (error) {
+        result = { ok: false, commandId, error: error.message };
+        vscodeApi?.window?.showWarningMessage?.(result.error, result);
+      }
+      appendCommandOutput(runtime.outputChannel, commandId, result);
+      return result;
+    }
+
+    if (commandId === AUDIT_VALIDATION_PREFLIGHT_COMMAND) {
+      let result;
+      try {
+        const request = createAssistantRequest(rawConfig, {
+          diagnosticsHandoffStatus: diagnosticsHandoffStatusFromRuntime(runtime),
+        });
+        let auditInput = input;
+        if (auditInput == null && typeof vscodeApi?.window?.showQuickPick === "function") {
+          const selected = await vscodeApi.window.showQuickPick(
+            validationPreflightQuickPickItems(listValidationCommandProposals({
+              contextBundle: {
+                diagnosticsHandoff: request.contextBundle.diagnosticsHandoff,
+              },
+            })),
+            {
+              title: "Validation Proposal Preflight Audit",
+              placeHolder: "Select a validation proposal to audit",
+            },
+          );
+          auditInput = selected?.proposalId ?? null;
+        }
+        result = {
+          ok: true,
+          commandId,
+          ...createValidationProposalPreflightAudit(auditInput ?? {}, {
+            contextBundle: {
+              diagnosticsHandoff: request.contextBundle.diagnosticsHandoff,
+            },
+          }),
+        };
+        const message =
+          `Validation preflight audit: ${result.proposalId || "unknown"} ${result.status}.`;
+        if (result.status === "passed") {
+          vscodeApi?.window?.showInformationMessage?.(message, result);
+        } else {
+          vscodeApi?.window?.showWarningMessage?.(message, result);
+        }
       } catch (error) {
         result = { ok: false, commandId, error: error.message };
         vscodeApi?.window?.showWarningMessage?.(result.error, result);

--- a/editors/vscode-prototype/src/validation-proposal-preflight-audit.mjs
+++ b/editors/vscode-prototype/src/validation-proposal-preflight-audit.mjs
@@ -1,0 +1,450 @@
+import {
+  VALIDATION_PROPOSAL_PREFLIGHT_VERSION,
+  createValidationDiagnosticsHandoffContext,
+  findValidationCommandProposalById,
+  listValidationCommandProposals,
+} from "./validation-proposals.mjs";
+
+export const VALIDATION_PROPOSAL_PREFLIGHT_AUDIT_VERSION =
+  "pccx.validationProposalPreflightAudit.v0";
+
+const PROPOSAL_ID_PATTERN = /^[A-Za-z][A-Za-z0-9]*$/;
+const MAX_CHECK_MESSAGE_CHARACTERS = 180;
+const MAX_TEXT_LINES = 18;
+const MAX_COLLECTED_STRINGS = 80;
+const MAX_COLLECTED_STRING_CHARACTERS = 320;
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]/i;
+const HOME_PATH_PATTERN = /(?:\/home\/[^/\s]+|\/Users\/[^/\s]+|[A-Za-z]:\\Users\\)/g;
+const SHELL_CONTROL_PATTERN = /(?:&&|\|\||;|`|\$\(|>|<)/;
+const RAW_SHELL_FIELD_PATTERN =
+  /^(?:command|commandLine|rawCommand|shellCommand|script|scriptText)$/i;
+const LAUNCHER_COMMAND_PATTERN =
+  /\b(?:pccx[-_]?llm[-_]?launcher|launcher_diagnostics_handoff|launcher\s+(?:run|status|launch|diagnostics|execute))\b/i;
+const PCCX_LAB_COMMAND_PATTERN =
+  /\b(?:pccx[-_]?lab|pccx_lab|pccx_ide_cli)\b/i;
+const PCCX_LAB_VALIDATOR_PATTERN =
+  /\b(?:diagnostics[-_ ]handoff\s+validate|validate\s+diagnostics[-_ ]handoff|pccx[-_]?lab[\s\S]{0,80}validate|pccx_ide_cli[\s\S]{0,80}validate)\b/i;
+const EXECUTION_CLAIM_PATTERN = new RegExp([
+  "\\b(?:provider|runtime|KV260|MCP|LSP|marketplace)\\b[^\\n]{0,80}\\b(?:ready|enabled|implemented|executes?|runs?|launch(?:es|ed)?|invoke[sd]?|calls?|integrat(?:e|ed|ion)|publishes?|uploads?|writes?|works)\\b",
+  "\\b(?:ready|enabled|implemented|executes?|runs?|launch(?:es|ed)?|invoke[sd]?|calls?|integrat(?:e|ed|ion)|publishes?|uploads?|writes?|works)\\b[^\\n]{0,80}\\b(?:provider|runtime|KV260|MCP|LSP|marketplace)\\b",
+].join("|"), "i");
+const EXECUTION_CLAIM_NEGATION_PATTERN =
+  /\b(?:no|not|never|without|does not|do not|disabled|unsupported|future|reserved|proposal-only|status-only|blocked|false)\b/i;
+
+function scrubLine(value, maxCharacters = MAX_CHECK_MESSAGE_CHARACTERS) {
+  if (typeof value !== "string" || maxCharacters <= 0) {
+    return "";
+  }
+  const cleaned = value
+    .replace(/\0/g, "")
+    .replace(/[\r\n]+/g, " ")
+    .replace(HOME_PATH_PATTERN, "[home]")
+    .trim();
+  return (SECRET_ASSIGNMENT_PATTERN.test(cleaned) ? "[redacted]" : cleaned)
+    .slice(0, maxCharacters)
+    .trim();
+}
+
+function check(id, status, message) {
+  return {
+    id,
+    status: status ? "pass" : "fail",
+    message: scrubLine(message),
+  };
+}
+
+function safeObject(value) {
+  return value && typeof value === "object" && !Array.isArray(value);
+}
+
+function proposalIdFromInput(input) {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (typeof input?.proposalId === "string") {
+    return input.proposalId;
+  }
+  if (typeof input?.proposal?.id === "string") {
+    return input.proposal.id;
+  }
+  if (typeof input?.id === "string") {
+    return input.id;
+  }
+  return "";
+}
+
+function directProposalFromInput(input) {
+  if (safeObject(input?.proposal)) {
+    return input.proposal;
+  }
+  if (
+    safeObject(input) &&
+    (
+      Object.hasOwn(input, "id") ||
+      Object.hasOwn(input, "category") ||
+      Object.hasOwn(input, "label") ||
+      Object.hasOwn(input, "command") ||
+      Object.hasOwn(input, "preflight")
+    ) &&
+    !Object.hasOwn(input, "proposalId")
+  ) {
+    return input;
+  }
+  return null;
+}
+
+function contextInputFrom(input, options = {}) {
+  return {
+    contextBundle: options.contextBundle ?? input?.contextBundle,
+    diagnosticsHandoffContext: options.diagnosticsHandoffContext ?? input?.diagnosticsHandoffContext,
+  };
+}
+
+function collectStrings(value, options = {}, state = { count: 0, strings: [] }) {
+  if (state.count >= MAX_COLLECTED_STRINGS || value == null) {
+    return state.strings;
+  }
+  if (typeof value === "string") {
+    state.count += 1;
+    state.strings.push(scrubLine(value, MAX_COLLECTED_STRING_CHARACTERS));
+    return state.strings;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    state.count += 1;
+    state.strings.push(String(value));
+    return state.strings;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectStrings(item, options, state);
+      if (state.count >= MAX_COLLECTED_STRINGS) {
+        break;
+      }
+    }
+    return state.strings;
+  }
+  if (safeObject(value)) {
+    for (const key of Object.keys(value).sort()) {
+      if (options.skipKeys?.has(key)) {
+        continue;
+      }
+      collectStrings(value[key], options, state);
+      if (state.count >= MAX_COLLECTED_STRINGS) {
+        break;
+      }
+    }
+  }
+  return state.strings;
+}
+
+function collectRawShellFindings(value, path = "", findings = []) {
+  if (value == null || findings.length >= 8) {
+    return findings;
+  }
+  if (typeof value === "string") {
+    const key = path.split(".").at(-1) ?? "";
+    if (RAW_SHELL_FIELD_PATTERN.test(key) || SHELL_CONTROL_PATTERN.test(value)) {
+      findings.push(path || "input");
+    }
+    return findings;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => collectRawShellFindings(item, `${path}[${index}]`, findings));
+    return findings;
+  }
+  if (safeObject(value)) {
+    for (const [key, item] of Object.entries(value)) {
+      const nextPath = path ? `${path}.${key}` : key;
+      if (key === "shell" && item === true) {
+        findings.push(nextPath);
+      }
+      if (findings.length >= 8) {
+        break;
+      }
+      collectRawShellFindings(item, nextPath, findings);
+    }
+  }
+  return findings;
+}
+
+function commandStringsFrom(input, proposal) {
+  const commandInputs = [
+    proposal?.command,
+    safeObject(input) ? input.command : null,
+    safeObject(input) ? input.argv : null,
+    safeObject(input) ? input.args : null,
+    safeObject(input) ? input.env : null,
+    safeObject(input) ? input.executable : null,
+    safeObject(input) ? input.commandLine : null,
+    safeObject(input) ? input.rawCommand : null,
+    safeObject(input) ? input.shellCommand : null,
+  ];
+  const strings = collectStrings(commandInputs);
+  const joined = scrubLine(strings.join(" "), MAX_COLLECTED_STRING_CHARACTERS);
+  return joined ? [...strings, joined] : strings;
+}
+
+function rawShellSourcesFrom(input, proposal) {
+  const inputSources = safeObject(input)
+    ? {
+        command: input.command,
+        argv: input.argv,
+        args: input.args,
+        env: input.env,
+        executable: input.executable,
+        commandLine: input.commandLine,
+        rawCommand: input.rawCommand,
+        shellCommand: input.shellCommand,
+        shell: input.shell,
+      }
+    : input;
+  return [
+    { command: proposal?.command },
+    inputSources,
+  ];
+}
+
+function jsonEqual(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function commandMatchesCanonical(proposal, canonical) {
+  if (!proposal?.command || !canonical?.command) {
+    return false;
+  }
+  return proposal.command.cwd === canonical.command.cwd &&
+    jsonEqual(proposal.command.argv, canonical.command.argv) &&
+    jsonEqual(proposal.command.env ?? {}, canonical.command.env ?? {});
+}
+
+function hasExecutionClaim(strings) {
+  return strings.some((line) => (
+    EXECUTION_CLAIM_PATTERN.test(line) &&
+    !EXECUTION_CLAIM_NEGATION_PATTERN.test(line)
+  ));
+}
+
+function diagnosticsHandoffFromProposal(proposal, input, options = {}) {
+  const context = createValidationDiagnosticsHandoffContext(contextInputFrom(input, options));
+  const proposalPreflight = proposal?.preflight?.diagnosticsHandoff;
+  return {
+    status: proposalPreflight?.status ?? context.status,
+    source: proposalPreflight?.source ?? context.source,
+    summaryAvailable: proposalPreflight?.summaryAvailable ?? context.summaryAvailable,
+    contextOnly: true,
+    executionInput: false,
+  };
+}
+
+function allowedRunnerIds(input, options = {}) {
+  return listValidationCommandProposals(contextInputFrom(input, options))
+    .filter((proposal) => proposal.command && proposal.runnerPolicy !== "proposalOnly")
+    .map((proposal) => proposal.id);
+}
+
+function boundedBlockedReasons(checks) {
+  return checks
+    .filter((item) => item.status === "fail")
+    .slice(0, 4)
+    .map((item) => item.id);
+}
+
+export function createValidationProposalPreflightAudit(input = {}, options = {}) {
+  const rawProposalId = proposalIdFromInput(input);
+  const proposalId = scrubLine(rawProposalId, 80);
+  const contextInput = contextInputFrom(input, options);
+  const directProposal = directProposalFromInput(input);
+  const canonical = proposalId && PROPOSAL_ID_PATTERN.test(proposalId)
+    ? findValidationCommandProposalById(proposalId, contextInput)
+    : null;
+  const proposal = directProposal ?? canonical;
+  const commandStrings = commandStringsFrom(input, proposal);
+  const proposalText = collectStrings(proposal, {
+    skipKeys: new Set(["diagnosticsHandoffContext"]),
+  });
+  const allText = collectStrings([input, proposal], {
+    skipKeys: new Set(["diagnosticsHandoffContext", "contextBundle"]),
+  });
+  const rawShellFindings = collectRawShellFindings(rawShellSourcesFrom(input, proposal));
+  const hasCommandShape = proposal?.command == null || (
+    safeObject(proposal.command) &&
+    typeof proposal.command.cwd === "string" &&
+    Array.isArray(proposal.command.argv) &&
+    proposal.command.argv.length > 0 &&
+    proposal.command.argv.every((arg) => typeof arg === "string") &&
+    safeObject(proposal.command.env ?? {})
+  );
+  const allowlistedIds = allowedRunnerIds(input, options);
+  const proposalIdKnown = Boolean(proposalId && canonical);
+  const commandAllowlisted = proposalIdKnown &&
+    allowlistedIds.includes(proposalId) &&
+    commandMatchesCanonical(proposal, canonical);
+  const rawShellBlocked = rawShellFindings.length > 0 ||
+    commandStrings.some((line) => SHELL_CONTROL_PATTERN.test(line));
+  const launcherBlocked = commandStrings.some((line) => LAUNCHER_COMMAND_PATTERN.test(line));
+  const pccxLabBlocked = commandStrings.some((line) => PCCX_LAB_COMMAND_PATTERN.test(line));
+  const pccxLabValidatorBlocked = commandStrings.some((line) => (
+    PCCX_LAB_VALIDATOR_PATTERN.test(line)
+  ));
+  const executionClaimBlocked = hasExecutionClaim(proposalText.concat(allText));
+  const diagnosticsHandoff = diagnosticsHandoffFromProposal(proposal, input, options);
+  const diagnosticsHandoffExecutionInput = commandStrings.some((line) => (
+    /diagnosticsHandoff|diagnostics[-_ ]handoff|pccx\.diagnosticsHandoff\.v0/i.test(line)
+  ));
+  const diagnosticsContextOnly = diagnosticsHandoff.contextOnly === true &&
+    diagnosticsHandoff.executionInput === false &&
+    diagnosticsHandoffExecutionInput === false;
+  const checks = [
+    check(
+      "proposal-id-exists",
+      proposalIdKnown,
+      proposalIdKnown
+        ? "proposal ID resolves to a checked validation proposal"
+        : "proposal ID is missing, malformed, or unknown",
+    ),
+    check(
+      "proposal-shape",
+      Boolean(proposal) && hasCommandShape,
+      Boolean(proposal) && hasCommandShape
+        ? "proposal shape is bounded and command is an argument array when present"
+        : "proposal is missing or command shape is malformed",
+    ),
+    check(
+      "command-allowlist",
+      commandAllowlisted,
+      commandAllowlisted
+        ? "command matches the existing approved runner proposal allowlist"
+        : "command is absent, proposal-only, placeholder, or not in the existing runner allowlist",
+    ),
+    check(
+      "no-raw-shell",
+      !rawShellBlocked,
+      rawShellBlocked
+        ? "raw shell string, shell flag, or shell control syntax was detected"
+        : "no raw shell string, shell flag, or shell control syntax detected",
+    ),
+    check(
+      "no-launcher-command",
+      !launcherBlocked,
+      launcherBlocked
+        ? "launcher command wording was detected in execution inputs"
+        : "no launcher command appears in execution inputs",
+    ),
+    check(
+      "no-pccx-lab-command",
+      !pccxLabBlocked,
+      pccxLabBlocked
+        ? "pccx-lab command wording was detected; no existing runner policy allows it"
+        : "no pccx-lab command appears in execution inputs",
+    ),
+    check(
+      "no-pccx-lab-validator",
+      !pccxLabValidatorBlocked,
+      pccxLabValidatorBlocked
+        ? "pccx-lab diagnostics handoff validator invocation was detected"
+        : "no pccx-lab diagnostics handoff validator invocation detected",
+    ),
+    check(
+      "no-execution-claim-wording",
+      !executionClaimBlocked,
+      executionClaimBlocked
+        ? "provider/runtime/KV260/MCP/LSP/marketplace wording implies execution"
+        : "no provider/runtime/KV260/MCP/LSP/marketplace execution claim detected",
+    ),
+    check(
+      "diagnostics-handoff-context-only",
+      diagnosticsContextOnly,
+      diagnosticsContextOnly
+        ? "diagnostics handoff is represented as proposal context only"
+        : "diagnostics handoff appears in command argv, env, or another execution input",
+    ),
+  ];
+  const failedCheckIds = boundedBlockedReasons(checks);
+  const eligibleForApprovedRunner = failedCheckIds.length === 0;
+
+  return {
+    version: VALIDATION_PROPOSAL_PREFLIGHT_AUDIT_VERSION,
+    kind: "validation-proposal-preflight-audit",
+    proposalId,
+    status: eligibleForApprovedRunner ? "passed" : "failed",
+    eligibleForApprovedRunner,
+    execution: "auditOnly",
+    proposalOnly: true,
+    executes: false,
+    auditScope: "validation-proposal-to-approved-runner",
+    preflightVersion: VALIDATION_PROPOSAL_PREFLIGHT_VERSION,
+    blockedReason: eligibleForApprovedRunner
+      ? ""
+      : `validation proposal preflight audit failed: ${failedCheckIds.join(", ")}`,
+    checks,
+    diagnosticsHandoff,
+    allowlist: {
+      source: "existing-approved-validation-runner",
+      broadened: false,
+      runnerProposalIds: allowlistedIds,
+    },
+    findings: {
+      rawShellString: rawShellBlocked,
+      launcherCommand: launcherBlocked,
+      pccxLabCommand: pccxLabBlocked,
+      pccxLabValidatorInvocation: pccxLabValidatorBlocked,
+      executionClaimWording: executionClaimBlocked,
+      diagnosticsHandoffExecutionInput,
+    },
+    bounds: {
+      maxCheckCount: checks.length,
+      maxCheckMessageCharacters: MAX_CHECK_MESSAGE_CHARACTERS,
+      maxTextLines: MAX_TEXT_LINES,
+      rawLogsExcluded: true,
+    },
+    safety: {
+      auditOnly: true,
+      dataOnly: true,
+      readOnly: true,
+      proposalOnly: true,
+      automaticExecution: false,
+      allowlistBroadened: false,
+      shellExecution: false,
+      rawShellStringExecution: false,
+      launcherExecution: false,
+      pccxLabExecution: false,
+      pccxLabValidatorInvocation: false,
+      providerCalls: false,
+      networkCalls: false,
+      runtimeCalls: false,
+      mcpCalls: false,
+      lspImplemented: false,
+      marketplaceFlow: false,
+      telemetry: false,
+      automaticUpload: false,
+      writeBack: false,
+    },
+  };
+}
+
+export function formatValidationProposalPreflightAudit(audit, options = {}) {
+  const maxLines = Number.isInteger(options.maxLines) ? options.maxLines : MAX_TEXT_LINES;
+  const lines = [
+    "Validation Proposal Preflight Audit",
+    `version: ${scrubLine(audit?.version ?? "", 120)}`,
+    `proposalId: ${scrubLine(audit?.proposalId ?? "", 80)}`,
+    `status: ${audit?.status === "passed" ? "passed" : "failed"}`,
+    `eligibleForApprovedRunner: ${audit?.eligibleForApprovedRunner === true ? "yes" : "no"}`,
+    `execution: ${audit?.executes === false ? "no command executed" : "unexpected execution flag"}`,
+    `allowlistBroadened: ${audit?.allowlist?.broadened === false ? "no" : "unknown"}`,
+    `diagnosticsHandoff: ${scrubLine(audit?.diagnosticsHandoff?.status ?? "unavailable", 80)} context-only`,
+    "checks:",
+  ];
+
+  for (const item of audit?.checks ?? []) {
+    lines.push(`- ${item.status}: ${item.id} - ${scrubLine(item.message)}`);
+    if (lines.length >= maxLines) {
+      break;
+    }
+  }
+  if (audit?.blockedReason && lines.length < maxLines) {
+    lines.push(`blockedReason: ${scrubLine(audit.blockedReason)}`);
+  }
+  return lines.slice(0, maxLines).join("\n");
+}

--- a/editors/vscode-prototype/test/approved-validation-runner.test.mjs
+++ b/editors/vscode-prototype/test/approved-validation-runner.test.mjs
@@ -145,6 +145,9 @@ async function testAllowlistedExecutionUsesExecFileArgumentArray() {
   assert.equal(result.stdoutSummary.truncated, true);
   assert.equal(result.resultSummary.proposalId, "vscodeAdapterSmoke");
   assert.equal(result.resultSummary.safety.fixedArgs, true);
+  assert.equal(result.preflightAudit.status, "passed");
+  assert.equal(result.preflightAudit.eligibleForApprovedRunner, true);
+  assert.equal(result.preflightAudit.executes, false);
   assert.equal(result.safety.allowlisted, true);
   assert.equal(result.safety.providerCalls, false);
   assert.equal(result.safety.launcherCalls, false);
@@ -155,6 +158,34 @@ async function testAllowlistedExecutionUsesExecFileArgumentArray() {
   assert.equal(stub.calls[0].options.cwd, "/repo");
   assert.equal(stub.calls[0].options.shell, false);
   assert.equal(stub.calls[0].options.timeout, 5000);
+}
+
+async function testPreflightAuditBlocksExecutionOverridesWhenEnabled() {
+  const stub = execFileStub(() => {
+    throw new Error("preflight audit failure must not execute");
+  });
+
+  const result = await runApprovedValidationProposal(
+    {
+      proposalId: "vscodeAdapterSmoke",
+      command: "bash scripts/vscode-adapter-smoke.sh; rm -rf /",
+    },
+    ENABLED_CONFIG,
+    {
+      repoRoot: "/repo",
+      execFile: stub.execFile,
+      clock: fakeClock(),
+    },
+  );
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, "blocked");
+  assert.match(result.blockedReason, /preflight audit failed/);
+  assert.equal(result.preflightAudit.status, "failed");
+  assert.equal(result.preflightAudit.eligibleForApprovedRunner, false);
+  assert.equal(result.preflightAudit.findings.rawShellString, true);
+  assert.equal(stub.calls.length, 0);
+  assert.doesNotMatch(JSON.stringify(result), /rm -rf/);
 }
 
 async function testFailureTimeoutAndProposalOnlyBlocks() {
@@ -200,6 +231,7 @@ await testMissingProposalIdBlocksEvenWhenEnabled();
 await testDisabledByDefaultBlocksWithoutExecution();
 await testUnknownAndRawCommandInputBlocks();
 await testAllowlistedExecutionUsesExecFileArgumentArray();
+await testPreflightAuditBlocksExecutionOverridesWhenEnabled();
 await testFailureTimeoutAndProposalOnlyBlocks();
 
 console.log("vscode approved validation runner tests ok");

--- a/editors/vscode-prototype/test/extension-entrypoint.test.mjs
+++ b/editors/vscode-prototype/test/extension-entrypoint.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   AI_CONTEXT_BUNDLE_COMMAND,
   AI_ASSISTANT_STATUS_COMMAND,
+  AUDIT_VALIDATION_PREFLIGHT_COMMAND,
   APPROVED_VALIDATION_RUNNER_COMMAND,
   CLEAR_PATCH_PROPOSAL_PREVIEW_COMMAND,
   CLEAR_VALIDATION_RESULT_CACHE_COMMAND,
@@ -964,6 +965,58 @@ async function testValidationProposalCommandReturnsDataOnly() {
   assert.doesNotMatch(JSON.stringify(result), /git push/);
 }
 
+async function testValidationPreflightAuditCommandReturnsAuditOnly() {
+  const outputLines = [];
+  const informationMessages = [];
+  const warningMessages = [];
+  const handler = createCommandHandler(
+    AUDIT_VALIDATION_PREFLIGHT_COMMAND,
+    {
+      window: {
+        showInformationMessage(...args) {
+          informationMessages.push(args);
+        },
+        showWarningMessage(...args) {
+          warningMessages.push(args);
+        },
+      },
+    },
+    {
+      outputChannel: {
+        appendLine(line) {
+          outputLines.push(line);
+        },
+        show() {},
+      },
+    },
+  );
+
+  const result = await handler({ proposalId: "vscodeAdapterSmoke" });
+  const blocked = await handler({
+    proposalId: "vscodeAdapterSmoke",
+    command: "bash scripts/vscode-adapter-smoke.sh; rm -rf /",
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.commandId, AUDIT_VALIDATION_PREFLIGHT_COMMAND);
+  assert.equal(result.kind, "validation-proposal-preflight-audit");
+  assert.equal(result.status, "passed");
+  assert.equal(result.eligibleForApprovedRunner, true);
+  assert.equal(result.executes, false);
+  assert.equal(result.safety.automaticExecution, false);
+  assert.equal(result.safety.allowlistBroadened, false);
+  assert.equal(result.diagnosticsHandoff.status, "available");
+  assert.equal(result.diagnosticsHandoff.contextOnly, true);
+  assert.equal(blocked.ok, true);
+  assert.equal(blocked.status, "failed");
+  assert.equal(blocked.eligibleForApprovedRunner, false);
+  assert.equal(blocked.findings.rawShellString, true);
+  assert.ok(outputLines.some((line) => line.includes("Validation Proposal Preflight Audit")));
+  assert.ok(informationMessages.some(([message]) => /Validation preflight audit: vscodeAdapterSmoke passed/.test(message)));
+  assert.ok(warningMessages.some(([message]) => /Validation preflight audit: vscodeAdapterSmoke failed/.test(message)));
+  assert.doesNotMatch(JSON.stringify(blocked), /rm -rf/);
+}
+
 async function testApprovedValidationRunnerBlocksByDefaultAndUpdatesContext() {
   const settings = new Map([
     ["mode", "checkedExample"],
@@ -1510,6 +1563,7 @@ await testCommandHandlerCanBeUsedWithoutRealVsCode();
 await testAIStatusCommandReturnsDisabledBackendNone();
 await testAIContextBundleCommandUsesActiveEditorSelectionAndDiagnostics();
 await testValidationProposalCommandReturnsDataOnly();
+await testValidationPreflightAuditCommandReturnsAuditOnly();
 await testApprovedValidationRunnerBlocksByDefaultAndUpdatesContext();
 await testApprovedValidationRunnerRequiresProposalIdWhenEnabled();
 await testApprovedValidationRunnerExecutesAllowlistedProposalWhenEnabled();

--- a/editors/vscode-prototype/test/extension-host-readiness.test.mjs
+++ b/editors/vscode-prototype/test/extension-host-readiness.test.mjs
@@ -104,6 +104,7 @@ async function testReadinessDocsAndCiPolicy() {
   assert.match(`${readme}\n${readiness}`, /buildAIContextBundle/);
   assert.match(`${readme}\n${readiness}`, /selected-symbol context/i);
   assert.match(`${readme}\n${readiness}`, /proposeValidationCommand/);
+  assert.match(`${readme}\n${readiness}`, /auditValidationProposalPreflight/);
   assert.match(`${readme}\n${readiness}`, /runApprovedValidationCommand/);
   assert.match(`${readme}\n${readiness}`, /showRecentValidationResults/);
   assert.match(`${readme}\n${readiness}`, /showValidationCacheStatus/);
@@ -116,6 +117,7 @@ async function testReadinessDocsAndCiPolicy() {
   assert.match(`${readme}\n${readiness}`, /showDiagnosticsHandoffSummary/);
   assert.match(`${readme}\n${readiness}`, /context bundle command/i);
   assert.match(`${readme}\n${readiness}`, /validation command proposal/i);
+  assert.match(`${readme}\n${readiness}`, /validation proposal preflight audit/i);
   assert.match(`${readme}\n${readiness}`, /patch proposal contract/i);
   assert.match(`${readme}\n${readiness}`, /validation-to-patch handoff/i);
   assert.match(`${readme}\n${readiness}`, /pccx-lab command descriptor contract/i);
@@ -169,6 +171,7 @@ async function testRuntimeRunnerIsPinnedAndBounded() {
   assert.match(suite, /buildAIContextBundle/);
   assert.match(suite, /selectedContext/);
   assert.match(suite, /proposeValidationCommand/);
+  assert.match(suite, /auditValidationProposalPreflight/);
   assert.match(suite, /runApprovedValidationCommand/);
   assert.match(suite, /showRecentValidationResults/);
   assert.match(suite, /showValidationCacheStatus/);

--- a/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
+++ b/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
@@ -67,6 +67,7 @@ async function run() {
     "pccxSystemVerilog.showAIAssistantStatus",
     "pccxSystemVerilog.buildAIContextBundle",
     "pccxSystemVerilog.proposeValidationCommand",
+    "pccxSystemVerilog.auditValidationProposalPreflight",
     "pccxSystemVerilog.runApprovedValidationCommand",
     "pccxSystemVerilog.showRecentValidationResults",
     "pccxSystemVerilog.showValidationCacheStatus",
@@ -403,6 +404,29 @@ async function run() {
   assert.ok(validationProposal.proposals.every((proposal) => (
     proposal.preflight.diagnosticsHandoff.status === "available"
   )));
+
+  const validationPreflightAudit = await vscode.commands.executeCommand(
+    "pccxSystemVerilog.auditValidationProposalPreflight",
+    { proposalId: "vscodeAdapterSmoke" },
+  );
+  assert.equal(validationPreflightAudit.ok, true);
+  assert.equal(validationPreflightAudit.kind, "validation-proposal-preflight-audit");
+  assert.equal(validationPreflightAudit.status, "passed");
+  assert.equal(validationPreflightAudit.eligibleForApprovedRunner, true);
+  assert.equal(validationPreflightAudit.executes, false);
+  assert.equal(validationPreflightAudit.diagnosticsHandoff.status, "available");
+  assert.equal(validationPreflightAudit.diagnosticsHandoff.contextOnly, true);
+  assert.equal(validationPreflightAudit.safety.automaticExecution, false);
+  assert.equal(validationPreflightAudit.safety.allowlistBroadened, false);
+
+  const blockedValidationPreflightAudit = await vscode.commands.executeCommand(
+    "pccxSystemVerilog.auditValidationProposalPreflight",
+    { proposalId: "vscodeAdapterSmoke", command: "bash scripts/vscode-adapter-smoke.sh; rm -rf /" },
+  );
+  assert.equal(blockedValidationPreflightAudit.ok, true);
+  assert.equal(blockedValidationPreflightAudit.status, "failed");
+  assert.equal(blockedValidationPreflightAudit.eligibleForApprovedRunner, false);
+  assert.equal(blockedValidationPreflightAudit.findings.rawShellString, true);
 
   const patchPreview = await vscode.commands.executeCommand(
     "pccxSystemVerilog.showPatchProposalPreview",

--- a/editors/vscode-prototype/test/extension-manifest.test.mjs
+++ b/editors/vscode-prototype/test/extension-manifest.test.mjs
@@ -17,6 +17,7 @@ const COMMAND_IDS = [
   "pccxSystemVerilog.showAIAssistantStatus",
   "pccxSystemVerilog.buildAIContextBundle",
   "pccxSystemVerilog.proposeValidationCommand",
+  "pccxSystemVerilog.auditValidationProposalPreflight",
   "pccxSystemVerilog.runApprovedValidationCommand",
   "pccxSystemVerilog.showRecentValidationResults",
   "pccxSystemVerilog.showValidationCacheStatus",
@@ -124,6 +125,7 @@ async function testDocsKeepExperimentalScope() {
   assert.match(combined, /context bundle command/i);
   assert.match(combined, /AI assistant status command/i);
   assert.match(combined, /validation command proposal/i);
+  assert.match(combined, /validation proposal preflight audit/i);
   assert.match(combined, /patch proposal contract/i);
   assert.match(combined, /validation-to-patch handoff/i);
   assert.match(combined, /pccx-lab command\s+descriptor contract/i);

--- a/editors/vscode-prototype/test/static-boundary.test.mjs
+++ b/editors/vscode-prototype/test/static-boundary.test.mjs
@@ -140,6 +140,7 @@ async function testNoDirectShellInterpolation() {
 async function testProposalAndStatusModulesAreDataOnly() {
   const proposalAndStatusSource = await readCombined([
     resolve(EXTENSION_ROOT, "src/validation-proposals.mjs"),
+    resolve(EXTENSION_ROOT, "src/validation-proposal-preflight-audit.mjs"),
     resolve(EXTENSION_ROOT, "src/patch-proposal-contract.mjs"),
     resolve(EXTENSION_ROOT, "src/patch-proposal-preview.mjs"),
     resolve(EXTENSION_ROOT, "src/validation-patch-handoff.mjs"),
@@ -164,6 +165,7 @@ async function testProposalAndStatusModulesAreDataOnly() {
   assert.doesNotMatch(proposalAndStatusSource, /\bgh\s+(?:secret|ruleset)\b/i);
   assert.match(proposalAndStatusSource, /proposalOnly/);
   assert.match(proposalAndStatusSource, /executes: false/);
+  assert.match(proposalAndStatusSource, /auditOnly/);
   assert.match(proposalAndStatusSource, /appliesPatches: false/);
   assert.match(proposalAndStatusSource, /backendCommandExecuted: false/);
 }

--- a/editors/vscode-prototype/test/validation-proposal-preflight-audit.test.mjs
+++ b/editors/vscode-prototype/test/validation-proposal-preflight-audit.test.mjs
@@ -1,0 +1,236 @@
+import assert from "node:assert/strict";
+
+import {
+  VALIDATION_PROPOSAL_PREFLIGHT_AUDIT_VERSION,
+  createValidationProposalPreflightAudit,
+  formatValidationProposalPreflightAudit,
+} from "../src/validation-proposal-preflight-audit.mjs";
+import {
+  findValidationCommandProposalById,
+} from "../src/validation-proposals.mjs";
+import {
+  buildContextBundle,
+} from "../src/context-bundle.mjs";
+import {
+  cloneDefaultDiagnosticsHandoffConsumerSummary,
+  createDiagnosticsHandoffStatusSurface,
+} from "../src/diagnostics-handoff-status-surface.mjs";
+
+function checkById(audit, id) {
+  return audit.checks.find((check) => check.id === id);
+}
+
+function cloneProposal(id = "vscodeAdapterSmoke") {
+  return JSON.parse(JSON.stringify(findValidationCommandProposalById(id)));
+}
+
+function assertAuditShape(audit) {
+  assert.equal(audit.version, VALIDATION_PROPOSAL_PREFLIGHT_AUDIT_VERSION);
+  assert.equal(audit.kind, "validation-proposal-preflight-audit");
+  assert.equal(audit.execution, "auditOnly");
+  assert.equal(audit.proposalOnly, true);
+  assert.equal(audit.executes, false);
+  assert.equal(audit.auditScope, "validation-proposal-to-approved-runner");
+  assert.ok(audit.checks.length <= audit.bounds.maxCheckCount);
+  assert.ok(audit.checks.every((check) => check.message.length <= audit.bounds.maxCheckMessageCharacters));
+  assert.equal(audit.allowlist.broadened, false);
+  assert.deepEqual(audit.allowlist.runnerProposalIds, [
+    "vscodeAdapterSmoke",
+    "editorBridgeSmoke",
+    "exampleDriftCheck",
+    "pytestBaseline",
+  ]);
+  assert.equal(audit.safety.auditOnly, true);
+  assert.equal(audit.safety.dataOnly, true);
+  assert.equal(audit.safety.readOnly, true);
+  assert.equal(audit.safety.automaticExecution, false);
+  assert.equal(audit.safety.allowlistBroadened, false);
+  assert.equal(audit.safety.shellExecution, false);
+  assert.equal(audit.safety.launcherExecution, false);
+  assert.equal(audit.safety.pccxLabExecution, false);
+  assert.equal(audit.safety.pccxLabValidatorInvocation, false);
+  assert.equal(audit.safety.providerCalls, false);
+  assert.equal(audit.safety.runtimeCalls, false);
+  assert.equal(audit.safety.mcpCalls, false);
+  assert.equal(audit.safety.lspImplemented, false);
+  assert.equal(audit.safety.marketplaceFlow, false);
+  assert.equal(audit.safety.telemetry, false);
+  assert.equal(audit.safety.automaticUpload, false);
+  assert.equal(audit.safety.writeBack, false);
+}
+
+function assertFailedCheck(audit, id) {
+  assert.equal(audit.status, "failed");
+  assert.equal(audit.eligibleForApprovedRunner, false);
+  assert.equal(checkById(audit, id)?.status, "fail");
+  assert.match(audit.blockedReason, new RegExp(id));
+}
+
+function testAllowedProposalAuditPasses() {
+  const first = createValidationProposalPreflightAudit("vscodeAdapterSmoke");
+  const second = createValidationProposalPreflightAudit({ proposalId: "vscodeAdapterSmoke" });
+  const text = formatValidationProposalPreflightAudit(first);
+
+  assertAuditShape(first);
+  assert.deepEqual(first, second);
+  assert.equal(first.proposalId, "vscodeAdapterSmoke");
+  assert.equal(first.status, "passed");
+  assert.equal(first.eligibleForApprovedRunner, true);
+  assert.equal(first.blockedReason, "");
+  assert.ok(first.checks.every((check) => check.status === "pass"));
+  assert.equal(first.diagnosticsHandoff.status, "unavailable");
+  assert.equal(first.diagnosticsHandoff.contextOnly, true);
+  assert.equal(first.diagnosticsHandoff.executionInput, false);
+  assert.match(text, /Validation Proposal Preflight Audit/);
+  assert.match(text, /eligibleForApprovedRunner: yes/);
+  assert.match(text, /execution: no command executed/);
+  assert.doesNotMatch(text, /\/home\/|TOKEN=/);
+}
+
+function testUnknownProposalIdAuditFails() {
+  const audit = createValidationProposalPreflightAudit("missingProposal");
+
+  assertAuditShape(audit);
+  assertFailedCheck(audit, "proposal-id-exists");
+  assertFailedCheck(audit, "command-allowlist");
+}
+
+function testMalformedProposalAuditFails() {
+  const audit = createValidationProposalPreflightAudit({
+    id: "vscodeAdapterSmoke",
+    command: "bash scripts/vscode-adapter-smoke.sh",
+  });
+
+  assertAuditShape(audit);
+  assertFailedCheck(audit, "proposal-shape");
+  assertFailedCheck(audit, "command-allowlist");
+  assertFailedCheck(audit, "no-raw-shell");
+}
+
+function testDiagnosticsHandoffContextsRemainContextOnly() {
+  const availableBundle = buildContextBundle({
+    diagnosticsHandoffSummary: cloneDefaultDiagnosticsHandoffConsumerSummary(),
+  });
+  const unavailableBundle = buildContextBundle({});
+  const unsafeSurface = createDiagnosticsHandoffStatusSurface(
+    cloneDefaultDiagnosticsHandoffConsumerSummary(),
+  );
+  unsafeSurface.safety.pccxLabExecution = true;
+  const invalidBundle = buildContextBundle({
+    diagnosticsHandoffStatus: unsafeSurface,
+  });
+  const available = createValidationProposalPreflightAudit({
+    proposalId: "vscodeAdapterSmoke",
+    contextBundle: availableBundle,
+  });
+  const unavailable = createValidationProposalPreflightAudit({
+    proposalId: "vscodeAdapterSmoke",
+    contextBundle: unavailableBundle,
+  });
+  const invalid = createValidationProposalPreflightAudit({
+    proposalId: "vscodeAdapterSmoke",
+    contextBundle: invalidBundle,
+  });
+
+  for (const audit of [available, unavailable, invalid]) {
+    assertAuditShape(audit);
+    assert.equal(audit.status, "passed");
+    assert.equal(checkById(audit, "diagnostics-handoff-context-only").status, "pass");
+    assert.equal(audit.diagnosticsHandoff.contextOnly, true);
+    assert.equal(audit.diagnosticsHandoff.executionInput, false);
+    assert.equal(audit.findings.diagnosticsHandoffExecutionInput, false);
+  }
+  assert.equal(available.diagnosticsHandoff.status, "available");
+  assert.equal(available.diagnosticsHandoff.summaryAvailable, true);
+  assert.equal(unavailable.diagnosticsHandoff.status, "unavailable");
+  assert.equal(unavailable.diagnosticsHandoff.summaryAvailable, false);
+  assert.equal(invalid.diagnosticsHandoff.status, "invalid");
+  assert.equal(invalid.diagnosticsHandoff.summaryAvailable, false);
+}
+
+function testLauncherExecutionIsBlocked() {
+  const proposal = cloneProposal();
+  proposal.command.argv = ["pccx-llm-launcher", "run"];
+
+  const audit = createValidationProposalPreflightAudit({ proposal });
+
+  assertAuditShape(audit);
+  assertFailedCheck(audit, "command-allowlist");
+  assertFailedCheck(audit, "no-launcher-command");
+  assert.equal(audit.findings.launcherCommand, true);
+}
+
+function testPccxLabExecutionIsBlocked() {
+  const proposal = cloneProposal();
+  proposal.command.argv = ["pccx-lab", "diagnostics"];
+
+  const audit = createValidationProposalPreflightAudit({ proposal });
+
+  assertAuditShape(audit);
+  assertFailedCheck(audit, "command-allowlist");
+  assertFailedCheck(audit, "no-pccx-lab-command");
+  assert.equal(audit.findings.pccxLabCommand, true);
+}
+
+function testPccxLabValidatorInvocationIsBlocked() {
+  const proposal = cloneProposal();
+  proposal.command.argv = ["pccx-lab", "diagnostics-handoff", "validate"];
+
+  const audit = createValidationProposalPreflightAudit({ proposal });
+
+  assertAuditShape(audit);
+  assertFailedCheck(audit, "command-allowlist");
+  assertFailedCheck(audit, "no-pccx-lab-command");
+  assertFailedCheck(audit, "no-pccx-lab-validator");
+  assert.equal(audit.findings.pccxLabValidatorInvocation, true);
+}
+
+function testShellExecutionPathIsBlocked() {
+  const audit = createValidationProposalPreflightAudit({
+    proposalId: "vscodeAdapterSmoke",
+    command: "bash scripts/vscode-adapter-smoke.sh; rm -rf /",
+  });
+
+  assertAuditShape(audit);
+  assertFailedCheck(audit, "no-raw-shell");
+  assert.equal(audit.findings.rawShellString, true);
+  assert.doesNotMatch(JSON.stringify(audit), /rm -rf/);
+}
+
+function testExecutionClaimWordingIsBlocked() {
+  const proposal = cloneProposal();
+  proposal.reason = "MCP runtime executes validation and KV260 provider integration works.";
+
+  const audit = createValidationProposalPreflightAudit({ proposal });
+
+  assertAuditShape(audit);
+  assertFailedCheck(audit, "no-execution-claim-wording");
+  assert.equal(audit.findings.executionClaimWording, true);
+}
+
+function testDiagnosticsHandoffExecutionInputIsBlocked() {
+  const proposal = cloneProposal();
+  proposal.command.env = {
+    PCCX_DIAGNOSTICS_HANDOFF: "pccx.diagnosticsHandoff.v0",
+  };
+
+  const audit = createValidationProposalPreflightAudit({ proposal });
+
+  assertAuditShape(audit);
+  assertFailedCheck(audit, "command-allowlist");
+  assertFailedCheck(audit, "diagnostics-handoff-context-only");
+  assert.equal(audit.findings.diagnosticsHandoffExecutionInput, true);
+}
+
+testAllowedProposalAuditPasses();
+testUnknownProposalIdAuditFails();
+testMalformedProposalAuditFails();
+testDiagnosticsHandoffContextsRemainContextOnly();
+testLauncherExecutionIsBlocked();
+testPccxLabExecutionIsBlocked();
+testPccxLabValidatorInvocationIsBlocked();
+testShellExecutionPathIsBlocked();
+testExecutionClaimWordingIsBlocked();
+testDiagnosticsHandoffExecutionInputIsBlocked();
+
+console.log("vscode validation proposal preflight audit tests ok");

--- a/scripts/vscode-adapter-smoke.sh
+++ b/scripts/vscode-adapter-smoke.sh
@@ -18,6 +18,7 @@ node editors/vscode-prototype/test/context-bundle.test.mjs
 node editors/vscode-prototype/test/selected-symbol-context.test.mjs
 node editors/vscode-prototype/test/ai-assistant-boundary.test.mjs
 node editors/vscode-prototype/test/validation-proposals.test.mjs
+node editors/vscode-prototype/test/validation-proposal-preflight-audit.test.mjs
 node editors/vscode-prototype/test/patch-proposal-contract.test.mjs
 node editors/vscode-prototype/test/patch-proposal-preview.test.mjs
 node editors/vscode-prototype/test/validation-patch-handoff.test.mjs


### PR DESCRIPTION
## Scope
- Add a deterministic validation proposal preflight audit module for the proposal-to-approved-runner boundary.
- Add a VS Code prototype review command: `pccxSystemVerilog.auditValidationProposalPreflight`.
- Gate the enabled approved runner path with the audit before `execFile` validation/execution.
- Add tests for allowed, unknown, malformed, diagnostics handoff context-only, launcher, pccx-lab, pccx-lab validator, shell, and provider/runtime/KV260/MCP/LSP/marketplace execution wording cases.
- Update docs and smoke coverage.

## Non-goals / safety boundaries
- Does not execute launcher or pccx-lab.
- Does not invoke the pccx-lab diagnostics-handoff validator.
- Does not broaden the approved runner allowlist.
- Does not add arbitrary shell execution.
- Does not add provider, runtime, KV260, MCP, LSP, marketplace, telemetry, upload, or writeback flows.
- Does not touch model weights, releases, tags, or pccx-FPGA-NPU-LLM-kv260.

## Validation
- `git diff --check`
- `python3 -m pytest -q`
- `bash scripts/vscode-adapter-smoke.sh`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh` (existing VS Code 1.90.2 runtime was already present)
- Targeted Node tests covered by the smoke and also run directly during development: validation proposal preflight audit, approved runner, diagnostics handoff/proposal, manifest/readiness, and static boundary.

## Notes
- Root `package.json` is absent and `editors/vscode-prototype/package.json` has no npm scripts, so npm test/build scripts are not applicable.