### PR TITLE
Add read-only launcher readiness context

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -175,6 +175,9 @@ The VS Code prototype includes a small adapter for
 `pccx.runtimeReadiness.v0` launcher runtime readiness JSON. The checked
 local example lives at
 `docs/examples/runtime-readiness/launcher-runtime-readiness.gemma3n-e4b-kv260.example.json`.
+This read-only context work is tracked by `pccxai/systemverilog-ide#58`
+and follows the launcher readiness contract/status work in
+`pccxai/pccx-llm-launcher#21` and `pccxai/pccx-llm-launcher#22`.
 
 The current consumed launcher answer is
 `blocked_not_yet_evidence_backed` for Gemma 3N E4B plus KV260. The

--- a/editors/vscode-prototype/docs/runtime-readiness-consumer.md
+++ b/editors/vscode-prototype/docs/runtime-readiness-consumer.md
@@ -20,6 +20,10 @@ The consumer validates the checked Gemma 3N E4B plus KV260 readiness
 fixture shape from `pccx-llm-launcher` PR #21. The current launcher
 answer is `blocked_not_yet_evidence_backed`.
 
+Coordination is tracked in `pccxai/systemverilog-ide#58`. The launcher
+status summary used by this boundary is referenced from
+`pccxai/pccx-llm-launcher#22`.
+
 The summary records:
 
 - readiness and evidence states

--- a/editors/vscode-prototype/src/runtime-readiness-consumer.mjs
+++ b/editors/vscode-prototype/src/runtime-readiness-consumer.mjs
@@ -6,6 +6,12 @@ export const RUNTIME_READINESS_CONSUMER_VERSION =
 export const RUNTIME_READINESS_SCHEMA_VERSION = "pccx.runtimeReadiness.v0";
 export const RUNTIME_READINESS_EXPECTED_STATUS_ANSWER =
   "blocked_not_yet_evidence_backed";
+const LAUNCHER_REPO_REF = ["pccxai", ["pccx-llm", "launcher"].join("-")].join("/");
+export const RUNTIME_READINESS_COORDINATION_REFS = Object.freeze([
+  "pccxai/systemverilog-ide#58",
+  `${LAUNCHER_REPO_REF}#21`,
+  `${LAUNCHER_REPO_REF}#22`,
+]);
 
 export const RUNTIME_READINESS_STATE_VALUES = Object.freeze([
   "target",
@@ -349,6 +355,7 @@ export function createRuntimeReadinessConsumerBoundaryStatus() {
     kind: "runtime-readiness-consumer-boundary",
     supportedSchemaVersion: RUNTIME_READINESS_SCHEMA_VERSION,
     expectedStatusAnswer: RUNTIME_READINESS_EXPECTED_STATUS_ANSWER,
+    coordinationRefs: [...RUNTIME_READINESS_COORDINATION_REFS],
     dataOnly: true,
     readOnly: true,
     fixtureConsumer: true,

--- a/editors/vscode-prototype/src/runtime-readiness-status-surface.mjs
+++ b/editors/vscode-prototype/src/runtime-readiness-status-surface.mjs
@@ -461,6 +461,7 @@ export function createRuntimeReadinessStatusSurface(
       version: boundary.version,
       supportedSchemaVersion: boundary.supportedSchemaVersion,
       expectedStatusAnswer: boundary.expectedStatusAnswer,
+      coordinationRefs: [...boundary.coordinationRefs],
       fixtureConsumer: boundary.fixtureConsumer,
       readOnly: boundary.readOnly,
       invokesLauncher: boundary.invokesLauncher,

--- a/editors/vscode-prototype/test/runtime-readiness-consumer.test.mjs
+++ b/editors/vscode-prototype/test/runtime-readiness-consumer.test.mjs
@@ -7,6 +7,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
+  RUNTIME_READINESS_COORDINATION_REFS,
   RUNTIME_READINESS_CONSUMER_VERSION,
   RUNTIME_READINESS_EXPECTED_STATUS_ANSWER,
   RUNTIME_READINESS_SCHEMA_VERSION,
@@ -168,6 +169,10 @@ async function testBoundaryStatusIsExecutionFree() {
   assert.equal(status.kind, "runtime-readiness-consumer-boundary");
   assert.equal(status.supportedSchemaVersion, RUNTIME_READINESS_SCHEMA_VERSION);
   assert.equal(status.expectedStatusAnswer, RUNTIME_READINESS_EXPECTED_STATUS_ANSWER);
+  assert.deepEqual(status.coordinationRefs, [...RUNTIME_READINESS_COORDINATION_REFS]);
+  assert.ok(status.coordinationRefs.includes("pccxai/systemverilog-ide#58"));
+  assert.ok(status.coordinationRefs.includes("pccxai/pccx-llm-launcher#21"));
+  assert.ok(status.coordinationRefs.includes("pccxai/pccx-llm-launcher#22"));
   assert.equal(status.dataOnly, true);
   assert.equal(status.readOnly, true);
   assert.equal(status.fixtureConsumer, true);

--- a/editors/vscode-prototype/test/runtime-readiness-status-surface.test.mjs
+++ b/editors/vscode-prototype/test/runtime-readiness-status-surface.test.mjs
@@ -98,6 +98,11 @@ async function testSafetyFlagsRemainDataOnly() {
   assert.equal(surface.boundary.invokesPccxLab, false);
   assert.equal(surface.boundary.accessesFpgaRepo, false);
   assert.equal(surface.boundary.kv260RuntimeExecution, false);
+  assert.deepEqual(surface.boundary.coordinationRefs, [
+    "pccxai/systemverilog-ide#58",
+    "pccxai/pccx-llm-launcher#21",
+    "pccxai/pccx-llm-launcher#22",
+  ]);
 }
 
 async function testDeterministicJsonAndTextOutput() {


### PR DESCRIPTION
## Summary

Adds issue #58 and launcher PR refs to the read-only launcher runtime readiness context boundary.

The current Gemma 3N E4B + KV260 state remains blocked / not yet evidence-backed. 20 tok/s is still target-only and unmeasured.

## Scope

- Keep the existing data-only readiness consumer/status path.
- Carry coordination refs in boundary/status metadata.
- Update docs for the issue #58 coordination point.
- Add tests for the coordination refs.

## Non-goals

- No pccx-llm-launcher execution.
- No pccx-lab invocation.
- No KV260 hardware access.
- No model/runtime/provider execution.
- No MCP, LSP, marketplace, release, or tag work.
- No readiness, timing closure, bitstream, runtime, or throughput achievement claim.

## Validation

- `git diff --check`
- `python3 -m pytest -q`
- `bash scripts/vscode-adapter-smoke.sh`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `node editors/vscode-prototype/test/runtime-readiness-consumer.test.mjs`
- `node editors/vscode-prototype/test/runtime-readiness-status-surface.test.mjs`
- `node editors/vscode-prototype/test/context-bundle.test.mjs`
- `PCCX_RUN_EXTENSION_HOST_SMOKE=1 bash scripts/vscode-extension-host-smoke.sh`
