### PR TITLE
Add SystemVerilog IDE roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ in [`docs/PROJECT_DIRECTION_AND_STYLE.md`](./docs/PROJECT_DIRECTION_AND_STYLE.md
 New code files and changed legacy code files are expected to carry the
 repository SPDX/Copyright header.
 
+The initial Now / Next / Later roadmap is tracked in
+[`docs/ROADMAP.md`](./docs/ROADMAP.md).
+
 ## Integration model
 
 `pccx-lab` is **CLI-first**. The IDE consumes the same CLI / core
@@ -188,6 +191,9 @@ The current pre-stable envelope shape is described in
 [`schema/diagnostics-v0.json`](./schema/diagnostics-v0.json).
 Handoff notes for the eventual `pccx-lab` and xsim integration paths
 live in [`docs/HANDOFF.md`](./docs/HANDOFF.md).
+The initial roadmap for navigation, diagnostics, read-only handoff
+surfaces, external editor planning, and later workflow tracks lives in
+[`docs/ROADMAP.md`](./docs/ROADMAP.md).
 The diagnostics/xsim planning boundary for the shared schema draft,
 read-only log path, and text surface sketches is documented in
 [`docs/DIAGNOSTICS_XSIM_INTEGRATION_PLAN.md`](./docs/DIAGNOSTICS_XSIM_INTEGRATION_PLAN.md).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,80 @@
+# SystemVerilog IDE Roadmap
+
+This roadmap keeps `systemverilog-ide` aligned with the PCCX tooling
+stack while the editor surface is still pre-stable. The repository is an
+editor cockpit spun out of `pccx-lab`; reusable analysis and validation
+behavior stays behind the `pccx-lab` CLI/core boundary.
+
+Direction and safety rules remain pinned in
+[`PROJECT_DIRECTION_AND_STYLE.md`](./PROJECT_DIRECTION_AND_STYLE.md).
+The external editor bridge shape is documented in
+[`EDITOR_BRIDGE_CONTRACT.md`](./EDITOR_BRIDGE_CONTRACT.md), and the
+cross-repo handoff notes live in [`HANDOFF.md`](./HANDOFF.md).
+
+## Now
+
+- Keep the Python CLI scaffold focused on diagnostics, declaration
+  indexing, declaration lookup, and editor problem export.
+- Keep the VS Code prototype in checked-example mode by default, with
+  live workspace commands gated by explicit local configuration.
+- Surface pccx-lab and launcher data only through checked, read-only
+  adapter boundaries:
+  - diagnostics handoff summaries
+  - runtime readiness summaries
+  - device/session status summaries
+  - existing xsim problem summaries
+- Preserve the fixed-command, no-shell, bounded-output model for approved
+  validation runner work.
+- Keep documentation explicit that current JSON shapes are pre-stable and
+  may change while the lab boundary matures.
+
+## Next
+
+- Expand project-aware navigation without claiming full semantic
+  SystemVerilog parsing or LSP coverage.
+- Continue diagnostics/xsim handoff planning through existing local JSON
+  and text surfaces; reusable xsim execution remains owned by pccx-lab.
+- Add editor-facing workflow notes for validation proposal preflight,
+  result summary, and reviewed patch handoff.
+- Cross-link IDE workflow planning to the pccx-lab roadmap items:
+  - [`pccx-lab#21`](https://github.com/pccxai/pccx-lab/issues/21) for the
+    future plugin-system boundary
+  - [`pccx-lab#22`](https://github.com/pccxai/pccx-lab/issues/22) for the
+    controlled MCP/tool boundary
+- Keep external editor planning separate from any stable extension API or
+  marketplace packaging claim.
+
+## Later
+
+- Plan a local coding-assistant workflow that uses bounded context,
+  reviewed proposals, and user-approved validation steps.
+- Plan an evolutionary generate / simulate / evaluate / refine loop on top
+  of the pccx-lab CLI/core boundary.
+- Sketch external editor bridges beyond the local VS Code prototype only
+  after the shared data contracts are clearer.
+- Evaluate future plugin and MCP/tool integration through pccx-lab-owned
+  boundaries before adding editor presentation.
+
+## Out Of Scope
+
+- No Vivado replacement claim.
+- No full LSP implementation claim.
+- No stable API/ABI or stable plugin ABI claim.
+- No published VS Code extension or marketplace-ready claim.
+- No launcher execution from this repository.
+- No pccx-lab execution from this repository unless a later PR explicitly
+  extends an allowlisted, reviewed boundary.
+- No MCP runtime implementation in this repository.
+- No AI provider integration.
+- No KV260 runtime integration, hardware access, model loading, or
+  throughput/performance claim.
+- No automatic merge, public push, release, tag, upload, telemetry, or
+  write-back flow.
+
+## Issue Alignment
+
+This document addresses
+[`systemverilog-ide#1`](https://github.com/pccxai/systemverilog-ide/issues/1)
+by recording a Now / Next / Later roadmap, linking the pccx-lab plugin and
+MCP/tool roadmap items, and keeping the current status language bounded to
+pre-stable editor and data-contract work.


### PR DESCRIPTION
## Summary

- Add `docs/ROADMAP.md` with Now / Next / Later tracks for the SystemVerilog IDE spin-out.
- Link the roadmap from the README.
- Cross-link the pccx-lab plugin and controlled MCP/tool roadmap issues while keeping the IDE scope pre-stable and data-boundary-first.

Closes #1

## Safety

This is documentation only. It does not add launcher execution, pccx-lab execution, xsim/Vivado execution, MCP runtime code, provider calls, hardware access, model loading, telemetry, upload, release/tag behavior, or write-back flows. It keeps stable API/ABI, marketplace, runtime, KV260, timing, and performance wording out of scope.

## Validation

- `python3 scripts/check-source-headers.py`
- `python3 -m pytest -q`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- local claim-scan matching `.github/workflows/ci.yml`
- `git diff --check`
- `git diff --cached --check`
