### PR TITLE
Add AI-assisted SystemVerilog workflow plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ repository SPDX/Copyright header.
 
 The initial Now / Next / Later roadmap is tracked in
 [`docs/ROADMAP.md`](./docs/ROADMAP.md).
+The AI-assisted SystemVerilog workflow planning boundary is tracked in
+[`docs/AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md`](./docs/AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md).
 
 ## Integration model
 
@@ -194,6 +196,9 @@ live in [`docs/HANDOFF.md`](./docs/HANDOFF.md).
 The initial roadmap for navigation, diagnostics, read-only handoff
 surfaces, external editor planning, and later workflow tracks lives in
 [`docs/ROADMAP.md`](./docs/ROADMAP.md).
+The planned AI-assisted SystemVerilog workflow, permission boundary, and
+pccx-lab controlled MCP/tool dependency are documented in
+[`docs/AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md`](./docs/AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md).
 The diagnostics/xsim planning boundary for the shared schema draft,
 read-only log path, and text surface sketches is documented in
 [`docs/DIAGNOSTICS_XSIM_INTEGRATION_PLAN.md`](./docs/DIAGNOSTICS_XSIM_INTEGRATION_PLAN.md).

--- a/docs/AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md
+++ b/docs/AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md
@@ -1,0 +1,116 @@
+# AI-Assisted SystemVerilog Workflow
+
+This document is a planning boundary for the future AI-assisted
+SystemVerilog development workflow hosted by `systemverilog-ide`. The
+IDE remains an editor cockpit over controlled data and command contracts;
+reusable analysis, validation, and simulation behavior stays behind the
+`pccx-lab` CLI/core boundary.
+
+This is not a model integration, not an MCP runtime implementation, not
+an LSP implementation, and not a stable API/ABI. It is a workflow shape
+for reviewed proposals, explicit user approval, and bounded local
+validation.
+
+## Related Boundaries
+
+- [`ROADMAP.md`](./ROADMAP.md) tracks the repository Now / Next / Later
+  direction.
+- [`EDITOR_BRIDGE_CONTRACT.md`](./EDITOR_BRIDGE_CONTRACT.md) describes
+  the pre-stable editor JSON surfaces.
+- [`HANDOFF.md`](./HANDOFF.md) records cross-repo handoff paths.
+- [`pccx-lab#22`](https://github.com/pccxai/pccx-lab/issues/22) tracks
+  the controlled MCP/tool interface that future automation should use.
+
+## Roles
+
+- User: reviews context, approves writes, approves validation, and owns
+  any public repository action.
+- IDE: gathers bounded context, presents diagnostics/navigation/status,
+  renders proposals, and records local validation summaries.
+- pccx-lab: owns reusable analysis, verification, trace/report handling,
+  and any future controlled tool execution boundary.
+- pccx-llm-launcher: remains a future local assistant/backend candidate;
+  this repository does not call it today.
+
+## Workflow
+
+1. Read project context.
+   The IDE builds bounded context from selected files, diagnostics,
+   declarations, recent validation summaries, and checked handoff/status
+   surfaces. Context excludes secret-like data, private paths where a
+   workspace root is known, full logs, generated blobs, model paths, and
+   repository-wide dumps.
+
+2. Propose a change.
+   AI-assisted tooling may return a proposal object with repository-
+   relative paths, bounded hunk previews, rationale, affected symbols,
+   and suggested validation. The proposal is data only. It does not write
+   files, apply patches, run commands, or create commits.
+
+3. Run analysis.
+   Current analysis surfaces are local diagnostics, declaration
+   navigation, editor problem exports, checked handoff summaries, and
+   explicitly configured approved validation commands. Any future
+   pccx-lab-backed analysis must use reviewed CLI/core contracts.
+
+4. Run simulation or validation.
+   Simulation remains a pccx-lab-owned or tool-owned execution path. The
+   IDE may propose allowlisted validation commands and may show local
+   summaries after explicit approval. It must not run raw shell commands,
+   silently start xsim/Vivado, invoke pccx-lab outside a reviewed
+   boundary, or bypass the controlled tool interface.
+
+5. Summarize result.
+   The IDE may summarize diagnostics, pass/fail status, bounded output,
+   and next proposal context. Summaries stay local unless the user chooses
+   to publish or commit them.
+
+## Permission Boundary
+
+| Action | Default | Boundary |
+|---|---:|---|
+| Read selected context | Allowed | Bounded context builder only |
+| Read full workspace | Blocked | Requires a narrower explicit selection |
+| Propose patch | Allowed | Data-only proposal, bounded preview |
+| Apply patch | Blocked | User-approved edit path required |
+| Run validation | Blocked | Explicit allowlisted runner approval required |
+| Run pccx-lab | Blocked | Future reviewed CLI/core boundary only |
+| Run xsim or Vivado | Blocked | Future reviewed validation boundary only |
+| Call pccx-llm-launcher | Blocked | Future reviewed launcher contract only |
+| Call an AI provider | Blocked | Outside this repository's current scope |
+| Implement MCP runtime | Blocked | Tracked separately by pccx-lab #22 |
+| Commit, push, merge, release, or tag | Blocked | User-owned repository action |
+| Access secrets or staging notes | Blocked | Never part of the IDE workflow |
+
+## Implementation Notes
+
+- Keep checked-example mode as the safe default.
+- Keep live workspace behavior opt-in and explicitly configured.
+- Keep proposal objects deterministic and bounded.
+- Keep validation command execution behind fixed argument arrays,
+  `shell=false`, bounded output, timeouts, and proposal IDs.
+- Keep patch previews and validation summaries local and summary-only.
+- Keep pccx-lab command descriptors as data until the owning repo exposes
+  a reviewed CLI/core command map.
+- Keep MCP/tool integration as a future pccx-lab-owned boundary rather
+  than an IDE-owned back channel.
+
+## Non-Goals
+
+- No vendor-specific AI naming in public user-facing docs.
+- No autonomous merge, push, release, or tag flow.
+- No automatic file writes from proposal data.
+- No raw shell execution.
+- No pccx-lab execution from this repository today.
+- No xsim/Vivado execution from this repository today.
+- No provider calls, launcher runtime calls, hardware access, model
+  loading, telemetry, upload, or write-back flow.
+- No production-ready, stable API/ABI, stable plugin ABI, LSP,
+  marketplace-ready, runtime, timing, or performance claim.
+
+## Issue Alignment
+
+This document addresses
+[`systemverilog-ide#4`](https://github.com/pccxai/systemverilog-ide/issues/4)
+by recording the workflow steps, stating the permission boundary, and
+linking the future controlled MCP/tool boundary in `pccx-lab#22`.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -18,6 +18,8 @@ Tracked handoff paths:
 
 Direction and style rules for preserving those boundaries are pinned in
 [`PROJECT_DIRECTION_AND_STYLE.md`](./PROJECT_DIRECTION_AND_STYLE.md).
+The AI-assisted SystemVerilog workflow planning boundary is documented in
+[`AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md`](./AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md).
 The diagnostics/xsim planning boundary for issue #3 is tracked in
 [`DIAGNOSTICS_XSIM_INTEGRATION_PLAN.md`](./DIAGNOSTICS_XSIM_INTEGRATION_PLAN.md).
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -35,7 +35,9 @@ cross-repo handoff notes live in [`HANDOFF.md`](./HANDOFF.md).
 - Continue diagnostics/xsim handoff planning through existing local JSON
   and text surfaces; reusable xsim execution remains owned by pccx-lab.
 - Add editor-facing workflow notes for validation proposal preflight,
-  result summary, and reviewed patch handoff.
+  result summary, and reviewed patch handoff. The AI-assisted workflow
+  planning boundary is tracked in
+  [`AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md`](./AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md).
 - Cross-link IDE workflow planning to the pccx-lab roadmap items:
   - [`pccx-lab#21`](https://github.com/pccxai/pccx-lab/issues/21) for the
     future plugin-system boundary


### PR DESCRIPTION
## Summary

- Add `docs/AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md` with the future AI-assisted SystemVerilog workflow shape.
- Document the permission boundary for context, proposals, validation, pccx-lab, xsim/Vivado, launcher, provider, MCP/tool, and repository actions.
- Link the workflow plan from the README, roadmap, and handoff notes.

Closes #4

## Safety

This is documentation only. It does not add launcher execution, pccx-lab execution, xsim/Vivado execution, MCP runtime code, provider calls, hardware access, model loading, telemetry, upload, release/tag behavior, or write-back flows. User approval remains required for writes and validation, and repository actions stay user-owned.

## Validation

- `python3 scripts/check-source-headers.py`
- `python3 -m pytest -q`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- local claim-scan matching `.github/workflows/ci.yml`
- `git diff --check`
- `git diff --cached --check`
