### PR TITLE
Add evolutionary loop plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The initial Now / Next / Later roadmap is tracked in
 [`docs/ROADMAP.md`](./docs/ROADMAP.md).
 The AI-assisted SystemVerilog workflow planning boundary is tracked in
 [`docs/AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md`](./docs/AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md).
+The evolutionary generate / simulate / evaluate / refine loop plan is
+tracked in [`docs/EVOLUTIONARY_LOOP_PLAN.md`](./docs/EVOLUTIONARY_LOOP_PLAN.md).
 
 ## Integration model
 
@@ -199,6 +201,8 @@ surfaces, external editor planning, and later workflow tracks lives in
 The planned AI-assisted SystemVerilog workflow, permission boundary, and
 pccx-lab controlled MCP/tool dependency are documented in
 [`docs/AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md`](./docs/AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md).
+The deferred evolutionary loop plan and fitness-criteria sketch are
+documented in [`docs/EVOLUTIONARY_LOOP_PLAN.md`](./docs/EVOLUTIONARY_LOOP_PLAN.md).
 The diagnostics/xsim planning boundary for the shared schema draft,
 read-only log path, and text surface sketches is documented in
 [`docs/DIAGNOSTICS_XSIM_INTEGRATION_PLAN.md`](./docs/DIAGNOSTICS_XSIM_INTEGRATION_PLAN.md).

--- a/docs/AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md
+++ b/docs/AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md
@@ -18,6 +18,8 @@ validation.
 - [`EDITOR_BRIDGE_CONTRACT.md`](./EDITOR_BRIDGE_CONTRACT.md) describes
   the pre-stable editor JSON surfaces.
 - [`HANDOFF.md`](./HANDOFF.md) records cross-repo handoff paths.
+- [`EVOLUTIONARY_LOOP_PLAN.md`](./EVOLUTIONARY_LOOP_PLAN.md) sketches the
+  deferred generate / simulate / evaluate / refine loop.
 - [`pccx-lab#22`](https://github.com/pccxai/pccx-lab/issues/22) tracks
   the controlled MCP/tool interface that future automation should use.
 

--- a/docs/EVOLUTIONARY_LOOP_PLAN.md
+++ b/docs/EVOLUTIONARY_LOOP_PLAN.md
@@ -1,0 +1,117 @@
+# Evolutionary Loop Plan
+
+This document sketches a future generate / simulate / evaluate / refine
+loop for SystemVerilog exploration in `systemverilog-ide`. The loop is a
+planning boundary only. It does not add command execution, pccx-lab
+execution, xsim/Vivado execution, MCP runtime behavior, provider calls,
+or automatic repository changes.
+
+The IDE remains the editor cockpit. `pccx-lab` remains the owner of
+reusable analysis, verification, trace handling, and any future reviewed
+simulation/tool execution boundary.
+
+## Related Boundaries
+
+- [`AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md`](./AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md)
+  defines the proposal and permission model.
+- [`ROADMAP.md`](./ROADMAP.md) records the repository roadmap.
+- [`HANDOFF.md`](./HANDOFF.md) records the pccx-lab handoff boundaries.
+- [`pccx-lab#22`](https://github.com/pccxai/pccx-lab/issues/22) tracks
+  the controlled MCP/tool interface that any future automation should use.
+
+## Loop Architecture
+
+```text
+bounded editor context
+  -> candidate proposal
+  -> user review
+  -> allowlisted validation request
+  -> pccx-lab-owned analysis or simulation boundary
+  -> bounded result summary
+  -> next proposal context
+```
+
+### Generate
+
+The generate step proposes candidate edits as data:
+
+- repository-relative file paths
+- bounded hunk previews
+- rationale and expected impact
+- affected module/package/interface names
+- proposed validation plan
+- known risk notes
+
+The proposal does not write files, apply patches, run tools, create
+commits, push branches, or publish results.
+
+### Simulate
+
+The simulate step is a future reviewed boundary, not an IDE-owned
+execution path. The IDE may request an allowlisted validation proposal,
+but reusable command execution belongs behind pccx-lab or tool-specific
+contracts.
+
+The safe default is read-only status and checked examples. Any later
+simulation path must keep:
+
+- fixed executable and argument shapes
+- no shell interpolation
+- explicit user approval
+- bounded stdout/stderr summaries
+- timeouts and cancellation behavior
+- no hardware or KV260 runtime side effects
+- no raw log upload or telemetry
+
+### Evaluate
+
+The evaluate step scores candidate results using bounded, reviewable
+signals. Candidate fitness can combine:
+
+- parse/check status
+- diagnostic count by severity
+- expected module/declaration changes
+- test or smoke status where an allowlisted validation ran
+- xsim/Vivado log summaries where an approved boundary produced them
+- waveform or trace delta summaries, if pccx-lab later exposes a checked
+  report shape
+- resource or timing-report status as reported evidence, without turning
+  a target into an achieved claim
+- reviewer notes and manual risk flags
+
+The IDE should present these as summary data. It should not infer hardware
+correctness, timing closure, runtime readiness, or performance success.
+
+### Refine
+
+The refine step creates the next bounded proposal context from:
+
+- the prior candidate summary
+- diagnostics near changed regions
+- validation-result summaries
+- reviewer-selected notes
+- explicit follow-up constraints
+
+Refinement does not auto-apply patches, re-run validation, push branches,
+merge PRs, or publish reports.
+
+## Safety Boundary
+
+| Boundary | Rule |
+|---|---|
+| Evaluation mode | Read-only by default |
+| Candidate promotion | Manual review and explicit user action |
+| Patch application | Outside this planning loop until user-approved |
+| Validation execution | Allowlisted runner or future pccx-lab boundary only |
+| Simulation execution | Future reviewed pccx-lab/tool boundary only |
+| Public reporting | User-reviewed PR, issue, or docs text only |
+| Repository actions | No automatic commit, push, merge, release, or tag |
+| Hardware/runtime | No KV260 runtime, model loading, provider calls, or hardware access |
+| Secrets/private data | Excluded from context and public output |
+
+## Issue Alignment
+
+This document addresses
+[`systemverilog-ide#5`](https://github.com/pccxai/systemverilog-ide/issues/5)
+by recording the loop architecture, fitness criteria, and safety boundary
+for read-only evaluation with manual promotion.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -20,6 +20,8 @@ Direction and style rules for preserving those boundaries are pinned in
 [`PROJECT_DIRECTION_AND_STYLE.md`](./PROJECT_DIRECTION_AND_STYLE.md).
 The AI-assisted SystemVerilog workflow planning boundary is documented in
 [`AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md`](./AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md).
+The evolutionary loop planning boundary is documented in
+[`EVOLUTIONARY_LOOP_PLAN.md`](./EVOLUTIONARY_LOOP_PLAN.md).
 The diagnostics/xsim planning boundary for issue #3 is tracked in
 [`DIAGNOSTICS_XSIM_INTEGRATION_PLAN.md`](./DIAGNOSTICS_XSIM_INTEGRATION_PLAN.md).
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -51,7 +51,9 @@ cross-repo handoff notes live in [`HANDOFF.md`](./HANDOFF.md).
 - Plan a local coding-assistant workflow that uses bounded context,
   reviewed proposals, and user-approved validation steps.
 - Plan an evolutionary generate / simulate / evaluate / refine loop on top
-  of the pccx-lab CLI/core boundary.
+  of the pccx-lab CLI/core boundary. The loop architecture and
+  fitness-criteria sketch are tracked in
+  [`EVOLUTIONARY_LOOP_PLAN.md`](./EVOLUTIONARY_LOOP_PLAN.md).
 - Sketch external editor bridges beyond the local VS Code prototype only
   after the shared data contracts are clearer.
 - Evaluate future plugin and MCP/tool integration through pccx-lab-owned


### PR DESCRIPTION
## Summary

- Add `docs/EVOLUTIONARY_LOOP_PLAN.md` with the future generate / simulate / evaluate / refine loop architecture.
- Document candidate fitness criteria and the read-only evaluation / manual promotion safety boundary.
- Link the plan from the README, roadmap, handoff notes, and AI-assisted workflow plan.

Closes #5

## Safety

This is documentation only. It does not add command execution, pccx-lab execution, xsim/Vivado execution, MCP runtime code, provider calls, hardware access, KV260 runtime, model loading, telemetry, upload, release/tag behavior, write-back flows, or automatic repository actions.

## Validation

- `python3 scripts/check-source-headers.py`
- `python3 -m pytest -q`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- local claim-scan matching `.github/workflows/ci.yml`
- `git diff --check`
- `git diff --cached --check`
