### PR TITLE
Add external editor integration plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ The AI-assisted SystemVerilog workflow planning boundary is tracked in
 [`docs/AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md`](./docs/AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md).
 The evolutionary generate / simulate / evaluate / refine loop plan is
 tracked in [`docs/EVOLUTIONARY_LOOP_PLAN.md`](./docs/EVOLUTIONARY_LOOP_PLAN.md).
+The later-track external editor integration plan is tracked in
+[`docs/EXTERNAL_EDITOR_INTEGRATION_PLAN.md`](./docs/EXTERNAL_EDITOR_INTEGRATION_PLAN.md).
 
 ## Integration model
 
@@ -203,6 +205,9 @@ pccx-lab controlled MCP/tool dependency are documented in
 [`docs/AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md`](./docs/AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md).
 The deferred evolutionary loop plan and fitness-criteria sketch are
 documented in [`docs/EVOLUTIONARY_LOOP_PLAN.md`](./docs/EVOLUTIONARY_LOOP_PLAN.md).
+The external editor integration direction for VS Code and other editor
+families is documented in
+[`docs/EXTERNAL_EDITOR_INTEGRATION_PLAN.md`](./docs/EXTERNAL_EDITOR_INTEGRATION_PLAN.md).
 The diagnostics/xsim planning boundary for the shared schema draft,
 read-only log path, and text surface sketches is documented in
 [`docs/DIAGNOSTICS_XSIM_INTEGRATION_PLAN.md`](./docs/DIAGNOSTICS_XSIM_INTEGRATION_PLAN.md).

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -7,6 +7,10 @@ It is not an LSP server, a published VS Code extension, a JetBrains
 plugin, or a stable ABI/API.  Treat all JSON shapes as subject to change
 while the `pccx-lab` boundary and IDE surface mature.
 
+The later-track VS Code, JetBrains, and generic editor bridge direction is
+tracked in
+[`EXTERNAL_EDITOR_INTEGRATION_PLAN.md`](./EXTERNAL_EDITOR_INTEGRATION_PLAN.md).
+
 ## Intended Consumers
 
 - The experimental local VS Code extension scaffold.

--- a/docs/EXTERNAL_EDITOR_INTEGRATION_PLAN.md
+++ b/docs/EXTERNAL_EDITOR_INTEGRATION_PLAN.md
@@ -1,0 +1,92 @@
+# External Editor Integration Plan
+
+This document sketches the later-track plan for bringing
+`systemverilog-ide` data surfaces to VS Code and other editors without
+making this repository VS Code-only. The current repository remains
+pre-stable: it has an experimental local VS Code prototype and checked
+editor-bridge examples, but it does not publish an extension, implement
+LSP, or claim a stable extension API.
+
+## Integration Principle
+
+External editors should consume the same small JSON contracts that the
+local CLI and prototype already use. Editor-specific code should map
+those contracts into native UI records without duplicating analysis,
+validation, or simulation logic.
+
+```text
+pccx_ide_cli JSON output
+  -> editor bridge adapter
+  -> editor-native diagnostics, navigation, status, and proposal UI
+```
+
+Reusable analysis and verification behavior stays behind the pccx-lab
+CLI/core boundary. The IDE may present pccx-lab and launcher status data
+through checked read-only adapters, but it must not invoke those tools
+outside a reviewed allowlisted boundary.
+
+## Target Editor Families
+
+### VS Code
+
+VS Code remains the local prototype path:
+
+- checked examples are the default
+- live workspace mode is explicit opt-in
+- Extension Host runtime smoke remains opt-in and local-only
+- command handlers remain thin wrappers over the facade
+- presenter behavior stays mockable and testable without GUI automation
+
+This is not a published extension or marketplace package.
+
+### JetBrains And Other Editors
+
+Future JetBrains or other editor bridges should start with adapter
+contracts, not IDE-specific logic:
+
+- consume diagnostics/problem JSON
+- consume declaration/index/locate JSON
+- consume bounded status/context summaries
+- map data to editor-native diagnostics, navigation, and panel models
+- keep writes and validation behind explicit user approval
+
+No editor bridge should receive a privileged back channel into pccx-lab,
+pccx-llm-launcher, hardware, provider calls, or private repository state.
+
+## Contract Surfaces
+
+Initial bridge surfaces are:
+
+- `pccx_ide_cli check`
+- `pccx_ide_cli problems from-check`
+- `pccx_ide_cli problems from-xsim-log`
+- `pccx_ide_cli index`
+- `pccx_ide_cli declarations`
+- `pccx_ide_cli locate`
+- checked launcher/lab handoff status summaries consumed by the VS Code
+  prototype
+- proposal and validation-result summaries where they remain data only
+
+All shapes remain pre-stable. Consumers should keep adapter layers small
+and treat schema drift as a normal development concern until the
+pccx-lab boundary is formal enough to bind to.
+
+## Safety Boundary
+
+- No stable extension API claim.
+- No LSP implementation claim.
+- No marketplace-ready claim.
+- No pccx-lab execution from editor adapters.
+- No launcher execution from editor adapters.
+- No xsim/Vivado execution from editor adapters.
+- No provider calls, telemetry, upload, or write-back flow.
+- No hardware access, KV260 runtime, model loading, or performance claim.
+- No automatic commit, push, merge, release, or tag action.
+
+## Issue Alignment
+
+This document addresses
+[`systemverilog-ide#9`](https://github.com/pccxai/systemverilog-ide/issues/9)
+by recording the VS Code, JetBrains/other editor, and generic data-bridge
+direction while keeping extension APIs pre-stable and dependent on the
+pccx-lab CLI/core boundary maturing first.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -22,6 +22,8 @@ The AI-assisted SystemVerilog workflow planning boundary is documented in
 [`AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md`](./AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md).
 The evolutionary loop planning boundary is documented in
 [`EVOLUTIONARY_LOOP_PLAN.md`](./EVOLUTIONARY_LOOP_PLAN.md).
+The external editor integration planning boundary is documented in
+[`EXTERNAL_EDITOR_INTEGRATION_PLAN.md`](./EXTERNAL_EDITOR_INTEGRATION_PLAN.md).
 The diagnostics/xsim planning boundary for issue #3 is tracked in
 [`DIAGNOSTICS_XSIM_INTEGRATION_PLAN.md`](./DIAGNOSTICS_XSIM_INTEGRATION_PLAN.md).
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -55,7 +55,9 @@ cross-repo handoff notes live in [`HANDOFF.md`](./HANDOFF.md).
   fitness-criteria sketch are tracked in
   [`EVOLUTIONARY_LOOP_PLAN.md`](./EVOLUTIONARY_LOOP_PLAN.md).
 - Sketch external editor bridges beyond the local VS Code prototype only
-  after the shared data contracts are clearer.
+  after the shared data contracts are clearer. The later-track bridge plan
+  is tracked in
+  [`EXTERNAL_EDITOR_INTEGRATION_PLAN.md`](./EXTERNAL_EDITOR_INTEGRATION_PLAN.md).
 - Evaluate future plugin and MCP/tool integration through pccx-lab-owned
   boundaries before adding editor presentation.
 


### PR DESCRIPTION
## Summary

- Add `docs/EXTERNAL_EDITOR_INTEGRATION_PLAN.md` for the later-track VS Code, JetBrains, and generic editor bridge direction.
- Document the pre-stable JSON contract approach and pccx-lab CLI/core dependency.
- Link the plan from the README, roadmap, handoff notes, and editor bridge contract.

Closes #9

## Safety

This is documentation only. It does not add LSP, marketplace packaging, a stable extension API, pccx-lab execution, launcher execution, xsim/Vivado execution, provider calls, telemetry, upload, hardware access, KV260 runtime, model loading, write-back flows, or automatic repository actions.

## Validation

- `python3 scripts/check-source-headers.py`
- `python3 -m pytest -q`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- local claim-scan matching `.github/workflows/ci.yml`
- `git diff --check`
- `git diff --cached --check`
