### PR TITLE
Add module organization boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ The evolutionary generate / simulate / evaluate / refine loop plan is
 tracked in [`docs/EVOLUTIONARY_LOOP_PLAN.md`](./docs/EVOLUTIONARY_LOOP_PLAN.md).
 The later-track external editor integration plan is tracked in
 [`docs/EXTERNAL_EDITOR_INTEGRATION_PLAN.md`](./docs/EXTERNAL_EDITOR_INTEGRATION_PLAN.md).
+The module organization workflow is tracked in
+[`docs/MODULE_ORGANIZATION_WORKFLOW.md`](./docs/MODULE_ORGANIZATION_WORKFLOW.md).
 
 ## Integration model
 
@@ -113,6 +115,10 @@ python -m pccx_ide_cli locate fixtures/modules/ simple_mod --format text
 # Declaration export for editor bridge consumers (pre-stable)
 python -m pccx_ide_cli declarations fixtures/modules/ --format json
 
+# Module organization export (pre-stable, read-only)
+python -m pccx_ide_cli organization fixtures/organization/hierarchy_top.sv --format json
+python -m pccx_ide_cli organization fixtures/organization/hierarchy_top.sv --format text
+
 # xsim log handoff scaffold (parses existing log files only)
 python -m pccx_ide_cli xsim-log fixtures/xsim/mixed.log --format json
 python -m pccx_ide_cli xsim-log fixtures/xsim/mixed.log --format text
@@ -162,6 +168,13 @@ not a stable API. A future editor bridge can consume this output.
 records used by `index` without the legacy module-only wrapper. It is a
 CLI bridge scaffold, not semantic resolution or a full parser.
 
+`organization` exports scanner-based module boundary spans, a small
+hierarchy seed, and proposal-only refactoring metadata. It is read-only:
+it does not edit files, apply refactors, execute validation, run vendor
+tools, invoke `pccx-lab` or the launcher, or implement semantic
+elaboration. The output shape is pre-stable and is documented in
+[`docs/MODULE_ORGANIZATION_WORKFLOW.md`](./docs/MODULE_ORGANIZATION_WORKFLOW.md).
+
 `xsim-log` is an early handoff scaffold. It parses existing synthetic
 xsim-style log files into diagnostics-like JSON or text output. It does
 not run xsim or Vivado, does not prove hardware correctness, and does
@@ -200,6 +213,9 @@ live in [`docs/HANDOFF.md`](./docs/HANDOFF.md).
 The initial roadmap for navigation, diagnostics, read-only handoff
 surfaces, external editor planning, and later workflow tracks lives in
 [`docs/ROADMAP.md`](./docs/ROADMAP.md).
+The scanner-based module organization workflow for module boundaries,
+hierarchy seeds, and proposal-only refactoring planning is documented in
+[`docs/MODULE_ORGANIZATION_WORKFLOW.md`](./docs/MODULE_ORGANIZATION_WORKFLOW.md).
 The planned AI-assisted SystemVerilog workflow, permission boundary, and
 pccx-lab controlled MCP/tool dependency are documented in
 [`docs/AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md`](./docs/AI_ASSISTED_SYSTEMVERILOG_WORKFLOW.md).

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -43,6 +43,9 @@ python -m pccx_ide_cli locate <path> <name> --kind package --format json
 python -m pccx_ide_cli locate <path> <name> --kind interface --format json
 python -m pccx_ide_cli locate <path> <name> --kind any --format json
 
+# Module organization for editor project trees
+python -m pccx_ide_cli organization <path> --format json
+
 # Opt-in pccx-lab diagnostics backend
 python -m pccx_ide_cli check <sv-file> --backend pccx-lab --format json
 ```
@@ -177,7 +180,11 @@ future/prepared in this prototype.
 `problems` converts local diagnostics and log records into editor-friendly
 problem records.  `index` provides scanner-based module/package/interface
 declaration records.  `declarations` exports those records directly, and
-`locate` resolves exact declaration names by requested kind.
+`locate` resolves exact declaration names by requested kind. `organization`
+adds scanner-based module boundary spans, hierarchy edges, root candidates,
+and proposal-only refactoring metadata for project tree and reviewed
+refactoring workflows. The organization surface is documented in
+[`MODULE_ORGANIZATION_WORKFLOW.md`](./MODULE_ORGANIZATION_WORKFLOW.md).
 
 For existing xsim logs, the VS Code prototype can consume the checked
 `problems from-xsim-log` JSON as a read-only status/context summary.  The
@@ -194,6 +201,8 @@ xsim path, and text surface sketches is documented in
 ## Limitations
 
 - Scanner-based scaffolds, not full SystemVerilog parsing.
+- Module organization is scanner-based; it is not semantic elaboration and
+  does not apply refactors.
 - No LSP server in this repository today.
 - No published editor extension or marketplace packaging is implemented
   here.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -24,6 +24,8 @@ The evolutionary loop planning boundary is documented in
 [`EVOLUTIONARY_LOOP_PLAN.md`](./EVOLUTIONARY_LOOP_PLAN.md).
 The external editor integration planning boundary is documented in
 [`EXTERNAL_EDITOR_INTEGRATION_PLAN.md`](./EXTERNAL_EDITOR_INTEGRATION_PLAN.md).
+The module organization workflow is documented in
+[`MODULE_ORGANIZATION_WORKFLOW.md`](./MODULE_ORGANIZATION_WORKFLOW.md).
 The diagnostics/xsim planning boundary for issue #3 is tracked in
 [`DIAGNOSTICS_XSIM_INTEGRATION_PLAN.md`](./DIAGNOSTICS_XSIM_INTEGRATION_PLAN.md).
 
@@ -427,6 +429,53 @@ JSON output uses:
 ```
 
 The output is pre-stable, scanner-based, and not semantic resolution.
+
+---
+
+## module organization scaffold (active, pre-stable)
+
+`pccx-ide organization` exposes scanner-based module boundary spans and a
+small hierarchy seed for editor/project organization workflows. It builds on
+the same local scanner used by `index`, `declarations`, and `locate`.
+
+```bash
+python -m pccx_ide_cli organization fixtures/organization/hierarchy_top.sv --format json
+python -m pccx_ide_cli organization fixtures/organization/hierarchy_top.sv --format text
+```
+
+JSON output uses:
+
+```json
+{
+  "kind": "module-organization",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "modules": [
+    {
+      "name": "top_mod",
+      "file": "<path>",
+      "start_line": 9,
+      "start_column": 1,
+      "end_line": 15,
+      "end_column": 1,
+      "span_lines": 7,
+      "complete": true
+    }
+  ],
+  "hierarchy": {
+    "edges": [],
+    "roots": [],
+    "unresolved": []
+  }
+}
+```
+
+The refactoring section is proposal-only and reports `writes_files: false`.
+This command does not apply refactors, move files, execute validation, invoke
+`pccx-lab`, invoke the launcher, run xsim or Vivado, access hardware, upload
+telemetry, or write back state. The full scope and limitations are tracked in
+[`MODULE_ORGANIZATION_WORKFLOW.md`](./MODULE_ORGANIZATION_WORKFLOW.md).
 
 ---
 

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -1,0 +1,125 @@
+# Module Organization Workflow
+
+## Status
+
+This is a pre-stable, scanner-based workflow for organizing modular RTL
+projects. It adds a read-only `organization` CLI surface that reports
+module boundary spans and a small hierarchy seed for editor navigation and
+reviewed refactoring planning.
+
+It is not a full SystemVerilog parser, not semantic elaboration, not an LSP
+implementation, and not a write-capable refactoring engine.
+
+## CLI Surface
+
+```bash
+python -m pccx_ide_cli organization <path> --format json
+python -m pccx_ide_cli organization <path> --format text
+```
+
+`<path>` may be a `.sv` / `.v` file or a directory. Directory scans follow the
+same recursive scanner rules as `index` and `declarations`.
+
+The JSON envelope uses:
+
+```json
+{
+  "kind": "module-organization",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "modules": [],
+  "hierarchy": {
+    "edges": [],
+    "roots": [],
+    "unresolved": []
+  },
+  "refactoring": {
+    "mode": "proposal-only",
+    "writes_files": false
+  },
+  "limitations": []
+}
+```
+
+The shape is pre-stable and may change while the editor bridge matures.
+
+## Module Boundary Detection
+
+Each `modules[]` record describes one scanner-detected `module` declaration:
+
+```json
+{
+  "name": "top_mod",
+  "file": "fixtures/organization/hierarchy_top.sv",
+  "start_line": 9,
+  "start_column": 1,
+  "end_line": 15,
+  "end_column": 1,
+  "span_lines": 7,
+  "complete": true
+}
+```
+
+The scanner matches simple declaration lines and the next visible
+`endmodule` line. If no end marker is found, `complete` is `false` and the end
+fields are `null`.
+
+## Hierarchy Seed
+
+`hierarchy.edges[]` records single-line instantiation candidates inside
+complete module spans:
+
+```json
+{
+  "parent": "top_mod",
+  "child": "leaf_mod",
+  "instance": "u_leaf",
+  "file": "fixtures/organization/hierarchy_top.sv",
+  "line": 12,
+  "column": 5,
+  "resolved": true
+}
+```
+
+`resolved` means the child type matches a module declaration found in the same
+scan. `roots[]` lists known modules that are not resolved children, and
+`unresolved[]` lists candidate child types without a local declaration.
+
+This is a visualization seed for editor trees and review workflows. It does
+not run elaboration, expand macros, interpret generate blocks, or replace
+vendor tooling.
+
+## Refactoring Boundary
+
+Refactoring remains proposal-only. The current workflow provides candidate
+inputs for later helpers:
+
+- module boundary spans
+- scanner-based hierarchy edges
+- planned helper names for rename, extract-port, and move-module workflows
+
+The CLI does not write files, apply patches, rename symbols, move modules,
+edit ports, run validation, execute shell commands, invoke `pccx-lab`, invoke
+the launcher, access hardware, upload telemetry, or perform automatic
+repository actions.
+
+Future write-capable helpers must be reviewed as a separate boundary and
+should route through explicit proposal and approval steps before any file
+mutation.
+
+## Limitations
+
+- Scanner-based module declarations and `endmodule` matching only.
+- Single-line instantiation candidates only.
+- No preprocessor, macro, generate-block, package import, modport, class,
+  interface semantic, or elaboration support.
+- Duplicate module names are not semantically resolved.
+- JSON output is pre-stable.
+
+## Issue Alignment
+
+This workflow advances
+[`systemverilog-ide#8`](https://github.com/pccxai/systemverilog-ide/issues/8)
+with read-only module boundary detection, a hierarchy visualization seed, and
+a proposal-only refactoring boundary.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -31,7 +31,10 @@ cross-repo handoff notes live in [`HANDOFF.md`](./HANDOFF.md).
 ## Next
 
 - Expand project-aware navigation without claiming full semantic
-  SystemVerilog parsing or LSP coverage.
+  SystemVerilog parsing or LSP coverage. The module organization workflow
+  for scanner-based boundary spans, hierarchy seeds, and proposal-only
+  refactoring inputs is tracked in
+  [`MODULE_ORGANIZATION_WORKFLOW.md`](./MODULE_ORGANIZATION_WORKFLOW.md).
 - Continue diagnostics/xsim handoff planning through existing local JSON
   and text surfaces; reusable xsim execution remains owned by pccx-lab.
 - Add editor-facing workflow notes for validation proposal preflight,

--- a/fixtures/organization/hierarchy_top.sv
+++ b/fixtures/organization/hierarchy_top.sv
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
+
+module leaf_mod (
+    input logic clk
+);
+endmodule
+
+module top_mod (
+    input logic clk
+);
+    leaf_mod u_leaf (
+        .clk(clk)
+    );
+endmodule

--- a/scripts/source-header-legacy-baseline.json
+++ b/scripts/source-header-legacy-baseline.json
@@ -80,7 +80,6 @@
   "scripts/vscode-extension-host-smoke.sh": "16232d6dfde7b760d634da1c3daf2f93dfbfe30d7d894b59752ef1b9dbdbe05d",
   "src/pccx_ide_cli/__init__.py": "4b1dfa220d8f3cfddab873439d0e952ea36fa22e1d74a3f6a9ee1af5641ca451",
   "src/pccx_ide_cli/__main__.py": "e34737246c4338a78411d7cac39a3a03c13fae12bd7c5bfc01896677e9e0b5c2",
-  "src/pccx_ide_cli/cli.py": "e25d1dcda1c495f5f1069c08479de1c5caffe70f2c972b37f4bc00bb0e34ee49",
   "src/pccx_ide_cli/diagnostics.py": "a17931de63813c67d6dcdc89b4c6ab7a92aecbb9257f5918e63309b51a73776e",
   "src/pccx_ide_cli/module_index.py": "604bae4cd08e857095267cd546a419bf3f41d659f4b208a99b655d99c484cf3a",
   "src/pccx_ide_cli/pccx_lab_backend.py": "2e4c9ba97d1bd883d8e954e36bb4931301e855a8c0768d770bfdc8066ff5db2f",

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+
 from __future__ import annotations
 
 import argparse
@@ -108,6 +111,25 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Declaration kind to locate (default: module).",
     )
     locate_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
+    organization_cmd = sub.add_parser(
+        "organization",
+        help=(
+            "Export scanner-based module boundaries and hierarchy seeds "
+            "for project organization."
+        ),
+    )
+    organization_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    organization_cmd.add_argument(
         "--format",
         choices=("json", "text"),
         default="json",
@@ -326,6 +348,24 @@ def main(argv: Sequence[str] | None = None) -> int:
                 f"error: ambiguous: {len(matches)} matches for {label} {args.name}\n"
             )
             return 2
+        return 0
+
+    if args.command == "organization":
+        from .module_organization import (
+            build_module_organization_export,
+            format_module_organization_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        export = build_module_organization_export(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(export, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_organization_text(export))
         return 0
 
     if args.command == "xsim-log":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from .module_index import _strip_block_comments, scan_path
+
+_ENDMODULE_RE = re.compile(r"^(\s*)endmodule\b")
+_INSTANCE_RE = re.compile(
+    r"^(\s*)([A-Za-z_]\w*)\s+(?:#\s*\([^;]*\)\s*)?([A-Za-z_]\w*)\s*\("
+)
+
+_NON_INSTANCE_WORDS: frozenset[str] = frozenset({
+    "always",
+    "always_comb",
+    "always_ff",
+    "always_latch",
+    "assign",
+    "case",
+    "class",
+    "covergroup",
+    "endcase",
+    "endclass",
+    "endfunction",
+    "endgenerate",
+    "endmodule",
+    "endpackage",
+    "endprogram",
+    "endtask",
+    "for",
+    "forever",
+    "function",
+    "generate",
+    "if",
+    "initial",
+    "interface",
+    "module",
+    "package",
+    "program",
+    "task",
+    "while",
+})
+
+LIMITATIONS: tuple[str, ...] = (
+    "scanner-based module declarations and endmodule matching only",
+    "single-line instantiation candidates only",
+    "no preprocessor, generate-block, modport, package import, or semantic resolution",
+    "refactoring helpers are proposal-only and do not write files",
+    "pre-stable JSON shape",
+)
+
+
+def _visible_lines(path: Path) -> list[tuple[int, str]]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    visible_lines: list[tuple[int, str]] = []
+    in_block_comment = False
+    for line_num, line in enumerate(text.splitlines(), 1):
+        visible, in_block_comment = _strip_block_comments(line, in_block_comment)
+        if visible.lstrip().startswith("//"):
+            visible = ""
+        visible_lines.append((line_num, visible))
+    return visible_lines
+
+
+def _find_endmodule(
+    visible_lines: list[tuple[int, str]], start_line: int
+) -> tuple[int | None, int | None]:
+    for line_num, visible in visible_lines:
+        if line_num <= start_line:
+            continue
+        match = _ENDMODULE_RE.match(visible)
+        if match:
+            return line_num, len(match.group(1)) + 1
+    return None, None
+
+
+def _module_boundary(
+    declaration: dict[str, Any],
+    visible_lines_by_file: dict[str, list[tuple[int, str]]],
+) -> dict[str, Any]:
+    file_name = declaration["file"]
+    end_line, end_column = _find_endmodule(
+        visible_lines_by_file[file_name],
+        declaration["line"],
+    )
+    boundary: dict[str, Any] = {
+        "complete": end_line is not None,
+        "end_column": end_column,
+        "end_line": end_line,
+        "file": file_name,
+        "name": declaration["name"],
+        "span_lines": (
+            end_line - declaration["line"] + 1
+            if end_line is not None
+            else None
+        ),
+        "start_column": declaration["column"],
+        "start_line": declaration["line"],
+    }
+    return boundary
+
+
+def _scan_instantiations(
+    boundary: dict[str, Any],
+    visible_lines: list[tuple[int, str]],
+    known_modules: set[str],
+) -> list[dict[str, Any]]:
+    if not boundary["complete"]:
+        return []
+
+    edges: list[dict[str, Any]] = []
+    for line_num, visible in visible_lines:
+        if line_num <= boundary["start_line"] or line_num >= boundary["end_line"]:
+            continue
+
+        match = _INSTANCE_RE.match(visible)
+        if not match:
+            continue
+
+        child = match.group(2)
+        if child in _NON_INSTANCE_WORDS:
+            continue
+
+        edges.append({
+            "child": child,
+            "file": boundary["file"],
+            "instance": match.group(3),
+            "line": line_num,
+            "column": len(match.group(1)) + 1,
+            "parent": boundary["name"],
+            "resolved": child in known_modules,
+        })
+    return edges
+
+
+def _build_hierarchy(
+    boundaries: list[dict[str, Any]],
+    visible_lines_by_file: dict[str, list[tuple[int, str]]],
+) -> dict[str, Any]:
+    known_modules = {boundary["name"] for boundary in boundaries}
+    edges: list[dict[str, Any]] = []
+    for boundary in boundaries:
+        edges.extend(
+            _scan_instantiations(
+                boundary,
+                visible_lines_by_file[boundary["file"]],
+                known_modules,
+            )
+        )
+
+    resolved_children = {
+        edge["child"]
+        for edge in edges
+        if edge["resolved"]
+    }
+    return {
+        "edges": sorted(
+            edges,
+            key=lambda e: (
+                e["parent"],
+                e["line"],
+                e["column"],
+                e["child"],
+                e["instance"],
+            ),
+        ),
+        "roots": sorted(known_modules - resolved_children),
+        "unresolved": sorted({
+            edge["child"]
+            for edge in edges
+            if not edge["resolved"]
+        }),
+    }
+
+
+def build_module_organization_export(
+    source: str, path: Path
+) -> dict[str, Any]:
+    declarations = scan_path(path)
+    module_declarations = [
+        declaration
+        for declaration in declarations
+        if declaration["kind"] == "module"
+    ]
+    files = sorted({declaration["file"] for declaration in module_declarations})
+    visible_lines_by_file = {
+        file_name: _visible_lines(Path(file_name))
+        for file_name in files
+    }
+    modules = [
+        _module_boundary(declaration, visible_lines_by_file)
+        for declaration in module_declarations
+    ]
+    modules.sort(key=lambda m: (m["file"], m["start_line"], m["name"]))
+
+    return {
+        "hierarchy": _build_hierarchy(modules, visible_lines_by_file),
+        "kind": "module-organization",
+        "limitations": list(LIMITATIONS),
+        "modules": modules,
+        "refactoring": {
+            "candidate_inputs": [
+                "module boundary spans",
+                "scanner-based hierarchy edges",
+            ],
+            "mode": "proposal-only",
+            "planned_helpers": [
+                "rename module",
+                "extract port",
+                "move module",
+            ],
+            "writes_files": False,
+        },
+        "scanner": "line-scanner",
+        "source": source,
+        "tool": "pccx-ide-cli",
+    }
+
+
+def format_module_organization_text(export: dict[str, Any]) -> str:
+    lines = [
+        f"source: {export['source']}",
+        f"{len(export['modules'])} module"
+        f"{'s' if len(export['modules']) != 1 else ''}",
+    ]
+    for module in export["modules"]:
+        end = (
+            f"{module['end_line']}:{module['end_column']}"
+            if module["complete"]
+            else "missing"
+        )
+        state = "complete" if module["complete"] else "incomplete"
+        lines.append(
+            f"{module['file']}:{module['start_line']}:{module['start_column']}"
+            f"-{end}: module {module['name']} ({state})"
+        )
+
+    hierarchy = export["hierarchy"]
+    lines.append(
+        f"{len(hierarchy['edges'])} hierarchy edge"
+        f"{'s' if len(hierarchy['edges']) != 1 else ''}"
+    )
+    for edge in hierarchy["edges"]:
+        state = "resolved" if edge["resolved"] else "unresolved"
+        lines.append(
+            f"{edge['parent']} -> {edge['child']} as {edge['instance']} "
+            f"at {edge['file']}:{edge['line']}:{edge['column']} ({state})"
+        )
+
+    if hierarchy["roots"]:
+        lines.append(f"roots: {', '.join(hierarchy['roots'])}")
+    if hierarchy["unresolved"]:
+        lines.append(f"unresolved: {', '.join(hierarchy['unresolved'])}")
+    lines.append("refactoring: proposal-only, no file writes")
+    return "\n".join(lines) + "\n"

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+FIXTURE = REPO_ROOT / "fixtures" / "organization" / "hierarchy_top.sv"
+CONTRACT_DOC = REPO_ROOT / "docs" / "EDITOR_BRIDGE_CONTRACT.md"
+WORKFLOW_DOC = REPO_ROOT / "docs" / "MODULE_ORGANIZATION_WORKFLOW.md"
+
+sys.path.insert(0, str(SRC))
+
+from pccx_ide_cli.module_organization import (  # noqa: E402
+    build_module_organization_export,
+    format_module_organization_text,
+)
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "pccx_ide_cli", *args],
+        cwd=REPO_ROOT,
+        env={
+            "PYTHONPATH": str(SRC),
+            "PATH": os.environ.get("PATH", ""),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_build_module_organization_export_boundaries():
+    export = build_module_organization_export(str(FIXTURE), FIXTURE)
+    assert export["kind"] == "module-organization"
+    assert export["tool"] == "pccx-ide-cli"
+    assert export["scanner"] == "line-scanner"
+
+    modules = {module["name"]: module for module in export["modules"]}
+    assert set(modules) == {"leaf_mod", "top_mod"}
+    assert modules["leaf_mod"]["complete"] is True
+    assert modules["leaf_mod"]["start_line"] == 4
+    assert modules["leaf_mod"]["end_line"] == 7
+    assert modules["leaf_mod"]["span_lines"] == 4
+    assert modules["top_mod"]["complete"] is True
+    assert modules["top_mod"]["start_line"] == 9
+    assert modules["top_mod"]["end_line"] == 15
+
+
+def test_build_module_organization_export_hierarchy_seed():
+    export = build_module_organization_export(str(FIXTURE), FIXTURE)
+    assert export["hierarchy"]["roots"] == ["top_mod"]
+    assert export["hierarchy"]["unresolved"] == []
+    assert export["hierarchy"]["edges"] == [
+        {
+            "child": "leaf_mod",
+            "column": 5,
+            "file": str(FIXTURE),
+            "instance": "u_leaf",
+            "line": 12,
+            "parent": "top_mod",
+            "resolved": True,
+        }
+    ]
+
+
+def test_build_module_organization_export_refactoring_is_proposal_only():
+    export = build_module_organization_export(str(FIXTURE), FIXTURE)
+    assert export["refactoring"]["mode"] == "proposal-only"
+    assert export["refactoring"]["writes_files"] is False
+    assert "rename module" in export["refactoring"]["planned_helpers"]
+
+
+def test_format_module_organization_text_mentions_boundary_and_hierarchy():
+    export = build_module_organization_export(str(FIXTURE), FIXTURE)
+    text = format_module_organization_text(export)
+    assert "2 modules" in text
+    assert "module top_mod (complete)" in text
+    assert "top_mod -> leaf_mod as u_leaf" in text
+    assert "refactoring: proposal-only, no file writes" in text
+
+
+def test_cli_organization_json():
+    result = _run_cli("organization", str(FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-organization"
+    assert payload["source"] == str(FIXTURE)
+    assert [edge["child"] for edge in payload["hierarchy"]["edges"]] == ["leaf_mod"]
+
+
+def test_cli_organization_text():
+    result = _run_cli("organization", str(FIXTURE), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "source:" in result.stdout
+    assert "2 modules" in result.stdout
+    assert "1 hierarchy edge" in result.stdout
+
+
+def test_cli_organization_missing_path_exits_nonzero():
+    result = _run_cli("organization", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
+def test_docs_cover_organization_flow_and_limits():
+    contract = CONTRACT_DOC.read_text(encoding="utf-8")
+    workflow = WORKFLOW_DOC.read_text(encoding="utf-8")
+    assert "organization <path>" in contract
+    assert "MODULE_ORGANIZATION_WORKFLOW.md" in contract
+    assert "proposal-only" in workflow
+    assert "does not write files" in workflow
+    assert "not a full SystemVerilog parser" in workflow


### PR DESCRIPTION
## Summary

- add a read-only `pccx_ide_cli organization` surface for scanner-based module boundary spans and hierarchy seeds
- document the module organization workflow and editor bridge limits
- add a checked hierarchy fixture plus tests for JSON/text output and proposal-only refactoring metadata

Refs #8. This is a bounded read-only organization slice; write-capable refactoring helpers remain separate future work.

## Scope / limits

- scanner-based only; not semantic elaboration and not a full SystemVerilog parser
- no file writes, refactor application, validation execution, xsim/Vivado execution, pccx-lab execution, launcher execution, provider call, hardware access, telemetry, upload, or automatic repository action
- JSON shape remains pre-stable

## Validation

- `python3 scripts/check-source-headers.py`
- `python3 -m pytest -q`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- local claim-scan matching CI
- `git diff --check`
- `git diff --cached --check`