### PR TITLE
Add module refactor proposal boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ python -m pccx_ide_cli declarations fixtures/modules/ --format json
 python -m pccx_ide_cli organization fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli organization fixtures/organization/hierarchy_top.sv --format text
 
+# Refactoring proposal export (pre-stable, proposal-only)
+python -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
+python -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action extract-port --module top_mod --port-name valid_i --direction input --format text
+
 # xsim log handoff scaffold (parses existing log files only)
 python -m pccx_ide_cli xsim-log fixtures/xsim/mixed.log --format json
 python -m pccx_ide_cli xsim-log fixtures/xsim/mixed.log --format text
@@ -174,6 +178,13 @@ it does not edit files, apply refactors, execute validation, run vendor
 tools, invoke `pccx-lab` or the launcher, or implement semantic
 elaboration. The output shape is pre-stable and is documented in
 [`docs/MODULE_ORGANIZATION_WORKFLOW.md`](./docs/MODULE_ORGANIZATION_WORKFLOW.md).
+
+`refactor-plan` emits proposal-only rename-module, extract-port, and
+move-module planning envelopes over scanner-detected module boundaries.
+It records requested inputs, a bounded preflight status, and planned
+review steps, but it does not write files, apply patches, run validation,
+invoke `pccx-lab` or the launcher, call providers, touch hardware, or
+perform automatic repository actions.
 
 `xsim-log` is an early handoff scaffold. It parses existing synthetic
 xsim-style log files into diagnostics-like JSON or text output. It does

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -185,6 +185,11 @@ adds scanner-based module boundary spans, hierarchy edges, root candidates,
 and proposal-only refactoring metadata for project tree and reviewed
 refactoring workflows. The organization surface is documented in
 [`MODULE_ORGANIZATION_WORKFLOW.md`](./MODULE_ORGANIZATION_WORKFLOW.md).
+`refactor-plan` extends the same boundary with proposal-only
+rename-module, extract-port, and move-module planning envelopes. It emits
+preflight metadata and review steps only; it does not apply edits, move
+files, run validation, invoke pccx-lab or the launcher, call providers, touch
+hardware, or perform automatic repository actions.
 
 For existing xsim logs, the VS Code prototype can consume the checked
 `problems from-xsim-log` JSON as a read-only status/context summary.  The
@@ -201,8 +206,8 @@ xsim path, and text surface sketches is documented in
 ## Limitations
 
 - Scanner-based scaffolds, not full SystemVerilog parsing.
-- Module organization is scanner-based; it is not semantic elaboration and
-  does not apply refactors.
+- Module organization and refactor planning are scanner-based; they are not
+  semantic elaboration and do not apply refactors.
 - No LSP server in this repository today.
 - No published editor extension or marketplace packaging is implemented
   here.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -441,6 +441,7 @@ the same local scanner used by `index`, `declarations`, and `locate`.
 ```bash
 python -m pccx_ide_cli organization fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli organization fixtures/organization/hierarchy_top.sv --format text
+python -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 ```
 
 JSON output uses:
@@ -472,9 +473,11 @@ JSON output uses:
 ```
 
 The refactoring section is proposal-only and reports `writes_files: false`.
-This command does not apply refactors, move files, execute validation, invoke
-`pccx-lab`, invoke the launcher, run xsim or Vivado, access hardware, upload
-telemetry, or write back state. The full scope and limitations are tracked in
+`refactor-plan` emits a separate proposal-only envelope for rename-module,
+extract-port, and move-module requests. These commands do not apply
+refactors, move files, execute validation, invoke `pccx-lab`, invoke the
+launcher, run xsim or Vivado, access hardware, upload telemetry, or write back
+state. The full scope and limitations are tracked in
 [`MODULE_ORGANIZATION_WORKFLOW.md`](./MODULE_ORGANIZATION_WORKFLOW.md).
 
 ---

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -15,6 +15,9 @@ implementation, and not a write-capable refactoring engine.
 ```bash
 python -m pccx_ide_cli organization <path> --format json
 python -m pccx_ide_cli organization <path> --format text
+python -m pccx_ide_cli refactor-plan <path> --action rename-module --module <name> --new-name <name> --format json
+python -m pccx_ide_cli refactor-plan <path> --action extract-port --module <name> --port-name <name> --direction input --format text
+python -m pccx_ide_cli refactor-plan <path> --action move-module --module <name> --destination rtl/<name>.sv --format json
 ```
 
 `<path>` may be a `.sv` / `.v` file or a directory. Directory scans follow the
@@ -107,6 +110,55 @@ repository actions.
 Future write-capable helpers must be reviewed as a separate boundary and
 should route through explicit proposal and approval steps before any file
 mutation.
+
+## Refactoring Proposal Plan
+
+`refactor-plan` is the next reviewed boundary for module organization. It
+does not apply a refactor. It emits a proposal envelope that a UI or
+maintainer workflow can review before any write-capable helper exists.
+
+Supported proposal actions:
+
+- `rename-module`
+- `extract-port`
+- `move-module`
+
+Each envelope includes the requested action, scanner-detected module span,
+preflight status, blocked reasons when inputs are missing or unsafe, planned
+review steps, and safety flags. Example shape:
+
+```json
+{
+  "kind": "module-refactor-proposal",
+  "proposal_state": "proposal-only",
+  "action": "rename-module",
+  "writes_files": false,
+  "preflight": {
+    "status": "ready-for-review",
+    "requires_approval_before_write": true,
+    "reasons": []
+  },
+  "safety": {
+    "applies_patch": false,
+    "writes_files": false,
+    "runs_validation": false,
+    "invokes_pccx_lab": false,
+    "invokes_launcher": false,
+    "hardware_access": false
+  }
+}
+```
+
+Blocked proposals still return JSON so editor consumers can display why a
+request is not ready for review. For example, a missing module, missing
+required input, absolute destination path, or invalid identifier produces
+`preflight.status: "blocked"` with reasons.
+
+This boundary is intentionally limited to proposal metadata. It does not
+rewrite symbols, edit ports, move files, generate patches, run validation,
+execute shell commands, invoke `pccx-lab`, invoke the launcher, call
+providers, touch hardware, upload telemetry, or perform automatic repository
+actions.
 
 ## Limitations
 

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -28,6 +30,7 @@ run_json editor-problems problems from-xsim-log fixtures/xsim/mixed.log --format
 run_json module-index index fixtures/modules --format json
 run_json declarations declarations fixtures/modules --format json
 run_json locate locate fixtures/modules/simple_module.sv simple_mod --format json
+run_json module-refactor-proposal refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 
 bash scripts/check-editor-bridge-examples.sh
 

--- a/scripts/source-header-legacy-baseline.json
+++ b/scripts/source-header-legacy-baseline.json
@@ -76,7 +76,6 @@
   "fixtures/modules/two_modules.sv": "8429c642682002a464abdd9dd04791c2aa8a8c4456d767bea72820799a09e674",
   "fixtures/ok_module.sv": "17a9c50eadc279a0f37cdc6f509d89b12a290b3d63d46cc0ce3680cda5e811ec",
   "scripts/check-editor-bridge-examples.sh": "2799db4307d2ed00b05607243c4f415aa44127749ffab7f0f1c423c02ec3a3df",
-  "scripts/editor-bridge-smoke.sh": "8e74f17165aa1b13e7e76073cf1916cacb9b674ed00893003b559fa12171c9ce",
   "scripts/vscode-extension-host-smoke.sh": "16232d6dfde7b760d634da1c3daf2f93dfbfe30d7d894b59752ef1b9dbdbe05d",
   "src/pccx_ide_cli/__init__.py": "4b1dfa220d8f3cfddab873439d0e952ea36fa22e1d74a3f6a9ee1af5641ca451",
   "src/pccx_ide_cli/__main__.py": "e34737246c4338a78411d7cac39a3a03c13fae12bd7c5bfc01896677e9e0b5c2",

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -136,6 +136,62 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    refactor_plan_cmd = sub.add_parser(
+        "refactor-plan",
+        help=(
+            "Emit a proposal-only refactoring plan for a scanner-detected "
+            "module boundary."
+        ),
+    )
+    refactor_plan_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    refactor_plan_cmd.add_argument(
+        "--action",
+        choices=("rename-module", "extract-port", "move-module"),
+        required=True,
+        help="Proposal kind to prepare.",
+    )
+    refactor_plan_cmd.add_argument(
+        "--module",
+        required=True,
+        help="Exact module name to use as the proposal target.",
+    )
+    refactor_plan_cmd.add_argument(
+        "--new-name",
+        default=None,
+        help="New module name for rename-module proposals.",
+    )
+    refactor_plan_cmd.add_argument(
+        "--port-name",
+        default=None,
+        help="Port name for extract-port proposals.",
+    )
+    refactor_plan_cmd.add_argument(
+        "--direction",
+        choices=("input", "output", "inout"),
+        default=None,
+        help="Port direction for extract-port proposals.",
+    )
+    refactor_plan_cmd.add_argument(
+        "--width",
+        default=None,
+        help="Optional port width text for extract-port proposals.",
+    )
+    refactor_plan_cmd.add_argument(
+        "--destination",
+        default=None,
+        help="Relative destination path for move-module proposals.",
+    )
+    refactor_plan_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     xsim_log = sub.add_parser(
         "xsim-log",
         help="Parse an existing xsim-style log file into diagnostics-like output.",
@@ -366,6 +422,34 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_organization_text(export))
+        return 0
+
+    if args.command == "refactor-plan":
+        from .module_organization import (
+            build_refactor_proposal,
+            format_refactor_proposal_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        proposal = build_refactor_proposal(
+            str(args.path),
+            args.path,
+            args.action,
+            args.module,
+            new_name=args.new_name,
+            port_name=args.port_name,
+            direction=args.direction,
+            width=args.width,
+            destination=args.destination,
+        )
+        if args.format == "json":
+            json.dump(proposal, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_refactor_proposal_text(proposal))
         return 0
 
     if args.command == "xsim-log":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -53,6 +53,46 @@ LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+REFACTOR_ACTIONS: tuple[str, ...] = (
+    "rename-module",
+    "extract-port",
+    "move-module",
+)
+
+PROPOSAL_LIMITATIONS: tuple[str, ...] = (
+    "proposal-only refactoring metadata",
+    "scanner-based module boundary lookup only",
+    "no symbol rewrite, port rewrite, file move, validation run, or patch generation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
+_REFACTOR_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
+    "rename-module": ("new_name",),
+    "extract-port": ("port_name", "direction"),
+    "move-module": ("destination",),
+}
+
+
+def _safe_identifier(value: str | None) -> bool:
+    return bool(value and re.fullmatch(r"[A-Za-z_]\w*", value))
+
+
+def _refactor_safety_flags() -> dict[str, bool]:
+    return {
+        "applies_patch": False,
+        "writes_files": False,
+        "moves_files": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
 
 def _visible_lines(path: Path) -> list[tuple[int, str]]:
     text = path.read_text(encoding="utf-8", errors="replace")
@@ -219,6 +259,176 @@ def build_module_organization_export(
         "source": source,
         "tool": "pccx-ide-cli",
     }
+
+
+def _module_lookup(modules: list[dict[str, Any]], name: str) -> list[dict[str, Any]]:
+    return [
+        module
+        for module in modules
+        if module["name"] == name
+    ]
+
+
+def _requested_change(
+    action: str,
+    module_name: str,
+    *,
+    new_name: str | None,
+    port_name: str | None,
+    direction: str | None,
+    width: str | None,
+    destination: str | None,
+) -> dict[str, Any]:
+    return {
+        "action": action,
+        "module": module_name,
+        "new_name": new_name,
+        "port_name": port_name,
+        "direction": direction,
+        "width": width,
+        "destination": destination,
+    }
+
+
+def _planned_steps(action: str, module: dict[str, Any] | None) -> list[str]:
+    if module is None:
+        return []
+    if action == "rename-module":
+        return [
+            "review scanner-detected module declaration span",
+            "prepare module declaration rename proposal",
+            "prepare same-file instantiation type review list",
+            "require explicit approval before any file edit",
+        ]
+    if action == "extract-port":
+        return [
+            "review scanner-detected module declaration span",
+            "prepare port declaration insertion proposal",
+            "prepare instance connection review list",
+            "require explicit approval before any file edit",
+        ]
+    if action == "move-module":
+        return [
+            "review scanner-detected module declaration span",
+            "prepare destination file review note",
+            "prepare source-file removal review note",
+            "require explicit approval before any file move or edit",
+        ]
+    return []
+
+
+def _preflight(
+    action: str,
+    module_name: str,
+    matches: list[dict[str, Any]],
+    requested: dict[str, Any],
+) -> dict[str, Any]:
+    reasons: list[str] = []
+    required = _REFACTOR_REQUIRED_FIELDS[action]
+    for field in required:
+        if not requested[field]:
+            reasons.append(f"missing required {field.replace('_', '-')}")
+
+    if len(matches) == 0:
+        reasons.append(f"module not found: {module_name}")
+    elif len(matches) > 1:
+        reasons.append(f"ambiguous module name: {module_name}")
+    elif not matches[0]["complete"]:
+        reasons.append(f"module boundary is incomplete: {module_name}")
+
+    if action == "rename-module" and requested["new_name"]:
+        if not _safe_identifier(requested["new_name"]):
+            reasons.append("new-name must be a SystemVerilog-style identifier")
+        if requested["new_name"] == module_name:
+            reasons.append("new-name matches the current module name")
+
+    if action == "extract-port" and requested["port_name"]:
+        if not _safe_identifier(requested["port_name"]):
+            reasons.append("port-name must be a SystemVerilog-style identifier")
+
+    if action == "move-module" and requested["destination"]:
+        destination = str(requested["destination"])
+        if destination.startswith("/") or ".." in Path(destination).parts:
+            reasons.append("destination must be a relative path inside the workspace")
+        if not destination.endswith((".sv", ".v")):
+            reasons.append("destination should end with .sv or .v")
+
+    return {
+        "reasons": reasons,
+        "requires_approval_before_write": True,
+        "status": "blocked" if reasons else "ready-for-review",
+    }
+
+
+def build_refactor_proposal(
+    source: str,
+    path: Path,
+    action: str,
+    module_name: str,
+    *,
+    new_name: str | None = None,
+    port_name: str | None = None,
+    direction: str | None = None,
+    width: str | None = None,
+    destination: str | None = None,
+) -> dict[str, Any]:
+    if action not in REFACTOR_ACTIONS:
+        raise ValueError(f"unknown refactor action: {action}")
+
+    organization = build_module_organization_export(source, path)
+    matches = _module_lookup(organization["modules"], module_name)
+    requested = _requested_change(
+        action,
+        module_name,
+        new_name=new_name,
+        port_name=port_name,
+        direction=direction,
+        width=width,
+        destination=destination,
+    )
+    preflight = _preflight(action, module_name, matches, requested)
+    selected_module = matches[0] if len(matches) == 1 else None
+
+    return {
+        "action": action,
+        "kind": "module-refactor-proposal",
+        "limitations": list(PROPOSAL_LIMITATIONS),
+        "module": selected_module,
+        "planned_steps": _planned_steps(action, selected_module),
+        "preflight": preflight,
+        "proposal_state": "proposal-only",
+        "requested_change": requested,
+        "safety": _refactor_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "tool": "pccx-ide-cli",
+        "writes_files": False,
+    }
+
+
+def format_refactor_proposal_text(proposal: dict[str, Any]) -> str:
+    lines = [
+        f"source: {proposal['source']}",
+        f"action: {proposal['action']}",
+        f"module: {proposal['requested_change']['module']}",
+        f"proposal: {proposal['proposal_state']}",
+        f"preflight: {proposal['preflight']['status']}",
+        "writes files: no",
+    ]
+    module = proposal["module"]
+    if module is not None:
+        lines.append(
+            f"boundary: {module['file']}:{module['start_line']}:"
+            f"{module['start_column']}-{module['end_line']}:{module['end_column']}"
+        )
+    if proposal["preflight"]["reasons"]:
+        for reason in proposal["preflight"]["reasons"]:
+            lines.append(f"blocked: {reason}")
+    else:
+        for step in proposal["planned_steps"]:
+            lines.append(f"plan: {step}")
+    lines.append("no patch, validation, lab, launcher, provider, or hardware execution")
+    return "\n".join(lines) + "\n"
 
 
 def format_module_organization_text(export: dict[str, Any]) -> str:

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -19,7 +19,9 @@ sys.path.insert(0, str(SRC))
 
 from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_organization_export,
+    build_refactor_proposal,
     format_module_organization_text,
+    format_refactor_proposal_text,
 )
 
 
@@ -78,6 +80,56 @@ def test_build_module_organization_export_refactoring_is_proposal_only():
     assert "rename module" in export["refactoring"]["planned_helpers"]
 
 
+def test_build_refactor_proposal_rename_is_review_only():
+    proposal = build_refactor_proposal(
+        str(FIXTURE),
+        FIXTURE,
+        "rename-module",
+        "top_mod",
+        new_name="top_mod_next",
+    )
+
+    assert proposal["kind"] == "module-refactor-proposal"
+    assert proposal["proposal_state"] == "proposal-only"
+    assert proposal["writes_files"] is False
+    assert proposal["preflight"]["status"] == "ready-for-review"
+    assert proposal["requested_change"]["new_name"] == "top_mod_next"
+    assert proposal["module"]["name"] == "top_mod"
+    assert proposal["safety"]["applies_patch"] is False
+    assert proposal["safety"]["runs_validation"] is False
+    assert proposal["safety"]["invokes_pccx_lab"] is False
+    assert proposal["safety"]["invokes_launcher"] is False
+
+
+def test_build_refactor_proposal_blocks_missing_module():
+    proposal = build_refactor_proposal(
+        str(FIXTURE),
+        FIXTURE,
+        "move-module",
+        "missing_mod",
+        destination="rtl/missing_mod.sv",
+    )
+
+    assert proposal["preflight"]["status"] == "blocked"
+    assert proposal["module"] is None
+    assert "module not found: missing_mod" in proposal["preflight"]["reasons"]
+    assert proposal["planned_steps"] == []
+
+
+def test_build_refactor_proposal_extract_port_requires_direction():
+    proposal = build_refactor_proposal(
+        str(FIXTURE),
+        FIXTURE,
+        "extract-port",
+        "top_mod",
+        port_name="enable_i",
+    )
+
+    assert proposal["preflight"]["status"] == "blocked"
+    assert "missing required direction" in proposal["preflight"]["reasons"]
+    assert proposal["safety"]["writes_files"] is False
+
+
 def test_format_module_organization_text_mentions_boundary_and_hierarchy():
     export = build_module_organization_export(str(FIXTURE), FIXTURE)
     text = format_module_organization_text(export)
@@ -85,6 +137,22 @@ def test_format_module_organization_text_mentions_boundary_and_hierarchy():
     assert "module top_mod (complete)" in text
     assert "top_mod -> leaf_mod as u_leaf" in text
     assert "refactoring: proposal-only, no file writes" in text
+
+
+def test_format_refactor_proposal_text_mentions_no_execution():
+    proposal = build_refactor_proposal(
+        str(FIXTURE),
+        FIXTURE,
+        "move-module",
+        "leaf_mod",
+        destination="rtl/leaf_mod.sv",
+    )
+    text = format_refactor_proposal_text(proposal)
+
+    assert "action: move-module" in text
+    assert "preflight: ready-for-review" in text
+    assert "writes files: no" in text
+    assert "no patch, validation, lab, launcher, provider, or hardware execution" in text
 
 
 def test_cli_organization_json():
@@ -102,6 +170,48 @@ def test_cli_organization_text():
     assert "source:" in result.stdout
     assert "2 modules" in result.stdout
     assert "1 hierarchy edge" in result.stdout
+
+
+def test_cli_refactor_plan_json():
+    result = _run_cli(
+        "refactor-plan",
+        str(FIXTURE),
+        "--action",
+        "rename-module",
+        "--module",
+        "leaf_mod",
+        "--new-name",
+        "leaf_mod_next",
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-refactor-proposal"
+    assert payload["action"] == "rename-module"
+    assert payload["preflight"]["status"] == "ready-for-review"
+    assert payload["writes_files"] is False
+
+
+def test_cli_refactor_plan_text():
+    result = _run_cli(
+        "refactor-plan",
+        str(FIXTURE),
+        "--action",
+        "extract-port",
+        "--module",
+        "top_mod",
+        "--port-name",
+        "valid_i",
+        "--direction",
+        "input",
+        "--format",
+        "text",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "action: extract-port" in result.stdout
+    assert "preflight: ready-for-review" in result.stdout
+    assert "writes files: no" in result.stdout
 
 
 def test_cli_organization_missing_path_exits_nonzero():


### PR DESCRIPTION
## Summary
- Add a proposal-only `refactor-plan` CLI surface for rename-module, extract-port, and move-module planning over scanner-detected module boundaries.
- Return bounded preflight metadata, planned review steps, and explicit safety flags without applying edits or running validation.
- Update module organization docs/tests and editor bridge smoke coverage for the new boundary.

Refs #8

## Validation
- `python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py`
- `python3 -m pytest -q tests/test_module_organization.py`
- `python3 -m pytest -q`
- `python3 scripts/check-source-headers.py`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- local claim-scan matching `.github/workflows/ci.yml`
- local README link sanity matching `.github/workflows/ci.yml`
- `git diff --check`
- `git diff --cached --check`

This does not apply refactors, move files, execute validation, invoke pccx-lab or pccx-llm-launcher, call providers, touch hardware, or perform automatic repository actions.
