### PR TITLE
Add module hierarchy view boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,13 @@ jobs:
           PYTHONPATH=src python -m pccx_ide_cli declarations fixtures/modules \
               | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='declarations'; assert len(d['declarations'])>0"
           echo "declarations directory smoke ok"
+      - name: cli smoke (hierarchy view exits zero)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli hierarchy \
+              fixtures/organization/hierarchy_top.sv \
+              | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-hierarchy-view'; assert d['safety']['writes_files'] is False"
+          echo "hierarchy view smoke ok"
       - name: cli smoke (index missing path exits non-zero)
         run: |
           set -e

--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ python -m pccx_ide_cli declarations fixtures/modules/ --format json
 python -m pccx_ide_cli organization fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli organization fixtures/organization/hierarchy_top.sv --format text
 
+# Module hierarchy view (pre-stable, read-only)
+python -m pccx_ide_cli hierarchy fixtures/organization/hierarchy_top.sv --format json
+python -m pccx_ide_cli hierarchy fixtures/organization/hierarchy_top.sv --format text
+
 # Refactoring proposal export (pre-stable, proposal-only)
 python -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 python -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action extract-port --module top_mod --port-name valid_i --direction input --format text
@@ -173,10 +177,12 @@ records used by `index` without the legacy module-only wrapper. It is a
 CLI bridge scaffold, not semantic resolution or a full parser.
 
 `organization` exports scanner-based module boundary spans, a small
-hierarchy seed, and proposal-only refactoring metadata. It is read-only:
-it does not edit files, apply refactors, execute validation, run vendor
-tools, invoke `pccx-lab` or the launcher, or implement semantic
-elaboration. The output shape is pre-stable and is documented in
+hierarchy seed, and proposal-only refactoring metadata. `hierarchy`
+renders the same scanner data as a focused read-only hierarchy view for
+editor tree consumers. These commands do not edit files, apply refactors,
+execute validation, run vendor tools, invoke `pccx-lab` or the launcher,
+or implement semantic elaboration. The output shapes are pre-stable and
+documented in
 [`docs/MODULE_ORGANIZATION_WORKFLOW.md`](./docs/MODULE_ORGANIZATION_WORKFLOW.md).
 
 `refactor-plan` emits proposal-only rename-module, extract-port, and
@@ -225,7 +231,7 @@ The initial roadmap for navigation, diagnostics, read-only handoff
 surfaces, external editor planning, and later workflow tracks lives in
 [`docs/ROADMAP.md`](./docs/ROADMAP.md).
 The scanner-based module organization workflow for module boundaries,
-hierarchy seeds, and proposal-only refactoring planning is documented in
+hierarchy views, and proposal-only refactoring planning is documented in
 [`docs/MODULE_ORGANIZATION_WORKFLOW.md`](./docs/MODULE_ORGANIZATION_WORKFLOW.md).
 The planned AI-assisted SystemVerilog workflow, permission boundary, and
 pccx-lab controlled MCP/tool dependency are documented in

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -45,6 +45,7 @@ python -m pccx_ide_cli locate <path> <name> --kind any --format json
 
 # Module organization for editor project trees
 python -m pccx_ide_cli organization <path> --format json
+python -m pccx_ide_cli hierarchy <path> --format json
 
 # Opt-in pccx-lab diagnostics backend
 python -m pccx_ide_cli check <sv-file> --backend pccx-lab --format json

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -3,9 +3,9 @@
 ## Status
 
 This is a pre-stable, scanner-based workflow for organizing modular RTL
-projects. It adds a read-only `organization` CLI surface that reports
-module boundary spans and a small hierarchy seed for editor navigation and
-reviewed refactoring planning.
+projects. It adds read-only `organization` and `hierarchy` CLI surfaces
+that report module boundary spans and scanner-based hierarchy data for
+editor navigation and reviewed refactoring planning.
 
 It is not a full SystemVerilog parser, not semantic elaboration, not an LSP
 implementation, and not a write-capable refactoring engine.
@@ -15,6 +15,8 @@ implementation, and not a write-capable refactoring engine.
 ```bash
 python -m pccx_ide_cli organization <path> --format json
 python -m pccx_ide_cli organization <path> --format text
+python -m pccx_ide_cli hierarchy <path> --format json
+python -m pccx_ide_cli hierarchy <path> --format text
 python -m pccx_ide_cli refactor-plan <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli refactor-plan <path> --action extract-port --module <name> --port-name <name> --direction input --format text
 python -m pccx_ide_cli refactor-plan <path> --action move-module --module <name> --destination rtl/<name>.sv --format json
@@ -46,6 +48,35 @@ The JSON envelope uses:
 ```
 
 The shape is pre-stable and may change while the editor bridge matures.
+
+The focused hierarchy view uses the same scanner data but emits a
+tree-oriented shape for editor consumers:
+
+```json
+{
+  "kind": "module-hierarchy-view",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "view_state": "available_as_data",
+  "module_count": 2,
+  "edge_count": 1,
+  "roots": [],
+  "tree": [],
+  "safety": {
+    "read_only": true,
+    "writes_files": false,
+    "applies_refactor": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The hierarchy view is display data only. It does not write files, apply
+refactors, run validation, execute shell commands, invoke `pccx-lab`,
+invoke the launcher, call providers, touch hardware, upload telemetry, or
+perform automatic repository actions.
 
 ## Module Boundary Detection
 
@@ -89,9 +120,10 @@ complete module spans:
 scan. `roots[]` lists known modules that are not resolved children, and
 `unresolved[]` lists candidate child types without a local declaration.
 
-This is a visualization seed for editor trees and review workflows. It does
-not run elaboration, expand macros, interpret generate blocks, or replace
-vendor tooling.
+This is a visualization seed for editor trees and review workflows. The
+`hierarchy` command renders it as JSON or text tree data. It does not run
+elaboration, expand macros, interpret generate blocks, or replace vendor
+tooling.
 
 ## Refactoring Boundary
 
@@ -173,5 +205,5 @@ actions.
 
 This workflow advances
 [`systemverilog-ide#8`](https://github.com/pccxai/systemverilog-ide/issues/8)
-with read-only module boundary detection, a hierarchy visualization seed, and
-a proposal-only refactoring boundary.
+with read-only module boundary detection, a focused hierarchy view, and a
+proposal-only refactoring boundary.

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -30,6 +30,7 @@ run_json editor-problems problems from-xsim-log fixtures/xsim/mixed.log --format
 run_json module-index index fixtures/modules --format json
 run_json declarations declarations fixtures/modules --format json
 run_json locate locate fixtures/modules/simple_module.sv simple_mod --format json
+run_json module-hierarchy-view hierarchy fixtures/organization/hierarchy_top.sv --format json
 run_json module-refactor-proposal refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 
 bash scripts/check-editor-bridge-examples.sh

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -136,6 +136,25 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    hierarchy_cmd = sub.add_parser(
+        "hierarchy",
+        help=(
+            "Render a scanner-based read-only module hierarchy view "
+            "for editor trees."
+        ),
+    )
+    hierarchy_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    hierarchy_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     refactor_plan_cmd = sub.add_parser(
         "refactor-plan",
         help=(
@@ -422,6 +441,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_organization_text(export))
+        return 0
+
+    if args.command == "hierarchy":
+        from .module_organization import (
+            build_module_hierarchy_view,
+            format_module_hierarchy_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        view = build_module_hierarchy_view(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(view, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_hierarchy_text(view))
         return 0
 
     if args.command == "refactor-plan":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -53,6 +53,15 @@ LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+HIERARCHY_VIEW_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based hierarchy visualization data only",
+    "single-line instantiation candidates only",
+    "no semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
+    "no refactor application, file write, validation run, or patch generation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 REFACTOR_ACTIONS: tuple[str, ...] = (
     "rename-module",
     "extract-port",
@@ -83,6 +92,22 @@ def _refactor_safety_flags() -> dict[str, bool]:
         "applies_patch": False,
         "writes_files": False,
         "moves_files": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _hierarchy_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "writes_files": False,
+        "applies_refactor": False,
         "runs_validation": False,
         "runs_shell": False,
         "invokes_pccx_lab": False,
@@ -267,6 +292,113 @@ def _module_lookup(modules: list[dict[str, Any]], name: str) -> list[dict[str, A
         for module in modules
         if module["name"] == name
     ]
+
+
+def _module_summary(module: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "complete": module["complete"],
+        "end_line": module["end_line"],
+        "file": module["file"],
+        "name": module["name"],
+        "start_line": module["start_line"],
+    }
+
+
+def _hierarchy_tree_rows(
+    modules: list[dict[str, Any]],
+    hierarchy: dict[str, Any],
+) -> list[dict[str, Any]]:
+    modules_by_name: dict[str, dict[str, Any]] = {}
+    for module in modules:
+        modules_by_name.setdefault(module["name"], module)
+
+    children_by_parent: dict[str, list[dict[str, Any]]] = {}
+    for edge in hierarchy["edges"]:
+        children_by_parent.setdefault(edge["parent"], []).append(edge)
+
+    roots = hierarchy["roots"] or sorted(modules_by_name)
+    rows: list[dict[str, Any]] = []
+
+    def visit(
+        module_name: str,
+        depth: int,
+        path: list[str],
+        via_edge: dict[str, Any] | None,
+    ) -> None:
+        module = modules_by_name.get(module_name)
+        next_path = [*path, module_name]
+        row = {
+            "complete": module["complete"] if module is not None else False,
+            "depth": depth,
+            "file": module["file"] if module is not None else via_edge["file"],
+            "module": module_name,
+            "path": next_path,
+            "start_line": (
+                module["start_line"] if module is not None else via_edge["line"]
+            ),
+            "state": (
+                "root"
+                if via_edge is None
+                else "resolved" if via_edge["resolved"] else "unresolved"
+            ),
+            "via_instance": via_edge["instance"] if via_edge is not None else None,
+            "via_parent": via_edge["parent"] if via_edge is not None else None,
+        }
+        rows.append(row)
+
+        if module_name in path:
+            row["state"] = "cycle"
+            return
+
+        for edge in children_by_parent.get(module_name, []):
+            if edge["resolved"]:
+                visit(edge["child"], depth + 1, next_path, edge)
+            else:
+                rows.append({
+                    "complete": False,
+                    "depth": depth + 1,
+                    "file": edge["file"],
+                    "module": edge["child"],
+                    "path": [*next_path, edge["child"]],
+                    "start_line": edge["line"],
+                    "state": "unresolved",
+                    "via_instance": edge["instance"],
+                    "via_parent": edge["parent"],
+                })
+
+    for root in roots:
+        visit(root, 0, [], None)
+    return rows
+
+
+def build_module_hierarchy_view(source: str, path: Path) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    hierarchy = organization["hierarchy"]
+    modules_by_name: dict[str, dict[str, Any]] = {}
+    for module in modules:
+        modules_by_name.setdefault(module["name"], module)
+
+    return {
+        "edge_count": len(hierarchy["edges"]),
+        "edges": hierarchy["edges"],
+        "kind": "module-hierarchy-view",
+        "limitations": list(HIERARCHY_VIEW_LIMITATIONS),
+        "module_count": len(modules),
+        "root_count": len(hierarchy["roots"]),
+        "roots": [
+            _module_summary(modules_by_name[root])
+            for root in hierarchy["roots"]
+            if root in modules_by_name
+        ],
+        "safety": _hierarchy_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "tool": "pccx-ide-cli",
+        "tree": _hierarchy_tree_rows(modules, hierarchy),
+        "unresolved": hierarchy["unresolved"],
+        "view_state": "available_as_data",
+    }
 
 
 def _requested_change(
@@ -466,4 +598,34 @@ def format_module_organization_text(export: dict[str, Any]) -> str:
     if hierarchy["unresolved"]:
         lines.append(f"unresolved: {', '.join(hierarchy['unresolved'])}")
     lines.append("refactoring: proposal-only, no file writes")
+    return "\n".join(lines) + "\n"
+
+
+def format_module_hierarchy_text(view: dict[str, Any]) -> str:
+    lines = [
+        f"source: {view['source']}",
+        f"hierarchy view: {view['view_state']}",
+        f"{view['module_count']} module"
+        f"{'s' if view['module_count'] != 1 else ''}",
+        f"{view['edge_count']} hierarchy edge"
+        f"{'s' if view['edge_count'] != 1 else ''}",
+        "tree:",
+    ]
+    if not view["tree"]:
+        lines.append("  empty")
+    for row in view["tree"]:
+        indent = "  " * (row["depth"] + 1)
+        if row["via_instance"] is None:
+            lines.append(f"{indent}{row['module']} ({row['state']})")
+        else:
+            lines.append(
+                f"{indent}{row['module']} as {row['via_instance']} "
+                f"({row['state']})"
+            )
+    if view["unresolved"]:
+        lines.append(f"unresolved: {', '.join(view['unresolved'])}")
+    lines.append(
+        "read-only: no file writes, refactors, validation, lab, launcher, "
+        "provider, or hardware execution"
+    )
     return "\n".join(lines) + "\n"

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -18,8 +18,10 @@ WORKFLOW_DOC = REPO_ROOT / "docs" / "MODULE_ORGANIZATION_WORKFLOW.md"
 sys.path.insert(0, str(SRC))
 
 from pccx_ide_cli.module_organization import (  # noqa: E402
+    build_module_hierarchy_view,
     build_module_organization_export,
     build_refactor_proposal,
+    format_module_hierarchy_text,
     format_module_organization_text,
     format_refactor_proposal_text,
 )
@@ -71,6 +73,31 @@ def test_build_module_organization_export_hierarchy_seed():
             "resolved": True,
         }
     ]
+
+
+def test_build_module_hierarchy_view_tree_is_read_only():
+    view = build_module_hierarchy_view(str(FIXTURE), FIXTURE)
+
+    assert view["kind"] == "module-hierarchy-view"
+    assert view["view_state"] == "available_as_data"
+    assert view["module_count"] == 2
+    assert view["edge_count"] == 1
+    assert view["root_count"] == 1
+    assert view["roots"][0]["name"] == "top_mod"
+    assert [row["module"] for row in view["tree"]] == ["top_mod", "leaf_mod"]
+    assert view["tree"][0]["depth"] == 0
+    assert view["tree"][0]["state"] == "root"
+    assert view["tree"][1]["depth"] == 1
+    assert view["tree"][1]["state"] == "resolved"
+    assert view["tree"][1]["via_instance"] == "u_leaf"
+    assert view["safety"]["read_only"] is True
+    assert view["safety"]["writes_files"] is False
+    assert view["safety"]["applies_refactor"] is False
+    assert view["safety"]["runs_validation"] is False
+    assert view["safety"]["invokes_pccx_lab"] is False
+    assert view["safety"]["invokes_launcher"] is False
+    assert view["safety"]["provider_calls"] is False
+    assert view["safety"]["hardware_access"] is False
 
 
 def test_build_module_organization_export_refactoring_is_proposal_only():
@@ -139,6 +166,16 @@ def test_format_module_organization_text_mentions_boundary_and_hierarchy():
     assert "refactoring: proposal-only, no file writes" in text
 
 
+def test_format_module_hierarchy_text_mentions_tree_and_boundary():
+    view = build_module_hierarchy_view(str(FIXTURE), FIXTURE)
+    text = format_module_hierarchy_text(view)
+
+    assert "hierarchy view: available_as_data" in text
+    assert "top_mod (root)" in text
+    assert "leaf_mod as u_leaf (resolved)" in text
+    assert "read-only: no file writes" in text
+
+
 def test_format_refactor_proposal_text_mentions_no_execution():
     proposal = build_refactor_proposal(
         str(FIXTURE),
@@ -170,6 +207,23 @@ def test_cli_organization_text():
     assert "source:" in result.stdout
     assert "2 modules" in result.stdout
     assert "1 hierarchy edge" in result.stdout
+
+
+def test_cli_hierarchy_json():
+    result = _run_cli("hierarchy", str(FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-hierarchy-view"
+    assert payload["tree"][0]["module"] == "top_mod"
+    assert payload["tree"][1]["module"] == "leaf_mod"
+    assert payload["safety"]["writes_files"] is False
+
+
+def test_cli_hierarchy_text():
+    result = _run_cli("hierarchy", str(FIXTURE), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "hierarchy view: available_as_data" in result.stdout
+    assert "leaf_mod as u_leaf (resolved)" in result.stdout
 
 
 def test_cli_refactor_plan_json():
@@ -220,11 +274,19 @@ def test_cli_organization_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_hierarchy_missing_path_exits_nonzero():
+    result = _run_cli("hierarchy", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_docs_cover_organization_flow_and_limits():
     contract = CONTRACT_DOC.read_text(encoding="utf-8")
     workflow = WORKFLOW_DOC.read_text(encoding="utf-8")
     assert "organization <path>" in contract
+    assert "hierarchy <path>" in contract
     assert "MODULE_ORGANIZATION_WORKFLOW.md" in contract
     assert "proposal-only" in workflow
+    assert "module-hierarchy-view" in workflow
     assert "does not write files" in workflow
     assert "not a full SystemVerilog parser" in workflow


### PR DESCRIPTION
## Summary
- Add a read-only `hierarchy` CLI surface that renders scanner-based module hierarchy data as JSON or text tree output.
- Reuse the existing module organization scanner and add explicit safety flags for no file writes, refactor application, validation runs, pccx-lab execution, launcher execution, provider calls, or hardware access.
- Document and test the pre-stable hierarchy view as a focused follow-up to the module organization and refactor proposal boundaries.

Refs #8.

## Validation
- `python3 -m pytest -q tests/test_module_organization.py`
- `PYTHONPATH=src python3 -m pccx_ide_cli hierarchy fixtures/organization/hierarchy_top.sv --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli hierarchy fixtures/organization/hierarchy_top.sv --format text`
- `bash scripts/editor-bridge-smoke.sh`
- `python3 -m pytest -q`
- `python3 scripts/check-source-headers.py`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py`
- local claim-scan matching CI
- local README link sanity matching CI
- `git diff --check`
- `git diff --cached --check`
