### PR TITLE
Add module dependency view boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,13 @@ jobs:
               fixtures/organization/hierarchy_top.sv \
               | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-hierarchy-view'; assert d['safety']['writes_files'] is False"
           echo "hierarchy view smoke ok"
+      - name: cli smoke (dependency view exits zero)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli dependencies \
+              fixtures/organization/hierarchy_top.sv \
+              | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-dependency-view'; assert d['safety']['writes_files'] is False"
+          echo "dependency view smoke ok"
       - name: cli smoke (index missing path exits non-zero)
         run: |
           set -e

--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ python -m pccx_ide_cli organization fixtures/organization/hierarchy_top.sv --for
 python -m pccx_ide_cli hierarchy fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli hierarchy fixtures/organization/hierarchy_top.sv --format text
 
+# Module dependency view (pre-stable, read-only)
+python -m pccx_ide_cli dependencies fixtures/organization/hierarchy_top.sv --format json
+python -m pccx_ide_cli dependencies fixtures/organization/hierarchy_top.sv --format text
+
 # Refactoring proposal export (pre-stable, proposal-only)
 python -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 python -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action extract-port --module top_mod --port-name valid_i --direction input --format text
@@ -179,10 +183,11 @@ CLI bridge scaffold, not semantic resolution or a full parser.
 `organization` exports scanner-based module boundary spans, a small
 hierarchy seed, and proposal-only refactoring metadata. `hierarchy`
 renders the same scanner data as a focused read-only hierarchy view for
-editor tree consumers. These commands do not edit files, apply refactors,
-execute validation, run vendor tools, invoke `pccx-lab` or the launcher,
-or implement semantic elaboration. The output shapes are pre-stable and
-documented in
+editor tree consumers. `dependencies` renders direct module dependency,
+dependent, and impact summaries from the same scanner data. These
+commands do not edit files, apply refactors, execute validation, run
+vendor tools, invoke `pccx-lab` or the launcher, or implement semantic
+elaboration. The output shapes are pre-stable and documented in
 [`docs/MODULE_ORGANIZATION_WORKFLOW.md`](./docs/MODULE_ORGANIZATION_WORKFLOW.md).
 
 `refactor-plan` emits proposal-only rename-module, extract-port, and
@@ -231,7 +236,8 @@ The initial roadmap for navigation, diagnostics, read-only handoff
 surfaces, external editor planning, and later workflow tracks lives in
 [`docs/ROADMAP.md`](./docs/ROADMAP.md).
 The scanner-based module organization workflow for module boundaries,
-hierarchy views, and proposal-only refactoring planning is documented in
+hierarchy views, dependency views, and proposal-only refactoring planning
+is documented in
 [`docs/MODULE_ORGANIZATION_WORKFLOW.md`](./docs/MODULE_ORGANIZATION_WORKFLOW.md).
 The planned AI-assisted SystemVerilog workflow, permission boundary, and
 pccx-lab controlled MCP/tool dependency are documented in

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -46,6 +46,7 @@ python -m pccx_ide_cli locate <path> <name> --kind any --format json
 # Module organization for editor project trees
 python -m pccx_ide_cli organization <path> --format json
 python -m pccx_ide_cli hierarchy <path> --format json
+python -m pccx_ide_cli dependencies <path> --format json
 
 # Opt-in pccx-lab diagnostics backend
 python -m pccx_ide_cli check <sv-file> --backend pccx-lab --format json
@@ -184,7 +185,9 @@ declaration records.  `declarations` exports those records directly, and
 `locate` resolves exact declaration names by requested kind. `organization`
 adds scanner-based module boundary spans, hierarchy edges, root candidates,
 and proposal-only refactoring metadata for project tree and reviewed
-refactoring workflows. The organization surface is documented in
+refactoring workflows. `hierarchy` and `dependencies` render focused
+read-only views from the same scanner data. The organization surface is
+documented in
 [`MODULE_ORGANIZATION_WORKFLOW.md`](./MODULE_ORGANIZATION_WORKFLOW.md).
 `refactor-plan` extends the same boundary with proposal-only
 rename-module, extract-port, and move-module planning envelopes. It emits

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -3,8 +3,9 @@
 ## Status
 
 This is a pre-stable, scanner-based workflow for organizing modular RTL
-projects. It adds read-only `organization` and `hierarchy` CLI surfaces
-that report module boundary spans and scanner-based hierarchy data for
+projects. It adds read-only `organization`, `hierarchy`, and
+`dependencies` CLI surfaces that report module boundary spans,
+scanner-based hierarchy data, and direct dependency impact data for
 editor navigation and reviewed refactoring planning.
 
 It is not a full SystemVerilog parser, not semantic elaboration, not an LSP
@@ -17,6 +18,8 @@ python -m pccx_ide_cli organization <path> --format json
 python -m pccx_ide_cli organization <path> --format text
 python -m pccx_ide_cli hierarchy <path> --format json
 python -m pccx_ide_cli hierarchy <path> --format text
+python -m pccx_ide_cli dependencies <path> --format json
+python -m pccx_ide_cli dependencies <path> --format text
 python -m pccx_ide_cli refactor-plan <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli refactor-plan <path> --action extract-port --module <name> --port-name <name> --direction input --format text
 python -m pccx_ide_cli refactor-plan <path> --action move-module --module <name> --destination rtl/<name>.sv --format json
@@ -78,6 +81,37 @@ refactors, run validation, execute shell commands, invoke `pccx-lab`,
 invoke the launcher, call providers, touch hardware, upload telemetry, or
 perform automatic repository actions.
 
+The dependency view uses the same scanner data and emits direct dependency
+and dependent summaries for refactor-impact review:
+
+```json
+{
+  "kind": "module-dependency-view",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "dependency_state": "available_as_data",
+  "module_count": 2,
+  "edge_count": 1,
+  "resolved_edge_count": 1,
+  "unresolved_edge_count": 0,
+  "impact": [],
+  "reverse_edges": [],
+  "safety": {
+    "read_only": true,
+    "writes_files": false,
+    "applies_refactor": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The dependency view is display data only. It does not write files, apply
+refactors, generate patches, run validation, execute shell commands,
+invoke `pccx-lab`, invoke the launcher, call providers, touch hardware,
+upload telemetry, or perform automatic repository actions.
+
 ## Module Boundary Detection
 
 Each `modules[]` record describes one scanner-detected `module` declaration:
@@ -121,9 +155,10 @@ scan. `roots[]` lists known modules that are not resolved children, and
 `unresolved[]` lists candidate child types without a local declaration.
 
 This is a visualization seed for editor trees and review workflows. The
-`hierarchy` command renders it as JSON or text tree data. It does not run
-elaboration, expand macros, interpret generate blocks, or replace vendor
-tooling.
+`hierarchy` command renders it as JSON or text tree data, and the
+`dependencies` command renders direct dependency and dependent data. These
+commands do not run elaboration, expand macros, interpret generate blocks,
+or replace vendor tooling.
 
 ## Refactoring Boundary
 
@@ -132,6 +167,7 @@ inputs for later helpers:
 
 - module boundary spans
 - scanner-based hierarchy edges
+- direct dependency and dependent summaries
 - planned helper names for rename, extract-port, and move-module workflows
 
 The CLI does not write files, apply patches, rename symbols, move modules,
@@ -206,4 +242,4 @@ actions.
 This workflow advances
 [`systemverilog-ide#8`](https://github.com/pccxai/systemverilog-ide/issues/8)
 with read-only module boundary detection, a focused hierarchy view, and a
-proposal-only refactoring boundary.
+direct dependency view, plus a proposal-only refactoring boundary.

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -31,6 +31,7 @@ run_json module-index index fixtures/modules --format json
 run_json declarations declarations fixtures/modules --format json
 run_json locate locate fixtures/modules/simple_module.sv simple_mod --format json
 run_json module-hierarchy-view hierarchy fixtures/organization/hierarchy_top.sv --format json
+run_json module-dependency-view dependencies fixtures/organization/hierarchy_top.sv --format json
 run_json module-refactor-proposal refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 
 bash scripts/check-editor-bridge-examples.sh

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -155,6 +155,24 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    dependencies_cmd = sub.add_parser(
+        "dependencies",
+        help=(
+            "Render scanner-based read-only module dependency and impact data."
+        ),
+    )
+    dependencies_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    dependencies_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     refactor_plan_cmd = sub.add_parser(
         "refactor-plan",
         help=(
@@ -459,6 +477,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_hierarchy_text(view))
+        return 0
+
+    if args.command == "dependencies":
+        from .module_organization import (
+            build_module_dependency_view,
+            format_module_dependency_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        view = build_module_dependency_view(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(view, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_dependency_text(view))
         return 0
 
     if args.command == "refactor-plan":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -62,6 +62,16 @@ HIERARCHY_VIEW_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+DEPENDENCY_VIEW_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based module dependency visualization data only",
+    "single-line instantiation candidates only",
+    "direct dependency and dependent summaries only",
+    "no semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
+    "no refactor application, file write, validation run, or patch generation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 REFACTOR_ACTIONS: tuple[str, ...] = (
     "rename-module",
     "extract-port",
@@ -104,6 +114,22 @@ def _refactor_safety_flags() -> dict[str, bool]:
 
 
 def _hierarchy_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "writes_files": False,
+        "applies_refactor": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _dependency_safety_flags() -> dict[str, bool]:
     return {
         "read_only": True,
         "writes_files": False,
@@ -401,6 +427,105 @@ def build_module_hierarchy_view(source: str, path: Path) -> dict[str, Any]:
     }
 
 
+def _dependency_impact_rows(
+    modules: list[dict[str, Any]],
+    hierarchy: dict[str, Any],
+) -> list[dict[str, Any]]:
+    module_names = sorted({module["name"] for module in modules})
+    dependencies_by_module: dict[str, set[str]] = {
+        module_name: set()
+        for module_name in module_names
+    }
+    dependents_by_module: dict[str, set[str]] = {
+        module_name: set()
+        for module_name in module_names
+    }
+    unresolved_by_module: dict[str, set[str]] = {
+        module_name: set()
+        for module_name in module_names
+    }
+
+    for edge in hierarchy["edges"]:
+        parent = edge["parent"]
+        child = edge["child"]
+        if parent not in dependencies_by_module:
+            continue
+        if edge["resolved"]:
+            dependencies_by_module[parent].add(child)
+            dependents_by_module.setdefault(child, set()).add(parent)
+        else:
+            unresolved_by_module[parent].add(child)
+
+    rows: list[dict[str, Any]] = []
+    for module_name in module_names:
+        dependencies = sorted(dependencies_by_module.get(module_name, set()))
+        dependents = sorted(dependents_by_module.get(module_name, set()))
+        unresolved = sorted(unresolved_by_module.get(module_name, set()))
+        rows.append({
+            "direct_dependencies": dependencies,
+            "direct_dependency_count": len(dependencies),
+            "direct_dependents": dependents,
+            "direct_dependent_count": len(dependents),
+            "impact_state": "available_as_data",
+            "module": module_name,
+            "unresolved_dependencies": unresolved,
+            "unresolved_dependency_count": len(unresolved),
+        })
+    return rows
+
+
+def build_module_dependency_view(source: str, path: Path) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    hierarchy = organization["hierarchy"]
+    resolved_edges = [
+        edge
+        for edge in hierarchy["edges"]
+        if edge["resolved"]
+    ]
+
+    reverse_edges = [
+        {
+            "dependent": edge["parent"],
+            "file": edge["file"],
+            "instance": edge["instance"],
+            "line": edge["line"],
+            "module": edge["child"],
+        }
+        for edge in resolved_edges
+    ]
+
+    return {
+        "dependency_state": "available_as_data",
+        "edge_count": len(hierarchy["edges"]),
+        "edges": hierarchy["edges"],
+        "impact": _dependency_impact_rows(modules, hierarchy),
+        "kind": "module-dependency-view",
+        "limitations": list(DEPENDENCY_VIEW_LIMITATIONS),
+        "module_count": len(modules),
+        "resolved_edge_count": len(resolved_edges),
+        "reverse_edges": sorted(
+            reverse_edges,
+            key=lambda e: (
+                e["module"],
+                e["dependent"],
+                e["line"],
+                e["instance"],
+            ),
+        ),
+        "safety": _dependency_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "tool": "pccx-ide-cli",
+        "unresolved": hierarchy["unresolved"],
+        "unresolved_edge_count": len([
+            edge
+            for edge in hierarchy["edges"]
+            if not edge["resolved"]
+        ]),
+    }
+
+
 def _requested_change(
     action: str,
     module_name: str,
@@ -622,6 +747,46 @@ def format_module_hierarchy_text(view: dict[str, Any]) -> str:
                 f"{indent}{row['module']} as {row['via_instance']} "
                 f"({row['state']})"
             )
+    if view["unresolved"]:
+        lines.append(f"unresolved: {', '.join(view['unresolved'])}")
+    lines.append(
+        "read-only: no file writes, refactors, validation, lab, launcher, "
+        "provider, or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_module_dependency_text(view: dict[str, Any]) -> str:
+    lines = [
+        f"source: {view['source']}",
+        f"dependency view: {view['dependency_state']}",
+        f"{view['module_count']} module"
+        f"{'s' if view['module_count'] != 1 else ''}",
+        f"{view['edge_count']} dependency edge"
+        f"{'s' if view['edge_count'] != 1 else ''}",
+        f"{view['resolved_edge_count']} resolved edge"
+        f"{'s' if view['resolved_edge_count'] != 1 else ''}",
+    ]
+    for edge in view["edges"]:
+        state = "resolved" if edge["resolved"] else "unresolved"
+        lines.append(
+            f"{edge['parent']} -> {edge['child']} as {edge['instance']} "
+            f"at {edge['file']}:{edge['line']}:{edge['column']} ({state})"
+        )
+    if not view["edges"]:
+        lines.append("edges: none")
+
+    lines.append("impact:")
+    if not view["impact"]:
+        lines.append("  empty")
+    for row in view["impact"]:
+        dependencies = ", ".join(row["direct_dependencies"]) or "none"
+        dependents = ", ".join(row["direct_dependents"]) or "none"
+        unresolved = ", ".join(row["unresolved_dependencies"]) or "none"
+        lines.append(
+            f"  {row['module']}: dependencies={dependencies}; "
+            f"dependents={dependents}; unresolved={unresolved}"
+        )
     if view["unresolved"]:
         lines.append(f"unresolved: {', '.join(view['unresolved'])}")
     lines.append(

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -18,9 +18,11 @@ WORKFLOW_DOC = REPO_ROOT / "docs" / "MODULE_ORGANIZATION_WORKFLOW.md"
 sys.path.insert(0, str(SRC))
 
 from pccx_ide_cli.module_organization import (  # noqa: E402
+    build_module_dependency_view,
     build_module_hierarchy_view,
     build_module_organization_export,
     build_refactor_proposal,
+    format_module_dependency_text,
     format_module_hierarchy_text,
     format_module_organization_text,
     format_refactor_proposal_text,
@@ -90,6 +92,44 @@ def test_build_module_hierarchy_view_tree_is_read_only():
     assert view["tree"][1]["depth"] == 1
     assert view["tree"][1]["state"] == "resolved"
     assert view["tree"][1]["via_instance"] == "u_leaf"
+    assert view["safety"]["read_only"] is True
+    assert view["safety"]["writes_files"] is False
+    assert view["safety"]["applies_refactor"] is False
+    assert view["safety"]["runs_validation"] is False
+    assert view["safety"]["invokes_pccx_lab"] is False
+    assert view["safety"]["invokes_launcher"] is False
+    assert view["safety"]["provider_calls"] is False
+    assert view["safety"]["hardware_access"] is False
+
+
+def test_build_module_dependency_view_is_read_only():
+    view = build_module_dependency_view(str(FIXTURE), FIXTURE)
+
+    assert view["kind"] == "module-dependency-view"
+    assert view["dependency_state"] == "available_as_data"
+    assert view["module_count"] == 2
+    assert view["edge_count"] == 1
+    assert view["resolved_edge_count"] == 1
+    assert view["unresolved_edge_count"] == 0
+    assert view["edges"][0]["parent"] == "top_mod"
+    assert view["edges"][0]["child"] == "leaf_mod"
+    assert view["reverse_edges"] == [
+        {
+            "dependent": "top_mod",
+            "file": str(FIXTURE),
+            "instance": "u_leaf",
+            "line": 12,
+            "module": "leaf_mod",
+        }
+    ]
+
+    impact = {row["module"]: row for row in view["impact"]}
+    assert impact["top_mod"]["direct_dependencies"] == ["leaf_mod"]
+    assert impact["top_mod"]["direct_dependency_count"] == 1
+    assert impact["top_mod"]["direct_dependents"] == []
+    assert impact["leaf_mod"]["direct_dependencies"] == []
+    assert impact["leaf_mod"]["direct_dependents"] == ["top_mod"]
+    assert impact["leaf_mod"]["direct_dependent_count"] == 1
     assert view["safety"]["read_only"] is True
     assert view["safety"]["writes_files"] is False
     assert view["safety"]["applies_refactor"] is False
@@ -176,6 +216,17 @@ def test_format_module_hierarchy_text_mentions_tree_and_boundary():
     assert "read-only: no file writes" in text
 
 
+def test_format_module_dependency_text_mentions_impact_and_boundary():
+    view = build_module_dependency_view(str(FIXTURE), FIXTURE)
+    text = format_module_dependency_text(view)
+
+    assert "dependency view: available_as_data" in text
+    assert "top_mod -> leaf_mod as u_leaf" in text
+    assert "top_mod: dependencies=leaf_mod; dependents=none" in text
+    assert "leaf_mod: dependencies=none; dependents=top_mod" in text
+    assert "read-only: no file writes" in text
+
+
 def test_format_refactor_proposal_text_mentions_no_execution():
     proposal = build_refactor_proposal(
         str(FIXTURE),
@@ -224,6 +275,22 @@ def test_cli_hierarchy_text():
     assert result.returncode == 0, result.stderr
     assert "hierarchy view: available_as_data" in result.stdout
     assert "leaf_mod as u_leaf (resolved)" in result.stdout
+
+
+def test_cli_dependencies_json():
+    result = _run_cli("dependencies", str(FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-dependency-view"
+    assert payload["impact"][0]["impact_state"] == "available_as_data"
+    assert payload["safety"]["writes_files"] is False
+
+
+def test_cli_dependencies_text():
+    result = _run_cli("dependencies", str(FIXTURE), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "dependency view: available_as_data" in result.stdout
+    assert "leaf_mod: dependencies=none; dependents=top_mod" in result.stdout
 
 
 def test_cli_refactor_plan_json():
@@ -280,13 +347,21 @@ def test_cli_hierarchy_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_dependencies_missing_path_exits_nonzero():
+    result = _run_cli("dependencies", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_docs_cover_organization_flow_and_limits():
     contract = CONTRACT_DOC.read_text(encoding="utf-8")
     workflow = WORKFLOW_DOC.read_text(encoding="utf-8")
     assert "organization <path>" in contract
     assert "hierarchy <path>" in contract
+    assert "dependencies <path>" in contract
     assert "MODULE_ORGANIZATION_WORKFLOW.md" in contract
     assert "proposal-only" in workflow
     assert "module-hierarchy-view" in workflow
+    assert "module-dependency-view" in workflow
     assert "does not write files" in workflow
     assert "not a full SystemVerilog parser" in workflow


### PR DESCRIPTION
## Summary
- add a read-only `dependencies` CLI surface for scanner-detected module dependency and impact data
- report direct dependencies, direct dependents, reverse edges, unresolved counts, and explicit safety flags
- document and test the pre-stable dependency view alongside organization, hierarchy, and proposal-only refactor planning

Refs #8.

## Validation
- `python3 -m pytest -q`
- `python3 -m pytest -q tests/test_module_organization.py`
- `python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py`
- `python3 scripts/check-source-headers.py`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `bash -n scripts/editor-bridge-smoke.sh scripts/check-editor-bridge-examples.sh scripts/vscode-adapter-smoke.sh`
- `git diff --check`
- `git diff --cached --check`
- local claim scan matching CI: `claim-scan clean`
- dependency CLI JSON/text smoke checks over `fixtures/organization/hierarchy_top.sv`
- README sibling-repo link sanity check
- hierarchy and dependency JSON parse smoke checks

## Scope boundary
Read-only scanner data only. This does not write files, apply refactors, generate patches, run validation, run vendor tools, invoke pccx-lab or the launcher, call providers, touch hardware, upload telemetry, perform automatic repository actions, or implement a full parser, LSP, stable API, or marketplace packaging.
