### PR TITLE
Add module summary boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,13 @@ jobs:
               fixtures/organization/hierarchy_top.sv \
               | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-dependency-view'; assert d['safety']['writes_files'] is False"
           echo "dependency view smoke ok"
+      - name: cli smoke (module summary exits zero)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli module-summary \
+              fixtures/organization/hierarchy_top.sv \
+              | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-summary-view'; assert d['safety']['writes_files'] is False"
+          echo "module summary smoke ok"
       - name: cli smoke (index missing path exits non-zero)
         run: |
           set -e

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ python -m pccx_ide_cli hierarchy fixtures/organization/hierarchy_top.sv --format
 python -m pccx_ide_cli dependencies fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli dependencies fixtures/organization/hierarchy_top.sv --format text
 
+# Module header/port summary view (pre-stable, read-only)
+python -m pccx_ide_cli module-summary fixtures/organization/hierarchy_top.sv --format json
+python -m pccx_ide_cli module-summary fixtures/organization/hierarchy_top.sv --format text
+
 # Refactoring proposal export (pre-stable, proposal-only)
 python -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 python -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action extract-port --module top_mod --port-name valid_i --direction input --format text
@@ -184,10 +188,12 @@ CLI bridge scaffold, not semantic resolution or a full parser.
 hierarchy seed, and proposal-only refactoring metadata. `hierarchy`
 renders the same scanner data as a focused read-only hierarchy view for
 editor tree consumers. `dependencies` renders direct module dependency,
-dependent, and impact summaries from the same scanner data. These
-commands do not edit files, apply refactors, execute validation, run
-vendor tools, invoke `pccx-lab` or the launcher, or implement semantic
-elaboration. The output shapes are pre-stable and documented in
+dependent, and impact summaries from the same scanner data.
+`module-summary` renders conservative module header and port summaries
+for editor sidebars and reviewed refactoring planning. These commands do
+not edit files, apply refactors, execute validation, run vendor tools,
+invoke `pccx-lab` or the launcher, or implement semantic elaboration. The
+output shapes are pre-stable and documented in
 [`docs/MODULE_ORGANIZATION_WORKFLOW.md`](./docs/MODULE_ORGANIZATION_WORKFLOW.md).
 
 `refactor-plan` emits proposal-only rename-module, extract-port, and
@@ -236,8 +242,8 @@ The initial roadmap for navigation, diagnostics, read-only handoff
 surfaces, external editor planning, and later workflow tracks lives in
 [`docs/ROADMAP.md`](./docs/ROADMAP.md).
 The scanner-based module organization workflow for module boundaries,
-hierarchy views, dependency views, and proposal-only refactoring planning
-is documented in
+hierarchy views, dependency views, module header/port summaries, and
+proposal-only refactoring planning is documented in
 [`docs/MODULE_ORGANIZATION_WORKFLOW.md`](./docs/MODULE_ORGANIZATION_WORKFLOW.md).
 The planned AI-assisted SystemVerilog workflow, permission boundary, and
 pccx-lab controlled MCP/tool dependency are documented in

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -47,6 +47,7 @@ python -m pccx_ide_cli locate <path> <name> --kind any --format json
 python -m pccx_ide_cli organization <path> --format json
 python -m pccx_ide_cli hierarchy <path> --format json
 python -m pccx_ide_cli dependencies <path> --format json
+python -m pccx_ide_cli module-summary <path> --format json
 
 # Opt-in pccx-lab diagnostics backend
 python -m pccx_ide_cli check <sv-file> --backend pccx-lab --format json
@@ -185,8 +186,9 @@ declaration records.  `declarations` exports those records directly, and
 `locate` resolves exact declaration names by requested kind. `organization`
 adds scanner-based module boundary spans, hierarchy edges, root candidates,
 and proposal-only refactoring metadata for project tree and reviewed
-refactoring workflows. `hierarchy` and `dependencies` render focused
-read-only views from the same scanner data. The organization surface is
+refactoring workflows. `hierarchy`, `dependencies`, and `module-summary`
+render focused read-only views from the same scanner data, including
+conservative module header/port summaries. The organization surface is
 documented in
 [`MODULE_ORGANIZATION_WORKFLOW.md`](./MODULE_ORGANIZATION_WORKFLOW.md).
 `refactor-plan` extends the same boundary with proposal-only
@@ -210,8 +212,9 @@ xsim path, and text surface sketches is documented in
 ## Limitations
 
 - Scanner-based scaffolds, not full SystemVerilog parsing.
-- Module organization and refactor planning are scanner-based; they are not
-  semantic elaboration and do not apply refactors.
+- Module organization, header/port summaries, and refactor planning are
+  scanner-based; they are not semantic elaboration and do not apply
+  refactors.
 - No LSP server in this repository today.
 - No published editor extension or marketplace packaging is implemented
   here.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -435,12 +435,16 @@ The output is pre-stable, scanner-based, and not semantic resolution.
 ## module organization scaffold (active, pre-stable)
 
 `pccx-ide organization` exposes scanner-based module boundary spans and a
-small hierarchy seed for editor/project organization workflows. It builds on
-the same local scanner used by `index`, `declarations`, and `locate`.
+small hierarchy seed for editor/project organization workflows.
+`hierarchy`, `dependencies`, and `module-summary` expose focused
+read-only views for trees, dependency impact, and conservative
+header/port summaries. They build on the same local scanner used by
+`index`, `declarations`, and `locate`.
 
 ```bash
 python -m pccx_ide_cli organization fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli organization fixtures/organization/hierarchy_top.sv --format text
+python -m pccx_ide_cli module-summary fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 ```
 
@@ -473,6 +477,8 @@ JSON output uses:
 ```
 
 The refactoring section is proposal-only and reports `writes_files: false`.
+`module-summary` reports scanner-detected module headers and simple
+ANSI-style port metadata as display data only.
 `refactor-plan` emits a separate proposal-only envelope for rename-module,
 extract-port, and move-module requests. These commands do not apply
 refactors, move files, execute validation, invoke `pccx-lab`, invoke the

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -3,10 +3,11 @@
 ## Status
 
 This is a pre-stable, scanner-based workflow for organizing modular RTL
-projects. It adds read-only `organization`, `hierarchy`, and
-`dependencies` CLI surfaces that report module boundary spans,
-scanner-based hierarchy data, and direct dependency impact data for
-editor navigation and reviewed refactoring planning.
+projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
+and `module-summary` CLI surfaces that report module boundary spans,
+scanner-based hierarchy data, direct dependency impact data, and
+conservative module header/port summaries for editor navigation and
+reviewed refactoring planning.
 
 It is not a full SystemVerilog parser, not semantic elaboration, not an LSP
 implementation, and not a write-capable refactoring engine.
@@ -20,6 +21,8 @@ python -m pccx_ide_cli hierarchy <path> --format json
 python -m pccx_ide_cli hierarchy <path> --format text
 python -m pccx_ide_cli dependencies <path> --format json
 python -m pccx_ide_cli dependencies <path> --format text
+python -m pccx_ide_cli module-summary <path> --format json
+python -m pccx_ide_cli module-summary <path> --format text
 python -m pccx_ide_cli refactor-plan <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli refactor-plan <path> --action extract-port --module <name> --port-name <name> --direction input --format text
 python -m pccx_ide_cli refactor-plan <path> --action move-module --module <name> --destination rtl/<name>.sv --format json
@@ -112,6 +115,57 @@ refactors, generate patches, run validation, execute shell commands,
 invoke `pccx-lab`, invoke the launcher, call providers, touch hardware,
 upload telemetry, or perform automatic repository actions.
 
+The module summary view reports conservative scanner-detected module
+header and port metadata:
+
+```json
+{
+  "kind": "module-summary-view",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "summary_state": "available_as_data",
+  "module_count": 2,
+  "port_count": 2,
+  "modules": [
+    {
+      "name": "top_mod",
+      "header": {
+        "complete": true,
+        "start_line": 9,
+        "end_line": 11,
+        "line_count": 3
+      },
+      "ports": [
+        {
+          "name": "clk",
+          "direction": "input",
+          "width": null,
+          "line": 10,
+          "state": "detected"
+        }
+      ],
+      "readiness": {
+        "state": "ready-for-review",
+        "reasons": []
+      }
+    }
+  ],
+  "safety": {
+    "read_only": true,
+    "writes_files": false,
+    "applies_refactor": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The module summary view is display data only. It does not write files,
+apply refactors, generate patches, run validation, execute shell
+commands, invoke `pccx-lab`, invoke the launcher, call providers, touch
+hardware, upload telemetry, or perform automatic repository actions.
+
 ## Module Boundary Detection
 
 Each `modules[]` record describes one scanner-detected `module` declaration:
@@ -156,9 +210,24 @@ scan. `roots[]` lists known modules that are not resolved children, and
 
 This is a visualization seed for editor trees and review workflows. The
 `hierarchy` command renders it as JSON or text tree data, and the
-`dependencies` command renders direct dependency and dependent data. These
-commands do not run elaboration, expand macros, interpret generate blocks,
-or replace vendor tooling.
+`dependencies` command renders direct dependency and dependent data. The
+`module-summary` command renders conservative module header and port data.
+These commands do not run elaboration, expand macros, interpret generate
+blocks, or replace vendor tooling.
+
+## Module Header And Port Summary
+
+`module-summary` scans each module declaration header up to the first
+semicolon inside the module boundary and reports conservative port records.
+It detects simple ANSI-style `input`, `output`, and `inout` declarations,
+including inherited direction for follow-on comma-separated names when the
+scanner can preserve that context.
+
+This is intended as review input for editor sidebars and later
+proposal-only refactoring helpers. It is not a full SystemVerilog parser:
+non-ANSI body declarations, parameter elaboration, macros, interfaces,
+modports, packages, and semantic type resolution are outside this
+boundary.
 
 ## Refactoring Boundary
 
@@ -168,6 +237,7 @@ inputs for later helpers:
 - module boundary spans
 - scanner-based hierarchy edges
 - direct dependency and dependent summaries
+- conservative module header and port summaries
 - planned helper names for rename, extract-port, and move-module workflows
 
 The CLI does not write files, apply patches, rename symbols, move modules,
@@ -241,5 +311,6 @@ actions.
 
 This workflow advances
 [`systemverilog-ide#8`](https://github.com/pccxai/systemverilog-ide/issues/8)
-with read-only module boundary detection, a focused hierarchy view, and a
-direct dependency view, plus a proposal-only refactoring boundary.
+with read-only module boundary detection, a focused hierarchy view, a
+direct dependency view, conservative module header/port summaries, and a
+proposal-only refactoring boundary.

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -32,6 +32,7 @@ run_json declarations declarations fixtures/modules --format json
 run_json locate locate fixtures/modules/simple_module.sv simple_mod --format json
 run_json module-hierarchy-view hierarchy fixtures/organization/hierarchy_top.sv --format json
 run_json module-dependency-view dependencies fixtures/organization/hierarchy_top.sv --format json
+run_json module-summary-view module-summary fixtures/organization/hierarchy_top.sv --format json
 run_json module-refactor-proposal refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 
 bash scripts/check-editor-bridge-examples.sh

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -173,6 +173,24 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    module_summary_cmd = sub.add_parser(
+        "module-summary",
+        help=(
+            "Render scanner-based read-only module header and port summaries."
+        ),
+    )
+    module_summary_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    module_summary_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     refactor_plan_cmd = sub.add_parser(
         "refactor-plan",
         help=(
@@ -495,6 +513,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_dependency_text(view))
+        return 0
+
+    if args.command == "module-summary":
+        from .module_organization import (
+            build_module_summary_view,
+            format_module_summary_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        view = build_module_summary_view(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(view, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_summary_text(view))
         return 0
 
     if args.command == "refactor-plan":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -13,6 +13,9 @@ _ENDMODULE_RE = re.compile(r"^(\s*)endmodule\b")
 _INSTANCE_RE = re.compile(
     r"^(\s*)([A-Za-z_]\w*)\s+(?:#\s*\([^;]*\)\s*)?([A-Za-z_]\w*)\s*\("
 )
+_IDENT_RE = re.compile(r"\b[A-Za-z_]\w*\b")
+_PORT_DIRECTION_RE = re.compile(r"\b(input|output|inout)\b")
+_PORT_WIDTH_RE = re.compile(r"(\[[^\]]+\])")
 
 _NON_INSTANCE_WORDS: frozenset[str] = frozenset({
     "always",
@@ -45,6 +48,26 @@ _NON_INSTANCE_WORDS: frozenset[str] = frozenset({
     "while",
 })
 
+_PORT_SKIP_WORDS: frozenset[str] = frozenset({
+    "bit",
+    "byte",
+    "input",
+    "inout",
+    "integer",
+    "int",
+    "logic",
+    "longint",
+    "output",
+    "parameter",
+    "reg",
+    "shortint",
+    "signed",
+    "time",
+    "tri",
+    "var",
+    "wire",
+})
+
 LIMITATIONS: tuple[str, ...] = (
     "scanner-based module declarations and endmodule matching only",
     "single-line instantiation candidates only",
@@ -66,6 +89,16 @@ DEPENDENCY_VIEW_LIMITATIONS: tuple[str, ...] = (
     "scanner-based module dependency visualization data only",
     "single-line instantiation candidates only",
     "direct dependency and dependent summaries only",
+    "no semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
+    "no refactor application, file write, validation run, or patch generation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
+MODULE_SUMMARY_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based module header and port summary data only",
+    "ANSI-style port declarations are detected conservatively",
+    "non-ANSI body declarations, parameters, macros, interfaces, and modports are not resolved",
     "no semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
     "no refactor application, file write, validation run, or patch generation",
     "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
@@ -130,6 +163,22 @@ def _hierarchy_safety_flags() -> dict[str, bool]:
 
 
 def _dependency_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "writes_files": False,
+        "applies_refactor": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _module_summary_safety_flags() -> dict[str, bool]:
     return {
         "read_only": True,
         "writes_files": False,
@@ -526,6 +575,185 @@ def build_module_dependency_view(source: str, path: Path) -> dict[str, Any]:
     }
 
 
+def _module_header(
+    module: dict[str, Any],
+    visible_lines: list[tuple[int, str]],
+) -> dict[str, Any]:
+    lines: list[tuple[int, str]] = []
+    header_end_line: int | None = None
+    boundary_end = module["end_line"]
+    for line_num, visible in visible_lines:
+        if line_num < module["start_line"]:
+            continue
+        if boundary_end is not None and line_num >= boundary_end:
+            break
+        lines.append((line_num, visible))
+        if ";" in visible:
+            header_end_line = line_num
+            break
+
+    return {
+        "complete": header_end_line is not None,
+        "end_line": header_end_line,
+        "line_count": len(lines),
+        "lines": lines,
+        "start_line": module["start_line"],
+    }
+
+
+def _port_segments(line: str, module_name: str) -> list[str]:
+    visible = line.split("//", 1)[0]
+    module_prefix = re.match(rf"^\s*module\s+{re.escape(module_name)}\b", visible)
+    if module_prefix:
+        open_paren = visible.find("(", module_prefix.end())
+        if open_paren == -1:
+            return []
+        visible = visible[open_paren + 1:]
+
+    visible = (
+        visible
+        .replace(");", " ")
+        .replace(";", " ")
+        .replace("(", " ")
+        .replace(")", " ")
+    )
+    return [
+        segment.strip()
+        for segment in visible.split(",")
+        if segment.strip()
+    ]
+
+
+def _port_name_from_segment(segment: str) -> str | None:
+    before_default = segment.split("=", 1)[0]
+    identifiers = [
+        identifier
+        for identifier in _IDENT_RE.findall(before_default)
+        if identifier not in _PORT_SKIP_WORDS
+    ]
+    return identifiers[-1] if identifiers else None
+
+
+def _scan_header_ports(
+    module: dict[str, Any],
+    header_lines: list[tuple[int, str]],
+) -> list[dict[str, Any]]:
+    ports: list[dict[str, Any]] = []
+    current_direction: str | None = None
+    current_width: str | None = None
+    seen_names: set[str] = set()
+
+    for line_num, visible in header_lines:
+        for segment in _port_segments(visible, module["name"]):
+            if "parameter" in _IDENT_RE.findall(segment):
+                current_direction = None
+                current_width = None
+                continue
+
+            direction_match = _PORT_DIRECTION_RE.search(segment)
+            width_match = _PORT_WIDTH_RE.search(segment)
+            if direction_match:
+                current_direction = direction_match.group(1)
+                current_width = width_match.group(1) if width_match else None
+                state = "detected"
+            elif current_direction is not None:
+                state = "inherited-direction"
+            else:
+                state = "direction-unknown"
+
+            name = _port_name_from_segment(segment)
+            if name is None or name in seen_names:
+                continue
+
+            seen_names.add(name)
+            ports.append({
+                "direction": current_direction or "unknown",
+                "line": line_num,
+                "name": name,
+                "state": state,
+                "width": current_width,
+            })
+
+    return ports
+
+
+def _port_direction_counts(ports: list[dict[str, Any]]) -> dict[str, int]:
+    counts = {
+        "input": 0,
+        "output": 0,
+        "inout": 0,
+        "unknown": 0,
+    }
+    for port in ports:
+        counts[port["direction"]] = counts.get(port["direction"], 0) + 1
+    return counts
+
+
+def _module_summary_readiness(
+    module: dict[str, Any],
+    header: dict[str, Any],
+) -> dict[str, Any]:
+    reasons: list[str] = []
+    if not module["complete"]:
+        reasons.append(f"module boundary is incomplete: {module['name']}")
+    if not header["complete"]:
+        reasons.append(f"module header is incomplete: {module['name']}")
+    return {
+        "reasons": reasons,
+        "state": "blocked" if reasons else "ready-for-review",
+    }
+
+
+def _module_summary_rows(
+    modules: list[dict[str, Any]],
+    visible_lines_by_file: dict[str, list[tuple[int, str]]],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for module in modules:
+        header = _module_header(module, visible_lines_by_file[module["file"]])
+        ports = _scan_header_ports(module, header["lines"])
+        rows.append({
+            "boundary": _module_summary(module),
+            "file": module["file"],
+            "header": {
+                "complete": header["complete"],
+                "end_line": header["end_line"],
+                "line_count": header["line_count"],
+                "start_line": header["start_line"],
+            },
+            "name": module["name"],
+            "port_count": len(ports),
+            "port_direction_counts": _port_direction_counts(ports),
+            "ports": ports,
+            "readiness": _module_summary_readiness(module, header),
+        })
+    return rows
+
+
+def build_module_summary_view(source: str, path: Path) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    files = sorted({module["file"] for module in modules})
+    visible_lines_by_file = {
+        file_name: _visible_lines(Path(file_name))
+        for file_name in files
+    }
+    summaries = _module_summary_rows(modules, visible_lines_by_file)
+
+    return {
+        "kind": "module-summary-view",
+        "limitations": list(MODULE_SUMMARY_LIMITATIONS),
+        "module_count": len(summaries),
+        "modules": summaries,
+        "port_count": sum(summary["port_count"] for summary in summaries),
+        "safety": _module_summary_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "summary_state": "available_as_data",
+        "tool": "pccx-ide-cli",
+    }
+
+
 def _requested_change(
     action: str,
     module_name: str,
@@ -789,6 +1017,39 @@ def format_module_dependency_text(view: dict[str, Any]) -> str:
         )
     if view["unresolved"]:
         lines.append(f"unresolved: {', '.join(view['unresolved'])}")
+    lines.append(
+        "read-only: no file writes, refactors, validation, lab, launcher, "
+        "provider, or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_module_summary_text(view: dict[str, Any]) -> str:
+    lines = [
+        f"source: {view['source']}",
+        f"module summary: {view['summary_state']}",
+        f"{view['module_count']} module"
+        f"{'s' if view['module_count'] != 1 else ''}",
+        f"{view['port_count']} port"
+        f"{'s' if view['port_count'] != 1 else ''}",
+    ]
+    for module in view["modules"]:
+        header_state = "complete" if module["header"]["complete"] else "incomplete"
+        readiness = module["readiness"]["state"]
+        lines.append(
+            f"{module['file']}:{module['boundary']['start_line']}: "
+            f"module {module['name']} ({header_state} header, {readiness})"
+        )
+        if not module["ports"]:
+            lines.append("  ports: none")
+        for port in module["ports"]:
+            width = f" {port['width']}" if port["width"] else ""
+            lines.append(
+                f"  {port['direction']}{width} {port['name']} "
+                f"at line {port['line']} ({port['state']})"
+            )
+        for reason in module["readiness"]["reasons"]:
+            lines.append(f"  blocked: {reason}")
     lines.append(
         "read-only: no file writes, refactors, validation, lab, launcher, "
         "provider, or hardware execution"

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -21,10 +21,12 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_dependency_view,
     build_module_hierarchy_view,
     build_module_organization_export,
+    build_module_summary_view,
     build_refactor_proposal,
     format_module_dependency_text,
     format_module_hierarchy_text,
     format_module_organization_text,
+    format_module_summary_text,
     format_refactor_proposal_text,
 )
 
@@ -140,6 +142,67 @@ def test_build_module_dependency_view_is_read_only():
     assert view["safety"]["hardware_access"] is False
 
 
+def test_build_module_summary_view_reports_ports_and_safety():
+    view = build_module_summary_view(str(FIXTURE), FIXTURE)
+
+    assert view["kind"] == "module-summary-view"
+    assert view["summary_state"] == "available_as_data"
+    assert view["module_count"] == 2
+    assert view["port_count"] == 2
+    modules = {module["name"]: module for module in view["modules"]}
+    assert set(modules) == {"leaf_mod", "top_mod"}
+    assert modules["leaf_mod"]["header"]["complete"] is True
+    assert modules["leaf_mod"]["readiness"]["state"] == "ready-for-review"
+    assert modules["leaf_mod"]["port_count"] == 1
+    assert modules["leaf_mod"]["port_direction_counts"]["input"] == 1
+    assert modules["leaf_mod"]["ports"] == [
+        {
+            "direction": "input",
+            "line": 5,
+            "name": "clk",
+            "state": "detected",
+            "width": None,
+        }
+    ]
+    assert view["safety"]["read_only"] is True
+    assert view["safety"]["writes_files"] is False
+    assert view["safety"]["applies_refactor"] is False
+    assert view["safety"]["runs_validation"] is False
+    assert view["safety"]["invokes_pccx_lab"] is False
+    assert view["safety"]["invokes_launcher"] is False
+    assert view["safety"]["provider_calls"] is False
+    assert view["safety"]["hardware_access"] is False
+
+
+def test_build_module_summary_view_inherits_port_direction(tmp_path):
+    source = tmp_path / "ports.sv"
+    source.write_text(
+        "\n".join([
+            "module ported (",
+            "    input logic [7:0] data_i,",
+            "    valid_i,",
+            "    output logic done_o",
+            ");",
+            "endmodule",
+            "",
+        ]),
+        encoding="utf-8",
+    )
+
+    view = build_module_summary_view(str(source), source)
+    module = view["modules"][0]
+    ports = {port["name"]: port for port in module["ports"]}
+
+    assert module["port_count"] == 3
+    assert ports["data_i"]["direction"] == "input"
+    assert ports["data_i"]["width"] == "[7:0]"
+    assert ports["valid_i"]["direction"] == "input"
+    assert ports["valid_i"]["state"] == "inherited-direction"
+    assert ports["valid_i"]["width"] == "[7:0]"
+    assert ports["done_o"]["direction"] == "output"
+    assert ports["done_o"]["state"] == "detected"
+
+
 def test_build_module_organization_export_refactoring_is_proposal_only():
     export = build_module_organization_export(str(FIXTURE), FIXTURE)
     assert export["refactoring"]["mode"] == "proposal-only"
@@ -227,6 +290,17 @@ def test_format_module_dependency_text_mentions_impact_and_boundary():
     assert "read-only: no file writes" in text
 
 
+def test_format_module_summary_text_mentions_ports_and_boundary():
+    view = build_module_summary_view(str(FIXTURE), FIXTURE)
+    text = format_module_summary_text(view)
+
+    assert "module summary: available_as_data" in text
+    assert "2 ports" in text
+    assert "module leaf_mod (complete header, ready-for-review)" in text
+    assert "input clk at line 5 (detected)" in text
+    assert "read-only: no file writes" in text
+
+
 def test_format_refactor_proposal_text_mentions_no_execution():
     proposal = build_refactor_proposal(
         str(FIXTURE),
@@ -293,6 +367,23 @@ def test_cli_dependencies_text():
     assert "leaf_mod: dependencies=none; dependents=top_mod" in result.stdout
 
 
+def test_cli_module_summary_json():
+    result = _run_cli("module-summary", str(FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-summary-view"
+    assert payload["port_count"] == 2
+    assert payload["modules"][0]["ports"][0]["name"] == "clk"
+    assert payload["safety"]["writes_files"] is False
+
+
+def test_cli_module_summary_text():
+    result = _run_cli("module-summary", str(FIXTURE), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "module summary: available_as_data" in result.stdout
+    assert "input clk at line 5 (detected)" in result.stdout
+
+
 def test_cli_refactor_plan_json():
     result = _run_cli(
         "refactor-plan",
@@ -353,15 +444,23 @@ def test_cli_dependencies_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_module_summary_missing_path_exits_nonzero():
+    result = _run_cli("module-summary", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_docs_cover_organization_flow_and_limits():
     contract = CONTRACT_DOC.read_text(encoding="utf-8")
     workflow = WORKFLOW_DOC.read_text(encoding="utf-8")
     assert "organization <path>" in contract
     assert "hierarchy <path>" in contract
     assert "dependencies <path>" in contract
+    assert "module-summary <path>" in contract
     assert "MODULE_ORGANIZATION_WORKFLOW.md" in contract
     assert "proposal-only" in workflow
     assert "module-hierarchy-view" in workflow
     assert "module-dependency-view" in workflow
+    assert "module-summary-view" in workflow
     assert "does not write files" in workflow
     assert "not a full SystemVerilog parser" in workflow


### PR DESCRIPTION
## Summary
- add a read-only `module-summary` CLI view for scanner-detected module headers and conservative port metadata
- document the pre-stable summary shape alongside organization, hierarchy, dependencies, and refactor-plan surfaces
- add pytest, smoke, and CI coverage for the new command

Refs pccxai/systemverilog-ide#8.

## Validation
- `python3 -m pytest tests/test_module_organization.py tests/test_repository_hygiene.py -q`
- `python3 -m pytest -q`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `git diff --check`
- local claim scan

## Scope Notes
This is scanner-based display data only. It does not write files, apply refactors, generate patches, run validation commands, invoke pccx-lab, invoke the launcher, call providers, touch hardware, upload telemetry, or perform automatic repository actions.