### PR TITLE
Add refactor impact boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,13 @@ jobs:
               fixtures/organization/hierarchy_top.sv \
               | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-summary-view'; assert d['safety']['writes_files'] is False"
           echo "module summary smoke ok"
+      - name: cli smoke (refactor impact exits zero)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli refactor-impact \
+              fixtures/organization/hierarchy_top.sv --module leaf_mod \
+              | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-refactor-impact-view'; assert d['safety']['writes_files'] is False"
+          echo "refactor impact smoke ok"
       - name: cli smoke (index missing path exits non-zero)
         run: |
           set -e

--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ python -m pccx_ide_cli dependencies fixtures/organization/hierarchy_top.sv --for
 python -m pccx_ide_cli module-summary fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli module-summary fixtures/organization/hierarchy_top.sv --format text
 
+# Target-specific refactor impact view (pre-stable, read-only)
+python -m pccx_ide_cli refactor-impact fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
+python -m pccx_ide_cli refactor-impact fixtures/organization/hierarchy_top.sv --module leaf_mod --format text
+
 # Refactoring proposal export (pre-stable, proposal-only)
 python -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 python -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action extract-port --module top_mod --port-name valid_i --direction input --format text
@@ -190,10 +194,12 @@ renders the same scanner data as a focused read-only hierarchy view for
 editor tree consumers. `dependencies` renders direct module dependency,
 dependent, and impact summaries from the same scanner data.
 `module-summary` renders conservative module header and port summaries
-for editor sidebars and reviewed refactoring planning. These commands do
-not edit files, apply refactors, execute validation, run vendor tools,
-invoke `pccx-lab` or the launcher, or implement semantic elaboration. The
-output shapes are pre-stable and documented in
+for editor sidebars and reviewed refactoring planning. `refactor-impact`
+renders target-specific declaration, dependent, and dependency review
+data for a named module. These commands do not edit files, apply
+refactors, execute validation, run vendor tools, invoke `pccx-lab` or the
+launcher, or implement semantic elaboration. The output shapes are
+pre-stable and documented in
 [`docs/MODULE_ORGANIZATION_WORKFLOW.md`](./docs/MODULE_ORGANIZATION_WORKFLOW.md).
 
 `refactor-plan` emits proposal-only rename-module, extract-port, and
@@ -243,7 +249,8 @@ surfaces, external editor planning, and later workflow tracks lives in
 [`docs/ROADMAP.md`](./docs/ROADMAP.md).
 The scanner-based module organization workflow for module boundaries,
 hierarchy views, dependency views, module header/port summaries, and
-proposal-only refactoring planning is documented in
+target-specific refactor impact review data plus proposal-only
+refactoring planning is documented in
 [`docs/MODULE_ORGANIZATION_WORKFLOW.md`](./docs/MODULE_ORGANIZATION_WORKFLOW.md).
 The planned AI-assisted SystemVerilog workflow, permission boundary, and
 pccx-lab controlled MCP/tool dependency are documented in

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -48,6 +48,7 @@ python -m pccx_ide_cli organization <path> --format json
 python -m pccx_ide_cli hierarchy <path> --format json
 python -m pccx_ide_cli dependencies <path> --format json
 python -m pccx_ide_cli module-summary <path> --format json
+python -m pccx_ide_cli refactor-impact <path> --module <name> --format json
 
 # Opt-in pccx-lab diagnostics backend
 python -m pccx_ide_cli check <sv-file> --backend pccx-lab --format json
@@ -186,9 +187,10 @@ declaration records.  `declarations` exports those records directly, and
 `locate` resolves exact declaration names by requested kind. `organization`
 adds scanner-based module boundary spans, hierarchy edges, root candidates,
 and proposal-only refactoring metadata for project tree and reviewed
-refactoring workflows. `hierarchy`, `dependencies`, and `module-summary`
-render focused read-only views from the same scanner data, including
-conservative module header/port summaries. The organization surface is
+refactoring workflows. `hierarchy`, `dependencies`, `module-summary`, and
+`refactor-impact` render focused read-only views from the same scanner
+data, including conservative module header/port summaries and
+target-specific refactor impact review data. The organization surface is
 documented in
 [`MODULE_ORGANIZATION_WORKFLOW.md`](./MODULE_ORGANIZATION_WORKFLOW.md).
 `refactor-plan` extends the same boundary with proposal-only
@@ -212,9 +214,9 @@ xsim path, and text surface sketches is documented in
 ## Limitations
 
 - Scanner-based scaffolds, not full SystemVerilog parsing.
-- Module organization, header/port summaries, and refactor planning are
-  scanner-based; they are not semantic elaboration and do not apply
-  refactors.
+- Module organization, header/port summaries, refactor impact review, and
+  refactor planning are scanner-based; they are not semantic elaboration
+  and do not apply refactors.
 - No LSP server in this repository today.
 - No published editor extension or marketplace packaging is implemented
   here.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -436,15 +436,17 @@ The output is pre-stable, scanner-based, and not semantic resolution.
 
 `pccx-ide organization` exposes scanner-based module boundary spans and a
 small hierarchy seed for editor/project organization workflows.
-`hierarchy`, `dependencies`, and `module-summary` expose focused
-read-only views for trees, dependency impact, and conservative
-header/port summaries. They build on the same local scanner used by
-`index`, `declarations`, and `locate`.
+`hierarchy`, `dependencies`, `module-summary`, and `refactor-impact`
+expose focused read-only views for trees, dependency impact,
+conservative header/port summaries, and target-specific refactor review
+data. They build on the same local scanner used by `index`,
+`declarations`, and `locate`.
 
 ```bash
 python -m pccx_ide_cli organization fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli organization fixtures/organization/hierarchy_top.sv --format text
 python -m pccx_ide_cli module-summary fixtures/organization/hierarchy_top.sv --format json
+python -m pccx_ide_cli refactor-impact fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
 python -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 ```
 
@@ -479,6 +481,9 @@ JSON output uses:
 The refactoring section is proposal-only and reports `writes_files: false`.
 `module-summary` reports scanner-detected module headers and simple
 ANSI-style port metadata as display data only.
+`refactor-impact` reports a target module declaration, dependent
+instantiation references, and direct dependency references as display
+data only.
 `refactor-plan` emits a separate proposal-only envelope for rename-module,
 extract-port, and move-module requests. These commands do not apply
 refactors, move files, execute validation, invoke `pccx-lab`, invoke the

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -4,10 +4,11 @@
 
 This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
-and `module-summary` CLI surfaces that report module boundary spans,
-scanner-based hierarchy data, direct dependency impact data, and
-conservative module header/port summaries for editor navigation and
-reviewed refactoring planning.
+`module-summary`, and `refactor-impact` CLI surfaces that report module
+boundary spans, scanner-based hierarchy data, direct dependency impact
+data, conservative module header/port summaries, and target-specific
+refactor impact data for editor navigation and reviewed refactoring
+planning.
 
 It is not a full SystemVerilog parser, not semantic elaboration, not an LSP
 implementation, and not a write-capable refactoring engine.
@@ -23,6 +24,8 @@ python -m pccx_ide_cli dependencies <path> --format json
 python -m pccx_ide_cli dependencies <path> --format text
 python -m pccx_ide_cli module-summary <path> --format json
 python -m pccx_ide_cli module-summary <path> --format text
+python -m pccx_ide_cli refactor-impact <path> --module <name> --format json
+python -m pccx_ide_cli refactor-impact <path> --module <name> --format text
 python -m pccx_ide_cli refactor-plan <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli refactor-plan <path> --action extract-port --module <name> --port-name <name> --direction input --format text
 python -m pccx_ide_cli refactor-plan <path> --action move-module --module <name> --destination rtl/<name>.sv --format json
@@ -166,6 +169,42 @@ apply refactors, generate patches, run validation, execute shell
 commands, invoke `pccx-lab`, invoke the launcher, call providers, touch
 hardware, upload telemetry, or perform automatic repository actions.
 
+The refactor impact view reports target-specific review data for a module:
+
+```json
+{
+  "kind": "module-refactor-impact-view",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "target": "leaf_mod",
+  "impact_state": "available_as_data",
+  "writes_files": false,
+  "preflight": {
+    "status": "ready-for-review",
+    "requires_approval_before_write": true,
+    "reasons": []
+  },
+  "direct_dependencies": [],
+  "direct_dependents": ["top_mod"],
+  "dependent_edges": [],
+  "dependency_edges": [],
+  "review_targets": [],
+  "safety": {
+    "read_only": true,
+    "writes_files": false,
+    "applies_refactor": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The refactor impact view is review data only. It does not write files,
+apply refactors, move files, generate patches, run validation, execute
+shell commands, invoke `pccx-lab`, invoke the launcher, call providers,
+touch hardware, upload telemetry, or perform automatic repository actions.
+
 ## Module Boundary Detection
 
 Each `modules[]` record describes one scanner-detected `module` declaration:
@@ -229,6 +268,19 @@ non-ANSI body declarations, parameter elaboration, macros, interfaces,
 modports, packages, and semantic type resolution are outside this
 boundary.
 
+## Refactor Impact Review
+
+`refactor-impact` accepts a target module name and reports scanner-detected
+review targets for rename, extract-port, and move-module planning. It
+includes the target declaration when the target is unambiguous, direct
+dependent instantiation references, direct dependency instantiation
+references, unresolved dependency names, and preflight reasons when the
+target is missing, ambiguous, or has an incomplete boundary.
+
+This surface is intentionally target-specific review data. It does not
+prepare a patch, rewrite symbols, edit ports, move files, or execute
+validation. Write-capable helpers remain a separate future boundary.
+
 ## Refactoring Boundary
 
 Refactoring remains proposal-only. The current workflow provides candidate
@@ -238,6 +290,7 @@ inputs for later helpers:
 - scanner-based hierarchy edges
 - direct dependency and dependent summaries
 - conservative module header and port summaries
+- target-specific refactor impact review data
 - planned helper names for rename, extract-port, and move-module workflows
 
 The CLI does not write files, apply patches, rename symbols, move modules,
@@ -312,5 +365,6 @@ actions.
 This workflow advances
 [`systemverilog-ide#8`](https://github.com/pccxai/systemverilog-ide/issues/8)
 with read-only module boundary detection, a focused hierarchy view, a
-direct dependency view, conservative module header/port summaries, and a
-proposal-only refactoring boundary.
+direct dependency view, conservative module header/port summaries,
+target-specific refactor impact review data, and a proposal-only
+refactoring boundary.

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -33,6 +33,7 @@ run_json locate locate fixtures/modules/simple_module.sv simple_mod --format jso
 run_json module-hierarchy-view hierarchy fixtures/organization/hierarchy_top.sv --format json
 run_json module-dependency-view dependencies fixtures/organization/hierarchy_top.sv --format json
 run_json module-summary-view module-summary fixtures/organization/hierarchy_top.sv --format json
+run_json module-refactor-impact-view refactor-impact fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
 run_json module-refactor-proposal refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 
 bash scripts/check-editor-bridge-examples.sh

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -191,6 +191,29 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    refactor_impact_cmd = sub.add_parser(
+        "refactor-impact",
+        help=(
+            "Emit read-only scanner-based impact data for a refactor target."
+        ),
+    )
+    refactor_impact_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    refactor_impact_cmd.add_argument(
+        "--module",
+        required=True,
+        help="Exact module name to inspect for review impact.",
+    )
+    refactor_impact_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     refactor_plan_cmd = sub.add_parser(
         "refactor-plan",
         help=(
@@ -531,6 +554,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_summary_text(view))
+        return 0
+
+    if args.command == "refactor-impact":
+        from .module_organization import (
+            build_refactor_impact_view,
+            format_refactor_impact_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        view = build_refactor_impact_view(str(args.path), args.path, args.module)
+        if args.format == "json":
+            json.dump(view, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_refactor_impact_text(view))
         return 0
 
     if args.command == "refactor-plan":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -105,6 +105,16 @@ MODULE_SUMMARY_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+REFACTOR_IMPACT_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based target-specific refactor impact data only",
+    "module declarations and single-line instantiation candidates only",
+    "direct dependency and dependent references only",
+    "no symbol rewrite, port rewrite, file move, validation run, or patch generation",
+    "no semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 REFACTOR_ACTIONS: tuple[str, ...] = (
     "rename-module",
     "extract-port",
@@ -183,6 +193,24 @@ def _module_summary_safety_flags() -> dict[str, bool]:
         "read_only": True,
         "writes_files": False,
         "applies_refactor": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _refactor_impact_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "writes_files": False,
+        "applies_refactor": False,
+        "moves_files": False,
+        "applies_patch": False,
         "runs_validation": False,
         "runs_shell": False,
         "invokes_pccx_lab": False,
@@ -754,6 +782,126 @@ def build_module_summary_view(source: str, path: Path) -> dict[str, Any]:
     }
 
 
+def _refactor_impact_preflight(
+    module_name: str,
+    matches: list[dict[str, Any]],
+) -> dict[str, Any]:
+    reasons: list[str] = []
+    if len(matches) == 0:
+        reasons.append(f"module not found: {module_name}")
+    elif len(matches) > 1:
+        reasons.append(f"ambiguous module name: {module_name}")
+    elif not matches[0]["complete"]:
+        reasons.append(f"module boundary is incomplete: {module_name}")
+
+    return {
+        "reasons": reasons,
+        "requires_approval_before_write": True,
+        "status": "blocked" if reasons else "ready-for-review",
+    }
+
+
+def _edge_review_target(edge: dict[str, Any], kind: str) -> dict[str, Any]:
+    return {
+        "child": edge["child"],
+        "column": edge["column"],
+        "file": edge["file"],
+        "instance": edge["instance"],
+        "kind": kind,
+        "line": edge["line"],
+        "parent": edge["parent"],
+        "resolved": edge["resolved"],
+    }
+
+
+def _refactor_impact_review_targets(
+    module: dict[str, Any] | None,
+    dependent_edges: list[dict[str, Any]],
+    dependency_edges: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    targets: list[dict[str, Any]] = []
+    if module is not None:
+        targets.append({
+            "column": module["start_column"],
+            "file": module["file"],
+            "kind": "module-declaration",
+            "line": module["start_line"],
+            "module": module["name"],
+        })
+    targets.extend(
+        _edge_review_target(edge, "dependent-instantiation")
+        for edge in dependent_edges
+    )
+    targets.extend(
+        _edge_review_target(edge, "dependency-instantiation")
+        for edge in dependency_edges
+    )
+    return targets
+
+
+def build_refactor_impact_view(
+    source: str,
+    path: Path,
+    module_name: str,
+) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    hierarchy = organization["hierarchy"]
+    matches = _module_lookup(modules, module_name)
+    selected_module = matches[0] if len(matches) == 1 else None
+    dependency_edges = [
+        edge
+        for edge in hierarchy["edges"]
+        if edge["parent"] == module_name
+    ]
+    dependent_edges = [
+        edge
+        for edge in hierarchy["edges"]
+        if edge["child"] == module_name
+    ]
+    direct_dependencies = sorted({
+        edge["child"]
+        for edge in dependency_edges
+        if edge["resolved"]
+    })
+    unresolved_dependencies = sorted({
+        edge["child"]
+        for edge in dependency_edges
+        if not edge["resolved"]
+    })
+    direct_dependents = sorted({
+        edge["parent"]
+        for edge in dependent_edges
+    })
+
+    return {
+        "dependency_edges": dependency_edges,
+        "dependent_edges": dependent_edges,
+        "direct_dependencies": direct_dependencies,
+        "direct_dependency_count": len(direct_dependencies),
+        "direct_dependents": direct_dependents,
+        "direct_dependent_count": len(direct_dependents),
+        "impact_state": "available_as_data",
+        "kind": "module-refactor-impact-view",
+        "limitations": list(REFACTOR_IMPACT_LIMITATIONS),
+        "module": selected_module,
+        "preflight": _refactor_impact_preflight(module_name, matches),
+        "review_targets": _refactor_impact_review_targets(
+            selected_module,
+            dependent_edges,
+            dependency_edges,
+        ),
+        "safety": _refactor_impact_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "target": module_name,
+        "tool": "pccx-ide-cli",
+        "unresolved_dependencies": unresolved_dependencies,
+        "unresolved_dependency_count": len(unresolved_dependencies),
+        "writes_files": False,
+    }
+
+
 def _requested_change(
     action: str,
     module_name: str,
@@ -1050,6 +1198,55 @@ def format_module_summary_text(view: dict[str, Any]) -> str:
             )
         for reason in module["readiness"]["reasons"]:
             lines.append(f"  blocked: {reason}")
+    lines.append(
+        "read-only: no file writes, refactors, validation, lab, launcher, "
+        "provider, or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_refactor_impact_text(view: dict[str, Any]) -> str:
+    lines = [
+        f"source: {view['source']}",
+        f"target: {view['target']}",
+        f"refactor impact: {view['impact_state']}",
+        f"preflight: {view['preflight']['status']}",
+        "writes files: no",
+    ]
+    module = view["module"]
+    if module is not None:
+        lines.append(
+            f"declaration: {module['file']}:{module['start_line']}:"
+            f"{module['start_column']}"
+        )
+
+    dependencies = ", ".join(view["direct_dependencies"]) or "none"
+    dependents = ", ".join(view["direct_dependents"]) or "none"
+    unresolved = ", ".join(view["unresolved_dependencies"]) or "none"
+    lines.append(f"dependencies: {dependencies}")
+    lines.append(f"dependents: {dependents}")
+    lines.append(f"unresolved dependencies: {unresolved}")
+
+    if view["dependent_edges"]:
+        lines.append("dependent references:")
+        for edge in view["dependent_edges"]:
+            state = "resolved" if edge["resolved"] else "unresolved"
+            lines.append(
+                f"  {edge['parent']} instantiates {edge['child']} "
+                f"as {edge['instance']} at {edge['file']}:"
+                f"{edge['line']}:{edge['column']} ({state})"
+            )
+    if view["dependency_edges"]:
+        lines.append("dependency references:")
+        for edge in view["dependency_edges"]:
+            state = "resolved" if edge["resolved"] else "unresolved"
+            lines.append(
+                f"  {edge['parent']} instantiates {edge['child']} "
+                f"as {edge['instance']} at {edge['file']}:"
+                f"{edge['line']}:{edge['column']} ({state})"
+            )
+    for reason in view["preflight"]["reasons"]:
+        lines.append(f"blocked: {reason}")
     lines.append(
         "read-only: no file writes, refactors, validation, lab, launcher, "
         "provider, or hardware execution"

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -22,11 +22,13 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_hierarchy_view,
     build_module_organization_export,
     build_module_summary_view,
+    build_refactor_impact_view,
     build_refactor_proposal,
     format_module_dependency_text,
     format_module_hierarchy_text,
     format_module_organization_text,
     format_module_summary_text,
+    format_refactor_impact_text,
     format_refactor_proposal_text,
 )
 
@@ -203,6 +205,53 @@ def test_build_module_summary_view_inherits_port_direction(tmp_path):
     assert ports["done_o"]["state"] == "detected"
 
 
+def test_build_refactor_impact_view_reports_target_references():
+    view = build_refactor_impact_view(str(FIXTURE), FIXTURE, "leaf_mod")
+
+    assert view["kind"] == "module-refactor-impact-view"
+    assert view["impact_state"] == "available_as_data"
+    assert view["target"] == "leaf_mod"
+    assert view["preflight"]["status"] == "ready-for-review"
+    assert view["writes_files"] is False
+    assert view["module"]["name"] == "leaf_mod"
+    assert view["direct_dependencies"] == []
+    assert view["direct_dependents"] == ["top_mod"]
+    assert view["dependent_edges"] == [
+        {
+            "child": "leaf_mod",
+            "column": 5,
+            "file": str(FIXTURE),
+            "instance": "u_leaf",
+            "line": 12,
+            "parent": "top_mod",
+            "resolved": True,
+        }
+    ]
+    assert [target["kind"] for target in view["review_targets"]] == [
+        "module-declaration",
+        "dependent-instantiation",
+    ]
+    assert view["safety"]["read_only"] is True
+    assert view["safety"]["writes_files"] is False
+    assert view["safety"]["applies_refactor"] is False
+    assert view["safety"]["applies_patch"] is False
+    assert view["safety"]["runs_validation"] is False
+    assert view["safety"]["invokes_pccx_lab"] is False
+    assert view["safety"]["invokes_launcher"] is False
+    assert view["safety"]["provider_calls"] is False
+    assert view["safety"]["hardware_access"] is False
+
+
+def test_build_refactor_impact_view_blocks_missing_module():
+    view = build_refactor_impact_view(str(FIXTURE), FIXTURE, "missing_mod")
+
+    assert view["preflight"]["status"] == "blocked"
+    assert "module not found: missing_mod" in view["preflight"]["reasons"]
+    assert view["module"] is None
+    assert view["review_targets"] == []
+    assert view["writes_files"] is False
+
+
 def test_build_module_organization_export_refactoring_is_proposal_only():
     export = build_module_organization_export(str(FIXTURE), FIXTURE)
     assert export["refactoring"]["mode"] == "proposal-only"
@@ -301,6 +350,18 @@ def test_format_module_summary_text_mentions_ports_and_boundary():
     assert "read-only: no file writes" in text
 
 
+def test_format_refactor_impact_text_mentions_references_and_no_execution():
+    view = build_refactor_impact_view(str(FIXTURE), FIXTURE, "leaf_mod")
+    text = format_refactor_impact_text(view)
+
+    assert "refactor impact: available_as_data" in text
+    assert "preflight: ready-for-review" in text
+    assert "dependents: top_mod" in text
+    assert "top_mod instantiates leaf_mod as u_leaf" in text
+    assert "writes files: no" in text
+    assert "read-only: no file writes" in text
+
+
 def test_format_refactor_proposal_text_mentions_no_execution():
     proposal = build_refactor_proposal(
         str(FIXTURE),
@@ -384,6 +445,37 @@ def test_cli_module_summary_text():
     assert "input clk at line 5 (detected)" in result.stdout
 
 
+def test_cli_refactor_impact_json():
+    result = _run_cli(
+        "refactor-impact",
+        str(FIXTURE),
+        "--module",
+        "leaf_mod",
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-refactor-impact-view"
+    assert payload["target"] == "leaf_mod"
+    assert payload["direct_dependents"] == ["top_mod"]
+    assert payload["safety"]["writes_files"] is False
+
+
+def test_cli_refactor_impact_text():
+    result = _run_cli(
+        "refactor-impact",
+        str(FIXTURE),
+        "--module",
+        "leaf_mod",
+        "--format",
+        "text",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "refactor impact: available_as_data" in result.stdout
+    assert "top_mod instantiates leaf_mod as u_leaf" in result.stdout
+
+
 def test_cli_refactor_plan_json():
     result = _run_cli(
         "refactor-plan",
@@ -450,6 +542,17 @@ def test_cli_module_summary_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_refactor_impact_missing_path_exits_nonzero():
+    result = _run_cli(
+        "refactor-impact",
+        str(FIXTURE.parent / "missing.sv"),
+        "--module",
+        "leaf_mod",
+    )
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_docs_cover_organization_flow_and_limits():
     contract = CONTRACT_DOC.read_text(encoding="utf-8")
     workflow = WORKFLOW_DOC.read_text(encoding="utf-8")
@@ -457,10 +560,12 @@ def test_docs_cover_organization_flow_and_limits():
     assert "hierarchy <path>" in contract
     assert "dependencies <path>" in contract
     assert "module-summary <path>" in contract
+    assert "refactor-impact <path>" in contract
     assert "MODULE_ORGANIZATION_WORKFLOW.md" in contract
     assert "proposal-only" in workflow
     assert "module-hierarchy-view" in workflow
     assert "module-dependency-view" in workflow
     assert "module-summary-view" in workflow
+    assert "module-refactor-impact-view" in workflow
     assert "does not write files" in workflow
     assert "not a full SystemVerilog parser" in workflow


### PR DESCRIPTION
## Summary
- add a read-only `refactor-impact` CLI view for a named module target
- report scanner-detected declaration, dependent instantiations, direct dependencies, review targets, and preflight state
- document the pre-stable shape and add pytest, smoke, and CI coverage

Refs pccxai/systemverilog-ide#8.

## Validation
- `python3 -m pytest tests/test_module_organization.py tests/test_repository_hygiene.py -q`
- `python3 -m pytest -q`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `git diff --check`
- local claim scan

## Scope Notes
This is scanner-based review data only. It does not write files, apply refactors, move files, generate patches, run validation commands, invoke pccx-lab, invoke the launcher, call providers, touch hardware, upload telemetry, or perform automatic repository actions.