### PR TITLE
Add module port usage boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ python -m pccx_ide_cli dependencies fixtures/organization/hierarchy_top.sv --for
 python -m pccx_ide_cli module-summary fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli module-summary fixtures/organization/hierarchy_top.sv --format text
 
+# Target port usage view (pre-stable, read-only)
+python -m pccx_ide_cli port-usage fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
+python -m pccx_ide_cli port-usage fixtures/organization/hierarchy_top.sv --module leaf_mod --format text
+
 # Target-specific refactor impact view (pre-stable, read-only)
 python -m pccx_ide_cli refactor-impact fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
 python -m pccx_ide_cli refactor-impact fixtures/organization/hierarchy_top.sv --module leaf_mod --format text
@@ -194,9 +198,11 @@ renders the same scanner data as a focused read-only hierarchy view for
 editor tree consumers. `dependencies` renders direct module dependency,
 dependent, and impact summaries from the same scanner data.
 `module-summary` renders conservative module header and port summaries
-for editor sidebars and reviewed refactoring planning. `refactor-impact`
-renders target-specific declaration, dependent, and dependency review
-data for a named module. These commands do not edit files, apply
+for editor sidebars and reviewed refactoring planning. `port-usage`
+renders target port declarations with scanner-detected dependent
+instantiation connection summaries. `refactor-impact` renders
+target-specific declaration, dependent, and dependency review data for a
+named module. These commands do not edit files, apply
 refactors, execute validation, run vendor tools, invoke `pccx-lab` or the
 launcher, or implement semantic elaboration. The output shapes are
 pre-stable and documented in

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -48,6 +48,7 @@ python -m pccx_ide_cli organization <path> --format json
 python -m pccx_ide_cli hierarchy <path> --format json
 python -m pccx_ide_cli dependencies <path> --format json
 python -m pccx_ide_cli module-summary <path> --format json
+python -m pccx_ide_cli port-usage <path> --module <name> --format json
 python -m pccx_ide_cli refactor-impact <path> --module <name> --format json
 
 # Opt-in pccx-lab diagnostics backend
@@ -187,11 +188,11 @@ declaration records.  `declarations` exports those records directly, and
 `locate` resolves exact declaration names by requested kind. `organization`
 adds scanner-based module boundary spans, hierarchy edges, root candidates,
 and proposal-only refactoring metadata for project tree and reviewed
-refactoring workflows. `hierarchy`, `dependencies`, `module-summary`, and
-`refactor-impact` render focused read-only views from the same scanner
-data, including conservative module header/port summaries and
-target-specific refactor impact review data. The organization surface is
-documented in
+refactoring workflows. `hierarchy`, `dependencies`, `module-summary`,
+`port-usage`, and `refactor-impact` render focused read-only views from
+the same scanner data, including conservative module header/port
+summaries, target port usage summaries, and target-specific refactor
+impact review data. The organization surface is documented in
 [`MODULE_ORGANIZATION_WORKFLOW.md`](./MODULE_ORGANIZATION_WORKFLOW.md).
 `refactor-plan` extends the same boundary with proposal-only
 rename-module, extract-port, and move-module planning envelopes. It emits
@@ -214,9 +215,9 @@ xsim path, and text surface sketches is documented in
 ## Limitations
 
 - Scanner-based scaffolds, not full SystemVerilog parsing.
-- Module organization, header/port summaries, refactor impact review, and
-  refactor planning are scanner-based; they are not semantic elaboration
-  and do not apply refactors.
+- Module organization, header/port summaries, port usage summaries,
+  refactor impact review, and refactor planning are scanner-based; they
+  are not semantic elaboration and do not apply refactors.
 - No LSP server in this repository today.
 - No published editor extension or marketplace packaging is implemented
   here.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -436,16 +436,18 @@ The output is pre-stable, scanner-based, and not semantic resolution.
 
 `pccx-ide organization` exposes scanner-based module boundary spans and a
 small hierarchy seed for editor/project organization workflows.
-`hierarchy`, `dependencies`, `module-summary`, and `refactor-impact`
-expose focused read-only views for trees, dependency impact,
-conservative header/port summaries, and target-specific refactor review
-data. They build on the same local scanner used by `index`,
+`hierarchy`, `dependencies`, `module-summary`, `port-usage`, and
+`refactor-impact` expose focused read-only views for trees, dependency
+impact, conservative header/port summaries, target port usage summaries,
+and target-specific refactor review data. They build on the same local
+scanner used by `index`,
 `declarations`, and `locate`.
 
 ```bash
 python -m pccx_ide_cli organization fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli organization fixtures/organization/hierarchy_top.sv --format text
 python -m pccx_ide_cli module-summary fixtures/organization/hierarchy_top.sv --format json
+python -m pccx_ide_cli port-usage fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
 python -m pccx_ide_cli refactor-impact fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
 python -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 ```
@@ -481,6 +483,9 @@ JSON output uses:
 The refactoring section is proposal-only and reports `writes_files: false`.
 `module-summary` reports scanner-detected module headers and simple
 ANSI-style port metadata as display data only.
+`port-usage` reports a target module's conservative port declarations,
+direct dependents, and scanner-detected usage-site connection summaries
+as display data only.
 `refactor-impact` reports a target module declaration, dependent
 instantiation references, and direct dependency references as display
 data only.

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -4,11 +4,11 @@
 
 This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
-`module-summary`, and `refactor-impact` CLI surfaces that report module
-boundary spans, scanner-based hierarchy data, direct dependency impact
-data, conservative module header/port summaries, and target-specific
-refactor impact data for editor navigation and reviewed refactoring
-planning.
+`module-summary`, `port-usage`, and `refactor-impact` CLI surfaces that
+report module boundary spans, scanner-based hierarchy data, direct
+dependency impact data, conservative module header/port summaries,
+target port usage summaries, and target-specific refactor impact data
+for editor navigation and reviewed refactoring planning.
 
 It is not a full SystemVerilog parser, not semantic elaboration, not an LSP
 implementation, and not a write-capable refactoring engine.
@@ -24,6 +24,8 @@ python -m pccx_ide_cli dependencies <path> --format json
 python -m pccx_ide_cli dependencies <path> --format text
 python -m pccx_ide_cli module-summary <path> --format json
 python -m pccx_ide_cli module-summary <path> --format text
+python -m pccx_ide_cli port-usage <path> --module <name> --format json
+python -m pccx_ide_cli port-usage <path> --module <name> --format text
 python -m pccx_ide_cli refactor-impact <path> --module <name> --format json
 python -m pccx_ide_cli refactor-impact <path> --module <name> --format text
 python -m pccx_ide_cli refactor-plan <path> --action rename-module --module <name> --new-name <name> --format json
@@ -169,6 +171,60 @@ apply refactors, generate patches, run validation, execute shell
 commands, invoke `pccx-lab`, invoke the launcher, call providers, touch
 hardware, upload telemetry, or perform automatic repository actions.
 
+The port usage view reports a target module's conservative port
+declarations and scanner-detected dependent instantiation usage sites:
+
+```json
+{
+  "kind": "module-port-usage-view",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "target": "leaf_mod",
+  "usage_state": "available_as_data",
+  "writes_files": false,
+  "preflight": {
+    "status": "ready-for-review",
+    "requires_approval_before_write": true,
+    "reasons": []
+  },
+  "ports": [
+    {
+      "name": "clk",
+      "direction": "input",
+      "width": null,
+      "line": 5,
+      "state": "detected"
+    }
+  ],
+  "usage_sites": [
+    {
+      "parent": "top_mod",
+      "child": "leaf_mod",
+      "instance": "u_leaf",
+      "connection_style": "named",
+      "connection_names": ["clk"],
+      "semantically_resolved": false
+    }
+  ],
+  "safety": {
+    "read_only": true,
+    "writes_files": false,
+    "applies_refactor": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The port usage view is display data only. It uses the existing
+instantiation scanner and bounded connection text from the candidate
+instantiation statement; it does not semantically resolve named or
+ordered port connections. It does not write files, apply refactors,
+generate patches, run validation, execute shell commands, invoke
+`pccx-lab`, invoke the launcher, call providers, touch hardware, upload
+telemetry, or perform automatic repository actions.
+
 The refactor impact view reports target-specific review data for a module:
 
 ```json
@@ -251,6 +307,8 @@ This is a visualization seed for editor trees and review workflows. The
 `hierarchy` command renders it as JSON or text tree data, and the
 `dependencies` command renders direct dependency and dependent data. The
 `module-summary` command renders conservative module header and port data.
+The `port-usage` command renders a target module's conservative port data
+and dependent instantiation connection summaries.
 These commands do not run elaboration, expand macros, interpret generate
 blocks, or replace vendor tooling.
 
@@ -267,6 +325,20 @@ proposal-only refactoring helpers. It is not a full SystemVerilog parser:
 non-ANSI body declarations, parameter elaboration, macros, interfaces,
 modports, packages, and semantic type resolution are outside this
 boundary.
+
+## Port Usage Review
+
+`port-usage` accepts a target module name and reports the target's
+scanner-detected ANSI-style port declarations, direct dependent modules,
+and dependent instantiation usage sites. For each usage site it reports
+the candidate instance location and a bounded connection summary such as
+named connection names or ordered connection count.
+
+This view is intended as review input for editor sidebars and future
+proposal-only port refactoring helpers. Connection data is not
+semantically resolved: macros, interfaces, generate blocks, parameter
+elaboration, implicit connections, and type compatibility are outside
+this boundary.
 
 ## Refactor Impact Review
 
@@ -290,6 +362,7 @@ inputs for later helpers:
 - scanner-based hierarchy edges
 - direct dependency and dependent summaries
 - conservative module header and port summaries
+- target-specific port usage summaries
 - target-specific refactor impact review data
 - planned helper names for rename, extract-port, and move-module workflows
 
@@ -366,5 +439,5 @@ This workflow advances
 [`systemverilog-ide#8`](https://github.com/pccxai/systemverilog-ide/issues/8)
 with read-only module boundary detection, a focused hierarchy view, a
 direct dependency view, conservative module header/port summaries,
-target-specific refactor impact review data, and a proposal-only
-refactoring boundary.
+target-specific port usage summaries, target-specific refactor impact
+review data, and a proposal-only refactoring boundary.

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -33,6 +33,7 @@ run_json locate locate fixtures/modules/simple_module.sv simple_mod --format jso
 run_json module-hierarchy-view hierarchy fixtures/organization/hierarchy_top.sv --format json
 run_json module-dependency-view dependencies fixtures/organization/hierarchy_top.sv --format json
 run_json module-summary-view module-summary fixtures/organization/hierarchy_top.sv --format json
+run_json module-port-usage-view port-usage fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
 run_json module-refactor-impact-view refactor-impact fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
 run_json module-refactor-proposal refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -191,6 +191,30 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    port_usage_cmd = sub.add_parser(
+        "port-usage",
+        help=(
+            "Emit read-only scanner-based target port declarations and "
+            "usage-site connection summaries."
+        ),
+    )
+    port_usage_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    port_usage_cmd.add_argument(
+        "--module",
+        required=True,
+        help="Exact module name to inspect for port usage review.",
+    )
+    port_usage_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     refactor_impact_cmd = sub.add_parser(
         "refactor-impact",
         help=(
@@ -554,6 +578,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_summary_text(view))
+        return 0
+
+    if args.command == "port-usage":
+        from .module_organization import (
+            build_module_port_usage_view,
+            format_module_port_usage_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        view = build_module_port_usage_view(str(args.path), args.path, args.module)
+        if args.format == "json":
+            json.dump(view, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_port_usage_text(view))
         return 0
 
     if args.command == "refactor-impact":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -16,6 +16,8 @@ _INSTANCE_RE = re.compile(
 _IDENT_RE = re.compile(r"\b[A-Za-z_]\w*\b")
 _PORT_DIRECTION_RE = re.compile(r"\b(input|output|inout)\b")
 _PORT_WIDTH_RE = re.compile(r"(\[[^\]]+\])")
+_PORT_NAMED_CONNECTION_RE = re.compile(r"\.\s*([A-Za-z_]\w*)\s*\(")
+_PORT_CONNECTION_SCAN_LINE_LIMIT = 40
 
 _NON_INSTANCE_WORDS: frozenset[str] = frozenset({
     "always",
@@ -99,6 +101,18 @@ MODULE_SUMMARY_LIMITATIONS: tuple[str, ...] = (
     "scanner-based module header and port summary data only",
     "ANSI-style port declarations are detected conservatively",
     "non-ANSI body declarations, parameters, macros, interfaces, and modports are not resolved",
+    "no semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
+    "no refactor application, file write, validation run, or patch generation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
+PORT_USAGE_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based target module port usage data only",
+    "ANSI-style target port declarations are detected conservatively",
+    "instantiation candidates come from the existing line scanner",
+    "connection summaries are bounded to the scanner-detected instantiation statement",
+    "named and ordered port connections are not semantically resolved",
     "no semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
     "no refactor application, file write, validation run, or patch generation",
     "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
@@ -205,6 +219,24 @@ def _module_summary_safety_flags() -> dict[str, bool]:
 
 
 def _refactor_impact_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "writes_files": False,
+        "applies_refactor": False,
+        "moves_files": False,
+        "applies_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _port_usage_safety_flags() -> dict[str, bool]:
     return {
         "read_only": True,
         "writes_files": False,
@@ -782,6 +814,185 @@ def build_module_summary_view(source: str, path: Path) -> dict[str, Any]:
     }
 
 
+def _instantiation_statement(
+    edge: dict[str, Any],
+    visible_lines: list[tuple[int, str]],
+) -> dict[str, Any]:
+    statement_lines: list[str] = []
+    complete = False
+    truncated = False
+
+    for line_num, visible in visible_lines:
+        if line_num < edge["line"]:
+            continue
+        if len(statement_lines) >= _PORT_CONNECTION_SCAN_LINE_LIMIT:
+            truncated = True
+            break
+
+        statement_lines.append(visible.strip())
+        if ";" in visible:
+            complete = True
+            break
+
+    return {
+        "complete": complete,
+        "line_count": len(statement_lines),
+        "text": " ".join(statement_lines).strip(),
+        "truncated": truncated,
+    }
+
+
+def _instantiation_argument_text(edge: dict[str, Any], statement: str) -> str:
+    head_match = re.search(
+        rf"\b{re.escape(edge['child'])}\s+"
+        rf"(?:#\s*\([^;]*\)\s*)?"
+        rf"{re.escape(edge['instance'])}\s*\(",
+        statement,
+    )
+    open_paren = (
+        head_match.end() - 1
+        if head_match is not None
+        else statement.find("(")
+    )
+    if open_paren == -1:
+        return ""
+
+    close_paren = statement.rfind(")")
+    if close_paren <= open_paren:
+        return statement[open_paren + 1:].strip()
+    return statement[open_paren + 1:close_paren].strip()
+
+
+def _ordered_connection_count(argument_text: str) -> int:
+    return len([
+        segment
+        for segment in argument_text.split(",")
+        if segment.strip()
+    ])
+
+
+def _instance_connection_summary(
+    edge: dict[str, Any],
+    visible_lines: list[tuple[int, str]],
+) -> dict[str, Any]:
+    statement = _instantiation_statement(edge, visible_lines)
+    argument_text = _instantiation_argument_text(edge, statement["text"])
+    named_connections = _PORT_NAMED_CONNECTION_RE.findall(argument_text)
+
+    if named_connections:
+        connection_style = "named"
+        connection_names = list(dict.fromkeys(named_connections))
+        connection_count = len(named_connections)
+    elif argument_text:
+        connection_style = "ordered"
+        connection_names = []
+        connection_count = _ordered_connection_count(argument_text)
+    else:
+        connection_style = "unknown"
+        connection_names = []
+        connection_count = 0
+
+    return {
+        "connection_count": connection_count,
+        "connection_names": connection_names,
+        "connection_style": connection_style,
+        "scan_complete": statement["complete"],
+        "scan_line_count": statement["line_count"],
+        "scan_truncated": statement["truncated"],
+        "semantically_resolved": False,
+    }
+
+
+def _port_usage_rows(
+    dependent_edges: list[dict[str, Any]],
+    visible_lines_by_file: dict[str, list[tuple[int, str]]],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for edge in dependent_edges:
+        rows.append({
+            "child": edge["child"],
+            "column": edge["column"],
+            "file": edge["file"],
+            "instance": edge["instance"],
+            "line": edge["line"],
+            "parent": edge["parent"],
+            "resolved": edge["resolved"],
+            **_instance_connection_summary(
+                edge,
+                visible_lines_by_file.get(edge["file"], []),
+            ),
+        })
+    return rows
+
+
+def build_module_port_usage_view(
+    source: str,
+    path: Path,
+    module_name: str,
+) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    hierarchy = organization["hierarchy"]
+    files = sorted({module["file"] for module in modules})
+    visible_lines_by_file = {
+        file_name: _visible_lines(Path(file_name))
+        for file_name in files
+    }
+
+    matches = _module_lookup(modules, module_name)
+    selected_module = matches[0] if len(matches) == 1 else None
+    header = None
+    ports: list[dict[str, Any]] = []
+    if selected_module is not None:
+        header = _module_header(
+            selected_module,
+            visible_lines_by_file[selected_module["file"]],
+        )
+        ports = _scan_header_ports(selected_module, header["lines"])
+
+    dependent_edges = [
+        edge
+        for edge in hierarchy["edges"]
+        if edge["child"] == module_name
+    ]
+    direct_dependents = sorted({
+        edge["parent"]
+        for edge in dependent_edges
+    })
+
+    return {
+        "dependent_edges": dependent_edges,
+        "direct_dependent_count": len(direct_dependents),
+        "direct_dependents": direct_dependents,
+        "header": (
+            {
+                "complete": header["complete"],
+                "end_line": header["end_line"],
+                "line_count": header["line_count"],
+                "start_line": header["start_line"],
+            }
+            if header is not None
+            else None
+        ),
+        "kind": "module-port-usage-view",
+        "limitations": list(PORT_USAGE_LIMITATIONS),
+        "module": selected_module,
+        "port_count": len(ports),
+        "port_direction_counts": _port_direction_counts(ports),
+        "ports": ports,
+        "preflight": _refactor_impact_preflight(module_name, matches),
+        "safety": _port_usage_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "target": module_name,
+        "tool": "pccx-ide-cli",
+        "usage_site_count": len(dependent_edges),
+        "usage_sites": _port_usage_rows(dependent_edges, visible_lines_by_file),
+        "usage_state": "available_as_data",
+        "writes_files": False,
+    }
+
+
 def _refactor_impact_preflight(
     module_name: str,
     matches: list[dict[str, Any]],
@@ -1198,6 +1409,68 @@ def format_module_summary_text(view: dict[str, Any]) -> str:
             )
         for reason in module["readiness"]["reasons"]:
             lines.append(f"  blocked: {reason}")
+    lines.append(
+        "read-only: no file writes, refactors, validation, lab, launcher, "
+        "provider, or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _port_usage_connection_label(site: dict[str, Any]) -> str:
+    if site["connection_style"] == "named":
+        names = ", ".join(site["connection_names"]) or "none"
+        return f"named connections: {names}"
+    if site["connection_style"] == "ordered":
+        return f"ordered connections: {site['connection_count']}"
+    return "connections: unknown"
+
+
+def format_module_port_usage_text(view: dict[str, Any]) -> str:
+    lines = [
+        f"source: {view['source']}",
+        f"target: {view['target']}",
+        f"port usage: {view['usage_state']}",
+        f"preflight: {view['preflight']['status']}",
+        "writes files: no",
+    ]
+
+    module = view["module"]
+    if module is not None:
+        lines.append(
+            f"declaration: {module['file']}:{module['start_line']}:"
+            f"{module['start_column']}"
+        )
+
+    lines.append(
+        f"{view['port_count']} target port"
+        f"{'s' if view['port_count'] != 1 else ''}"
+    )
+    if not view["ports"]:
+        lines.append("ports: none")
+    for port in view["ports"]:
+        width = f" {port['width']}" if port["width"] else ""
+        lines.append(
+            f"  {port['direction']}{width} {port['name']} "
+            f"at line {port['line']} ({port['state']})"
+        )
+
+    dependents = ", ".join(view["direct_dependents"]) or "none"
+    lines.append(f"dependents: {dependents}")
+    lines.append("usage sites:")
+    if not view["usage_sites"]:
+        lines.append("  none")
+    for site in view["usage_sites"]:
+        state = "resolved" if site["resolved"] else "unresolved"
+        connection_label = _port_usage_connection_label(site)
+        lines.append(
+            f"  {site['parent']} instantiates {site['child']} "
+            f"as {site['instance']} at {site['file']}:"
+            f"{site['line']}:{site['column']} ({state}; "
+            f"{connection_label}; not semantically resolved)"
+        )
+
+    for reason in view["preflight"]["reasons"]:
+        lines.append(f"blocked: {reason}")
     lines.append(
         "read-only: no file writes, refactors, validation, lab, launcher, "
         "provider, or hardware execution"

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -21,12 +21,14 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_dependency_view,
     build_module_hierarchy_view,
     build_module_organization_export,
+    build_module_port_usage_view,
     build_module_summary_view,
     build_refactor_impact_view,
     build_refactor_proposal,
     format_module_dependency_text,
     format_module_hierarchy_text,
     format_module_organization_text,
+    format_module_port_usage_text,
     format_module_summary_text,
     format_refactor_impact_text,
     format_refactor_proposal_text,
@@ -205,6 +207,67 @@ def test_build_module_summary_view_inherits_port_direction(tmp_path):
     assert ports["done_o"]["state"] == "detected"
 
 
+def test_build_module_port_usage_view_reports_ports_and_usage_sites():
+    view = build_module_port_usage_view(str(FIXTURE), FIXTURE, "leaf_mod")
+
+    assert view["kind"] == "module-port-usage-view"
+    assert view["usage_state"] == "available_as_data"
+    assert view["target"] == "leaf_mod"
+    assert view["preflight"]["status"] == "ready-for-review"
+    assert view["writes_files"] is False
+    assert view["module"]["name"] == "leaf_mod"
+    assert view["port_count"] == 1
+    assert view["ports"] == [
+        {
+            "direction": "input",
+            "line": 5,
+            "name": "clk",
+            "state": "detected",
+            "width": None,
+        }
+    ]
+    assert view["direct_dependents"] == ["top_mod"]
+    assert view["usage_site_count"] == 1
+    assert view["usage_sites"] == [
+        {
+            "child": "leaf_mod",
+            "column": 5,
+            "connection_count": 1,
+            "connection_names": ["clk"],
+            "connection_style": "named",
+            "file": str(FIXTURE),
+            "instance": "u_leaf",
+            "line": 12,
+            "parent": "top_mod",
+            "resolved": True,
+            "scan_complete": True,
+            "scan_line_count": 3,
+            "scan_truncated": False,
+            "semantically_resolved": False,
+        }
+    ]
+    assert view["safety"]["read_only"] is True
+    assert view["safety"]["writes_files"] is False
+    assert view["safety"]["applies_refactor"] is False
+    assert view["safety"]["applies_patch"] is False
+    assert view["safety"]["runs_validation"] is False
+    assert view["safety"]["invokes_pccx_lab"] is False
+    assert view["safety"]["invokes_launcher"] is False
+    assert view["safety"]["provider_calls"] is False
+    assert view["safety"]["hardware_access"] is False
+
+
+def test_build_module_port_usage_view_blocks_missing_module():
+    view = build_module_port_usage_view(str(FIXTURE), FIXTURE, "missing_mod")
+
+    assert view["preflight"]["status"] == "blocked"
+    assert "module not found: missing_mod" in view["preflight"]["reasons"]
+    assert view["module"] is None
+    assert view["ports"] == []
+    assert view["usage_sites"] == []
+    assert view["writes_files"] is False
+
+
 def test_build_refactor_impact_view_reports_target_references():
     view = build_refactor_impact_view(str(FIXTURE), FIXTURE, "leaf_mod")
 
@@ -350,6 +413,19 @@ def test_format_module_summary_text_mentions_ports_and_boundary():
     assert "read-only: no file writes" in text
 
 
+def test_format_module_port_usage_text_mentions_usage_and_no_execution():
+    view = build_module_port_usage_view(str(FIXTURE), FIXTURE, "leaf_mod")
+    text = format_module_port_usage_text(view)
+
+    assert "port usage: available_as_data" in text
+    assert "preflight: ready-for-review" in text
+    assert "input clk at line 5 (detected)" in text
+    assert "top_mod instantiates leaf_mod as u_leaf" in text
+    assert "named connections: clk" in text
+    assert "writes files: no" in text
+    assert "read-only: no file writes" in text
+
+
 def test_format_refactor_impact_text_mentions_references_and_no_execution():
     view = build_refactor_impact_view(str(FIXTURE), FIXTURE, "leaf_mod")
     text = format_refactor_impact_text(view)
@@ -443,6 +519,38 @@ def test_cli_module_summary_text():
     assert result.returncode == 0, result.stderr
     assert "module summary: available_as_data" in result.stdout
     assert "input clk at line 5 (detected)" in result.stdout
+
+
+def test_cli_port_usage_json():
+    result = _run_cli(
+        "port-usage",
+        str(FIXTURE),
+        "--module",
+        "leaf_mod",
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-port-usage-view"
+    assert payload["target"] == "leaf_mod"
+    assert payload["port_count"] == 1
+    assert payload["usage_sites"][0]["connection_names"] == ["clk"]
+    assert payload["safety"]["writes_files"] is False
+
+
+def test_cli_port_usage_text():
+    result = _run_cli(
+        "port-usage",
+        str(FIXTURE),
+        "--module",
+        "leaf_mod",
+        "--format",
+        "text",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "port usage: available_as_data" in result.stdout
+    assert "top_mod instantiates leaf_mod as u_leaf" in result.stdout
 
 
 def test_cli_refactor_impact_json():
@@ -542,6 +650,17 @@ def test_cli_module_summary_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_port_usage_missing_path_exits_nonzero():
+    result = _run_cli(
+        "port-usage",
+        str(FIXTURE.parent / "missing.sv"),
+        "--module",
+        "leaf_mod",
+    )
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_cli_refactor_impact_missing_path_exits_nonzero():
     result = _run_cli(
         "refactor-impact",
@@ -560,12 +679,14 @@ def test_docs_cover_organization_flow_and_limits():
     assert "hierarchy <path>" in contract
     assert "dependencies <path>" in contract
     assert "module-summary <path>" in contract
+    assert "port-usage <path>" in contract
     assert "refactor-impact <path>" in contract
     assert "MODULE_ORGANIZATION_WORKFLOW.md" in contract
     assert "proposal-only" in workflow
     assert "module-hierarchy-view" in workflow
     assert "module-dependency-view" in workflow
     assert "module-summary-view" in workflow
+    assert "module-port-usage-view" in workflow
     assert "module-refactor-impact-view" in workflow
     assert "does not write files" in workflow
     assert "not a full SystemVerilog parser" in workflow


### PR DESCRIPTION
## Summary

- add a read-only `port-usage` CLI surface for target module port declarations and dependent instantiation usage-site summaries
- keep connection data scanner-bounded and explicitly not semantically resolved
- document the pre-stable `module-port-usage-view` boundary and add smoke/test coverage

Refs pccxai/systemverilog-ide#8.

## Validation

- `python3 -m pytest tests/test_module_organization.py`
- `python3 -m pytest -q`
- `python3 -m compileall -q src tests`
- `./scripts/editor-bridge-smoke.sh`
- `python3 scripts/check-source-headers.py`
- CI-equivalent forbidden-claim scan
- `git diff --check`
- `git diff --cached --check`
