### PR TITLE
Add module context bundle boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,13 @@ jobs:
               fixtures/organization/hierarchy_top.sv \
               | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-summary-view'; assert d['safety']['writes_files'] is False"
           echo "module summary smoke ok"
+      - name: cli smoke (module context exits zero)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli module-context \
+              fixtures/organization/hierarchy_top.sv --module leaf_mod \
+              | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-context-bundle'; assert d['safety']['writes_files'] is False"
+          echo "module context smoke ok"
       - name: cli smoke (refactor impact exits zero)
         run: |
           set -e

--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ python -m pccx_ide_cli module-summary fixtures/organization/hierarchy_top.sv --f
 python -m pccx_ide_cli port-usage fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
 python -m pccx_ide_cli port-usage fixtures/organization/hierarchy_top.sv --module leaf_mod --format text
 
+# Target module context bundle (pre-stable, read-only)
+python -m pccx_ide_cli module-context fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
+python -m pccx_ide_cli module-context fixtures/organization/hierarchy_top.sv --module leaf_mod --format text
+
 # Target-specific refactor impact view (pre-stable, read-only)
 python -m pccx_ide_cli refactor-impact fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
 python -m pccx_ide_cli refactor-impact fixtures/organization/hierarchy_top.sv --module leaf_mod --format text
@@ -200,9 +204,11 @@ dependent, and impact summaries from the same scanner data.
 `module-summary` renders conservative module header and port summaries
 for editor sidebars and reviewed refactoring planning. `port-usage`
 renders target port declarations with scanner-detected dependent
-instantiation connection summaries. `refactor-impact` renders
-target-specific declaration, dependent, and dependency review data for a
-named module. These commands do not edit files, apply
+instantiation connection summaries. `module-context` bundles target
+summary, dependency, port-usage, and refactor-impact review data for
+editor context panes. `refactor-impact` renders target-specific
+declaration, dependent, and dependency review data for a named module.
+These commands do not edit files, apply
 refactors, execute validation, run vendor tools, invoke `pccx-lab` or the
 launcher, or implement semantic elaboration. The output shapes are
 pre-stable and documented in
@@ -256,7 +262,7 @@ surfaces, external editor planning, and later workflow tracks lives in
 The scanner-based module organization workflow for module boundaries,
 hierarchy views, dependency views, module header/port summaries, and
 target-specific refactor impact review data plus proposal-only
-refactoring planning is documented in
+refactoring planning, including the target module context bundle, is documented in
 [`docs/MODULE_ORGANIZATION_WORKFLOW.md`](./docs/MODULE_ORGANIZATION_WORKFLOW.md).
 The planned AI-assisted SystemVerilog workflow, permission boundary, and
 pccx-lab controlled MCP/tool dependency are documented in

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -49,6 +49,7 @@ python -m pccx_ide_cli hierarchy <path> --format json
 python -m pccx_ide_cli dependencies <path> --format json
 python -m pccx_ide_cli module-summary <path> --format json
 python -m pccx_ide_cli port-usage <path> --module <name> --format json
+python -m pccx_ide_cli module-context <path> --module <name> --format json
 python -m pccx_ide_cli refactor-impact <path> --module <name> --format json
 
 # Opt-in pccx-lab diagnostics backend
@@ -189,10 +190,11 @@ declaration records.  `declarations` exports those records directly, and
 adds scanner-based module boundary spans, hierarchy edges, root candidates,
 and proposal-only refactoring metadata for project tree and reviewed
 refactoring workflows. `hierarchy`, `dependencies`, `module-summary`,
-`port-usage`, and `refactor-impact` render focused read-only views from
-the same scanner data, including conservative module header/port
-summaries, target port usage summaries, and target-specific refactor
-impact review data. The organization surface is documented in
+`port-usage`, `module-context`, and `refactor-impact` render focused
+read-only views from the same scanner data, including conservative module
+header/port summaries, target port usage summaries, target module context
+bundles, and target-specific refactor impact review data. The
+organization surface is documented in
 [`MODULE_ORGANIZATION_WORKFLOW.md`](./MODULE_ORGANIZATION_WORKFLOW.md).
 `refactor-plan` extends the same boundary with proposal-only
 rename-module, extract-port, and move-module planning envelopes. It emits

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -4,11 +4,12 @@
 
 This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
-`module-summary`, `port-usage`, and `refactor-impact` CLI surfaces that
+`module-summary`, `port-usage`, `module-context`, and `refactor-impact` CLI surfaces that
 report module boundary spans, scanner-based hierarchy data, direct
 dependency impact data, conservative module header/port summaries,
-target port usage summaries, and target-specific refactor impact data
-for editor navigation and reviewed refactoring planning.
+target port usage summaries, target module context bundles, and
+target-specific refactor impact data for editor navigation and reviewed
+refactoring planning.
 
 It is not a full SystemVerilog parser, not semantic elaboration, not an LSP
 implementation, and not a write-capable refactoring engine.
@@ -26,6 +27,8 @@ python -m pccx_ide_cli module-summary <path> --format json
 python -m pccx_ide_cli module-summary <path> --format text
 python -m pccx_ide_cli port-usage <path> --module <name> --format json
 python -m pccx_ide_cli port-usage <path> --module <name> --format text
+python -m pccx_ide_cli module-context <path> --module <name> --format json
+python -m pccx_ide_cli module-context <path> --module <name> --format text
 python -m pccx_ide_cli refactor-impact <path> --module <name> --format json
 python -m pccx_ide_cli refactor-impact <path> --module <name> --format text
 python -m pccx_ide_cli refactor-plan <path> --action rename-module --module <name> --new-name <name> --format json
@@ -225,6 +228,49 @@ generate patches, run validation, execute shell commands, invoke
 `pccx-lab`, invoke the launcher, call providers, touch hardware, upload
 telemetry, or perform automatic repository actions.
 
+The module context bundle combines the existing target-specific view
+outputs into a bounded editor context packet:
+
+```json
+{
+  "kind": "module-context-bundle",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "target": "leaf_mod",
+  "context_state": "available_as_data",
+  "writes_files": false,
+  "preflight": {
+    "status": "ready-for-review",
+    "requires_approval_before_write": true,
+    "reasons": []
+  },
+  "summary_context": {},
+  "dependency_context": {},
+  "port_context": {},
+  "refactor_context": {
+    "review_target_count": 2,
+    "writes_files": false
+  },
+  "source_views": [],
+  "safety": {
+    "read_only": true,
+    "writes_files": false,
+    "applies_refactor": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The module context bundle is display/context data only. It summarizes
+the existing `module-summary`, `dependencies`, `port-usage`, and
+`refactor-impact` surfaces for a named module. It does not write files,
+apply refactors, move files, generate patches, run validation, execute
+shell commands, invoke `pccx-lab`, invoke the launcher, call providers,
+touch hardware, upload telemetry, or perform automatic repository
+actions.
+
 The refactor impact view reports target-specific review data for a module:
 
 ```json
@@ -309,6 +355,8 @@ This is a visualization seed for editor trees and review workflows. The
 `module-summary` command renders conservative module header and port data.
 The `port-usage` command renders a target module's conservative port data
 and dependent instantiation connection summaries.
+The `module-context` command bundles target summary, dependency,
+port-usage, and refactor-impact review data for editor context panes.
 These commands do not run elaboration, expand macros, interpret generate
 blocks, or replace vendor tooling.
 
@@ -340,6 +388,20 @@ semantically resolved: macros, interfaces, generate blocks, parameter
 elaboration, implicit connections, and type compatibility are outside
 this boundary.
 
+## Module Context Bundle
+
+`module-context` accepts a target module name and returns one read-only
+context packet assembled from the existing scanner-derived summary,
+dependency, port-usage, and refactor-impact views. The bundle is meant
+for editor context panes that need a compact target module snapshot
+without making separate UI-layer assumptions about the individual view
+shapes.
+
+This command does not create a new analysis engine. It does not write
+files, apply refactors, generate patches, run validation, execute shell
+commands, invoke `pccx-lab`, invoke the launcher, call providers, touch
+hardware, upload telemetry, or perform automatic repository actions.
+
 ## Refactor Impact Review
 
 `refactor-impact` accepts a target module name and reports scanner-detected
@@ -363,6 +425,7 @@ inputs for later helpers:
 - direct dependency and dependent summaries
 - conservative module header and port summaries
 - target-specific port usage summaries
+- target-specific module context bundles
 - target-specific refactor impact review data
 - planned helper names for rename, extract-port, and move-module workflows
 
@@ -439,5 +502,6 @@ This workflow advances
 [`systemverilog-ide#8`](https://github.com/pccxai/systemverilog-ide/issues/8)
 with read-only module boundary detection, a focused hierarchy view, a
 direct dependency view, conservative module header/port summaries,
-target-specific port usage summaries, target-specific refactor impact
-review data, and a proposal-only refactoring boundary.
+target-specific port usage summaries, target-specific module context
+bundles, target-specific refactor impact review data, and a
+proposal-only refactoring boundary.

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -215,6 +215,29 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    module_context_cmd = sub.add_parser(
+        "module-context",
+        help=(
+            "Emit a read-only scanner-based target module context bundle."
+        ),
+    )
+    module_context_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    module_context_cmd.add_argument(
+        "--module",
+        required=True,
+        help="Exact module name to inspect for context review.",
+    )
+    module_context_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     refactor_impact_cmd = sub.add_parser(
         "refactor-impact",
         help=(
@@ -596,6 +619,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_port_usage_text(view))
+        return 0
+
+    if args.command == "module-context":
+        from .module_organization import (
+            build_module_context_bundle,
+            format_module_context_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        bundle = build_module_context_bundle(str(args.path), args.path, args.module)
+        if args.format == "json":
+            json.dump(bundle, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_context_text(bundle))
         return 0
 
     if args.command == "refactor-impact":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -119,6 +119,15 @@ PORT_USAGE_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+MODULE_CONTEXT_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based target module context bundle data only",
+    "combines existing summary, dependency, port-usage, and refactor-impact views",
+    "no semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
+    "no refactor application, file write, validation run, or patch generation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 REFACTOR_IMPACT_LIMITATIONS: tuple[str, ...] = (
     "scanner-based target-specific refactor impact data only",
     "module declarations and single-line instantiation candidates only",
@@ -237,6 +246,24 @@ def _refactor_impact_safety_flags() -> dict[str, bool]:
 
 
 def _port_usage_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "writes_files": False,
+        "applies_refactor": False,
+        "moves_files": False,
+        "applies_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _module_context_safety_flags() -> dict[str, bool]:
     return {
         "read_only": True,
         "writes_files": False,
@@ -1113,6 +1140,138 @@ def build_refactor_impact_view(
     }
 
 
+def _selected_module_summary(
+    summary_view: dict[str, Any],
+    selected_module: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if selected_module is None:
+        return None
+    for summary in summary_view["modules"]:
+        boundary = summary["boundary"]
+        if (
+            summary["name"] == selected_module["name"]
+            and boundary["file"] == selected_module["file"]
+            and boundary["start_line"] == selected_module["start_line"]
+        ):
+            return summary
+    return None
+
+
+def _selected_dependency_impact(
+    dependency_view: dict[str, Any],
+    module_name: str,
+) -> dict[str, Any] | None:
+    for row in dependency_view["impact"]:
+        if row["module"] == module_name:
+            return row
+    return None
+
+
+def _source_view_refs(
+    summary_view: dict[str, Any],
+    dependency_view: dict[str, Any],
+    port_usage_view: dict[str, Any],
+    refactor_impact_view: dict[str, Any],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "command": "module-summary",
+            "kind": summary_view["kind"],
+            "state": summary_view["summary_state"],
+            "included": True,
+            "summary": "conservative module header and port metadata",
+        },
+        {
+            "command": "dependencies",
+            "kind": dependency_view["kind"],
+            "state": dependency_view["dependency_state"],
+            "included": True,
+            "summary": "direct dependency and dependent summaries",
+        },
+        {
+            "command": "port-usage",
+            "kind": port_usage_view["kind"],
+            "state": port_usage_view["usage_state"],
+            "included": True,
+            "summary": "target port declarations and dependent usage sites",
+        },
+        {
+            "command": "refactor-impact",
+            "kind": refactor_impact_view["kind"],
+            "state": refactor_impact_view["impact_state"],
+            "included": True,
+            "summary": "target-specific declaration and reference review data",
+        },
+    ]
+
+
+def build_module_context_bundle(
+    source: str,
+    path: Path,
+    module_name: str,
+) -> dict[str, Any]:
+    summary_view = build_module_summary_view(source, path)
+    dependency_view = build_module_dependency_view(source, path)
+    port_usage_view = build_module_port_usage_view(source, path, module_name)
+    refactor_impact_view = build_refactor_impact_view(source, path, module_name)
+    selected_module = refactor_impact_view["module"]
+    selected_summary = _selected_module_summary(summary_view, selected_module)
+    dependency_impact = _selected_dependency_impact(dependency_view, module_name)
+    preflight = refactor_impact_view["preflight"]
+
+    return {
+        "context_state": (
+            "blocked"
+            if preflight["status"] == "blocked"
+            else "available_as_data"
+        ),
+        "dependency_context": {
+            "dependency_edges": refactor_impact_view["dependency_edges"],
+            "dependency_impact": dependency_impact,
+            "dependent_edges": refactor_impact_view["dependent_edges"],
+            "direct_dependencies": refactor_impact_view["direct_dependencies"],
+            "direct_dependency_count": refactor_impact_view["direct_dependency_count"],
+            "direct_dependents": refactor_impact_view["direct_dependents"],
+            "direct_dependent_count": refactor_impact_view["direct_dependent_count"],
+            "unresolved_dependencies": refactor_impact_view["unresolved_dependencies"],
+            "unresolved_dependency_count": (
+                refactor_impact_view["unresolved_dependency_count"]
+            ),
+        },
+        "kind": "module-context-bundle",
+        "limitations": list(MODULE_CONTEXT_LIMITATIONS),
+        "module": selected_module,
+        "port_context": {
+            "direct_dependents": port_usage_view["direct_dependents"],
+            "header": port_usage_view["header"],
+            "port_count": port_usage_view["port_count"],
+            "port_direction_counts": port_usage_view["port_direction_counts"],
+            "ports": port_usage_view["ports"],
+            "usage_site_count": port_usage_view["usage_site_count"],
+            "usage_sites": port_usage_view["usage_sites"],
+        },
+        "preflight": preflight,
+        "refactor_context": {
+            "review_target_count": len(refactor_impact_view["review_targets"]),
+            "review_targets": refactor_impact_view["review_targets"],
+            "writes_files": False,
+        },
+        "safety": _module_context_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "source_views": _source_view_refs(
+            summary_view,
+            dependency_view,
+            port_usage_view,
+            refactor_impact_view,
+        ),
+        "summary_context": selected_summary,
+        "target": module_name,
+        "tool": "pccx-ide-cli",
+        "writes_files": False,
+    }
+
+
 def _requested_change(
     action: str,
     module_name: str,
@@ -1519,6 +1678,58 @@ def format_refactor_impact_text(view: dict[str, Any]) -> str:
                 f"{edge['line']}:{edge['column']} ({state})"
             )
     for reason in view["preflight"]["reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(
+        "read-only: no file writes, refactors, validation, lab, launcher, "
+        "provider, or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_module_context_text(bundle: dict[str, Any]) -> str:
+    lines = [
+        f"source: {bundle['source']}",
+        f"target: {bundle['target']}",
+        f"module context: {bundle['context_state']}",
+        f"preflight: {bundle['preflight']['status']}",
+        "writes files: no",
+    ]
+
+    module = bundle["module"]
+    if module is not None:
+        lines.append(
+            f"declaration: {module['file']}:{module['start_line']}:"
+            f"{module['start_column']}"
+        )
+
+    summary = bundle["summary_context"]
+    if summary is None:
+        lines.append("summary: unavailable")
+    else:
+        readiness = summary["readiness"]["state"]
+        lines.append(
+            f"summary: {summary['port_count']} port"
+            f"{'s' if summary['port_count'] != 1 else ''}; {readiness}"
+        )
+
+    dependency = bundle["dependency_context"]
+    dependencies = ", ".join(dependency["direct_dependencies"]) or "none"
+    dependents = ", ".join(dependency["direct_dependents"]) or "none"
+    unresolved = ", ".join(dependency["unresolved_dependencies"]) or "none"
+    lines.append(f"dependencies: {dependencies}")
+    lines.append(f"dependents: {dependents}")
+    lines.append(f"unresolved dependencies: {unresolved}")
+
+    port_context = bundle["port_context"]
+    lines.append(
+        f"port usage: {port_context['usage_site_count']} site"
+        f"{'s' if port_context['usage_site_count'] != 1 else ''}"
+    )
+    lines.append(
+        f"review targets: {bundle['refactor_context']['review_target_count']}"
+    )
+
+    for reason in bundle["preflight"]["reasons"]:
         lines.append(f"blocked: {reason}")
     lines.append(
         "read-only: no file writes, refactors, validation, lab, launcher, "

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -19,6 +19,7 @@ sys.path.insert(0, str(SRC))
 
 from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_dependency_view,
+    build_module_context_bundle,
     build_module_hierarchy_view,
     build_module_organization_export,
     build_module_port_usage_view,
@@ -26,6 +27,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_refactor_impact_view,
     build_refactor_proposal,
     format_module_dependency_text,
+    format_module_context_text,
     format_module_hierarchy_text,
     format_module_organization_text,
     format_module_port_usage_text,
@@ -268,6 +270,53 @@ def test_build_module_port_usage_view_blocks_missing_module():
     assert view["writes_files"] is False
 
 
+def test_build_module_context_bundle_summarizes_target_views():
+    bundle = build_module_context_bundle(str(FIXTURE), FIXTURE, "leaf_mod")
+
+    assert bundle["kind"] == "module-context-bundle"
+    assert bundle["context_state"] == "available_as_data"
+    assert bundle["target"] == "leaf_mod"
+    assert bundle["preflight"]["status"] == "ready-for-review"
+    assert bundle["writes_files"] is False
+    assert bundle["module"]["name"] == "leaf_mod"
+    assert bundle["summary_context"]["name"] == "leaf_mod"
+    assert bundle["summary_context"]["port_count"] == 1
+    assert bundle["dependency_context"]["direct_dependencies"] == []
+    assert bundle["dependency_context"]["direct_dependents"] == ["top_mod"]
+    assert bundle["dependency_context"]["unresolved_dependencies"] == []
+    assert bundle["port_context"]["port_count"] == 1
+    assert bundle["port_context"]["usage_site_count"] == 1
+    assert bundle["refactor_context"]["review_target_count"] == 2
+    assert [view["command"] for view in bundle["source_views"]] == [
+        "module-summary",
+        "dependencies",
+        "port-usage",
+        "refactor-impact",
+    ]
+    assert bundle["safety"]["read_only"] is True
+    assert bundle["safety"]["writes_files"] is False
+    assert bundle["safety"]["applies_refactor"] is False
+    assert bundle["safety"]["applies_patch"] is False
+    assert bundle["safety"]["runs_validation"] is False
+    assert bundle["safety"]["invokes_pccx_lab"] is False
+    assert bundle["safety"]["invokes_launcher"] is False
+    assert bundle["safety"]["provider_calls"] is False
+    assert bundle["safety"]["hardware_access"] is False
+
+
+def test_build_module_context_bundle_blocks_missing_module():
+    bundle = build_module_context_bundle(str(FIXTURE), FIXTURE, "missing_mod")
+
+    assert bundle["context_state"] == "blocked"
+    assert bundle["preflight"]["status"] == "blocked"
+    assert "module not found: missing_mod" in bundle["preflight"]["reasons"]
+    assert bundle["module"] is None
+    assert bundle["summary_context"] is None
+    assert bundle["port_context"]["ports"] == []
+    assert bundle["refactor_context"]["review_targets"] == []
+    assert bundle["writes_files"] is False
+
+
 def test_build_refactor_impact_view_reports_target_references():
     view = build_refactor_impact_view(str(FIXTURE), FIXTURE, "leaf_mod")
 
@@ -426,6 +475,20 @@ def test_format_module_port_usage_text_mentions_usage_and_no_execution():
     assert "read-only: no file writes" in text
 
 
+def test_format_module_context_text_mentions_context_and_no_execution():
+    bundle = build_module_context_bundle(str(FIXTURE), FIXTURE, "leaf_mod")
+    text = format_module_context_text(bundle)
+
+    assert "module context: available_as_data" in text
+    assert "preflight: ready-for-review" in text
+    assert "summary: 1 port; ready-for-review" in text
+    assert "dependents: top_mod" in text
+    assert "port usage: 1 site" in text
+    assert "review targets: 2" in text
+    assert "writes files: no" in text
+    assert "read-only: no file writes" in text
+
+
 def test_format_refactor_impact_text_mentions_references_and_no_execution():
     view = build_refactor_impact_view(str(FIXTURE), FIXTURE, "leaf_mod")
     text = format_refactor_impact_text(view)
@@ -553,6 +616,40 @@ def test_cli_port_usage_text():
     assert "top_mod instantiates leaf_mod as u_leaf" in result.stdout
 
 
+def test_cli_module_context_json():
+    result = _run_cli(
+        "module-context",
+        str(FIXTURE),
+        "--module",
+        "leaf_mod",
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-context-bundle"
+    assert payload["target"] == "leaf_mod"
+    assert payload["summary_context"]["port_count"] == 1
+    assert payload["dependency_context"]["direct_dependents"] == ["top_mod"]
+    assert payload["port_context"]["usage_site_count"] == 1
+    assert payload["refactor_context"]["review_target_count"] == 2
+    assert payload["safety"]["writes_files"] is False
+
+
+def test_cli_module_context_text():
+    result = _run_cli(
+        "module-context",
+        str(FIXTURE),
+        "--module",
+        "leaf_mod",
+        "--format",
+        "text",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "module context: available_as_data" in result.stdout
+    assert "dependents: top_mod" in result.stdout
+
+
 def test_cli_refactor_impact_json():
     result = _run_cli(
         "refactor-impact",
@@ -672,6 +769,17 @@ def test_cli_refactor_impact_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_module_context_missing_path_exits_nonzero():
+    result = _run_cli(
+        "module-context",
+        str(FIXTURE.parent / "missing.sv"),
+        "--module",
+        "leaf_mod",
+    )
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_docs_cover_organization_flow_and_limits():
     contract = CONTRACT_DOC.read_text(encoding="utf-8")
     workflow = WORKFLOW_DOC.read_text(encoding="utf-8")
@@ -680,6 +788,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "dependencies <path>" in contract
     assert "module-summary <path>" in contract
     assert "port-usage <path>" in contract
+    assert "module-context <path>" in contract
     assert "refactor-impact <path>" in contract
     assert "MODULE_ORGANIZATION_WORKFLOW.md" in contract
     assert "proposal-only" in workflow
@@ -687,6 +796,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-dependency-view" in workflow
     assert "module-summary-view" in workflow
     assert "module-port-usage-view" in workflow
+    assert "module-context-bundle" in workflow
     assert "module-refactor-impact-view" in workflow
     assert "does not write files" in workflow
     assert "not a full SystemVerilog parser" in workflow


### PR DESCRIPTION
Summary
- Add a read-only `module-context` CLI bundle over existing scanner-derived module summary, dependency, port-usage, and refactor-impact views.
- Document the pre-stable `module-context-bundle` shape and wire CI smoke coverage.
- Add module organization tests for target and missing-module bundles.

Validation
- `PYTHONPATH=src python3 -m pytest -q`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- workflow claim scan
- `python3 scripts/check-source-headers.py`
- `git diff --check`
- `git diff --cached --check`

Refs #8