### PR TITLE
Add refactor validation plan surface

### DIFF
--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -51,6 +51,7 @@ python -m pccx_ide_cli module-summary <path> --format json
 python -m pccx_ide_cli port-usage <path> --module <name> --format json
 python -m pccx_ide_cli module-context <path> --module <name> --format json
 python -m pccx_ide_cli refactor-impact <path> --module <name> --format json
+python -m pccx_ide_cli validation-plan <path> --action rename-module --module <name> --new-name <name> --format json
 
 # Opt-in pccx-lab diagnostics backend
 python -m pccx_ide_cli check <sv-file> --backend pccx-lab --format json
@@ -201,6 +202,12 @@ rename-module, extract-port, and move-module planning envelopes. It emits
 preflight metadata and review steps only; it does not apply edits, move
 files, run validation, invoke pccx-lab or the launcher, call providers, touch
 hardware, or perform automatic repository actions.
+`validation-plan` emits proposal-only validation planning envelopes for those
+refactor requests. It returns fixed argument-array command descriptors with
+`proposed-not-run` state and explicit approval metadata; it does not execute
+validation, run shell commands, apply edits, invoke pccx-lab or the launcher,
+run vendor tools, call providers, touch hardware, or perform automatic
+repository actions.
 
 For existing xsim logs, the VS Code prototype can consume the checked
 `problems from-xsim-log` JSON as a read-only status/context summary.  The
@@ -218,8 +225,9 @@ xsim path, and text surface sketches is documented in
 
 - Scanner-based scaffolds, not full SystemVerilog parsing.
 - Module organization, header/port summaries, port usage summaries,
-  refactor impact review, and refactor planning are scanner-based; they
-  are not semantic elaboration and do not apply refactors.
+  refactor impact review, refactor planning, and validation planning are
+  scanner-based; they are not semantic elaboration and do not apply
+  refactors or execute validation.
 - No LSP server in this repository today.
 - No published editor extension or marketplace packaging is implemented
   here.

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -4,11 +4,12 @@
 
 This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
-`module-summary`, `port-usage`, `module-context`, and `refactor-impact` CLI surfaces that
-report module boundary spans, scanner-based hierarchy data, direct
-dependency impact data, conservative module header/port summaries,
-target port usage summaries, target module context bundles, and
-target-specific refactor impact data for editor navigation and reviewed
+`module-summary`, `port-usage`, `module-context`, `refactor-impact`, and
+`validation-plan` CLI surfaces that report module boundary spans,
+scanner-based hierarchy data, direct dependency impact data, conservative
+module header/port summaries, target port usage summaries, target module
+context bundles, target-specific refactor impact data, and proposal-only
+validation command descriptors for editor navigation and reviewed
 refactoring planning.
 
 It is not a full SystemVerilog parser, not semantic elaboration, not an LSP
@@ -34,6 +35,9 @@ python -m pccx_ide_cli refactor-impact <path> --module <name> --format text
 python -m pccx_ide_cli refactor-plan <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli refactor-plan <path> --action extract-port --module <name> --port-name <name> --direction input --format text
 python -m pccx_ide_cli refactor-plan <path> --action move-module --module <name> --destination rtl/<name>.sv --format json
+python -m pccx_ide_cli validation-plan <path> --action rename-module --module <name> --new-name <name> --format json
+python -m pccx_ide_cli validation-plan <path> --action extract-port --module <name> --port-name <name> --direction input --format text
+python -m pccx_ide_cli validation-plan <path> --action move-module --module <name> --destination rtl/<name>.sv --format json
 ```
 
 `<path>` may be a `.sv` / `.v` file or a directory. Directory scans follow the
@@ -487,6 +491,66 @@ execute shell commands, invoke `pccx-lab`, invoke the launcher, call
 providers, touch hardware, upload telemetry, or perform automatic repository
 actions.
 
+## Validation Proposal Plan
+
+`validation-plan` adds a proposal-only validation planning envelope for a
+reviewed refactor request. It reuses the same requested action fields as
+`refactor-plan`, returns the refactor preflight status, and emits fixed
+argument-array command descriptors that an editor or maintainer workflow can
+review later.
+
+Example shape:
+
+```json
+{
+  "kind": "module-refactor-validation-plan",
+  "validation_state": "proposal-only",
+  "action": "rename-module",
+  "command_descriptor_count": 8,
+  "writes_files": false,
+  "preflight": {
+    "status": "ready-for-review",
+    "requires_explicit_approval_before_run": true,
+    "reasons": []
+  },
+  "validation_groups": [
+    {
+      "phase": "pre-change-review",
+      "status": "proposal-only",
+      "commands": [
+        {
+          "id": "module-context",
+          "argv": ["python", "-m", "pccx_ide_cli", "module-context", "<path>", "--module", "<name>", "--format", "json"],
+          "fixed_argv": true,
+          "shell": false,
+          "state": "proposed-not-run"
+        }
+      ]
+    }
+  ],
+  "safety": {
+    "read_only": true,
+    "emits_command_descriptors": true,
+    "writes_files": false,
+    "runs_validation": false,
+    "runs_shell": false,
+    "invokes_pccx_lab": false,
+    "invokes_launcher": false,
+    "hardware_access": false
+  }
+}
+```
+
+Blocked plans still return JSON. The pre-change review descriptors remain
+available as data, while post-change validation descriptors are withheld until
+the refactor preflight is ready for review.
+
+The command descriptors are proposed-not-run data. This boundary does not
+execute validation, execute shell commands, write files, apply refactors,
+generate patches, invoke `pccx-lab`, invoke the launcher, run vendor tools,
+call providers, touch hardware, upload telemetry, or perform automatic
+repository actions.
+
 ## Limitations
 
 - Scanner-based module declarations and `endmodule` matching only.
@@ -504,4 +568,4 @@ with read-only module boundary detection, a focused hierarchy view, a
 direct dependency view, conservative module header/port summaries,
 target-specific port usage summaries, target-specific module context
 bundles, target-specific refactor impact review data, and a
-proposal-only refactoring boundary.
+proposal-only refactoring and validation planning boundary.

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -36,6 +36,7 @@ run_json module-summary-view module-summary fixtures/organization/hierarchy_top.
 run_json module-port-usage-view port-usage fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
 run_json module-refactor-impact-view refactor-impact fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
 run_json module-refactor-proposal refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
+run_json module-refactor-validation-plan validation-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 
 bash scripts/check-editor-bridge-examples.sh
 

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -317,6 +317,62 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    validation_plan_cmd = sub.add_parser(
+        "validation-plan",
+        help=(
+            "Emit proposal-only validation command descriptors for a "
+            "refactor plan."
+        ),
+    )
+    validation_plan_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    validation_plan_cmd.add_argument(
+        "--action",
+        choices=("rename-module", "extract-port", "move-module"),
+        required=True,
+        help="Refactor proposal kind to validate after review.",
+    )
+    validation_plan_cmd.add_argument(
+        "--module",
+        required=True,
+        help="Exact module name to use as the validation target.",
+    )
+    validation_plan_cmd.add_argument(
+        "--new-name",
+        default=None,
+        help="New module name for rename-module validation plans.",
+    )
+    validation_plan_cmd.add_argument(
+        "--port-name",
+        default=None,
+        help="Port name for extract-port validation plans.",
+    )
+    validation_plan_cmd.add_argument(
+        "--direction",
+        choices=("input", "output", "inout"),
+        default=None,
+        help="Port direction for extract-port validation plans.",
+    )
+    validation_plan_cmd.add_argument(
+        "--width",
+        default=None,
+        help="Optional port width text for extract-port validation plans.",
+    )
+    validation_plan_cmd.add_argument(
+        "--destination",
+        default=None,
+        help="Relative destination path for move-module validation plans.",
+    )
+    validation_plan_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     xsim_log = sub.add_parser(
         "xsim-log",
         help="Parse an existing xsim-style log file into diagnostics-like output.",
@@ -683,6 +739,34 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_refactor_proposal_text(proposal))
+        return 0
+
+    if args.command == "validation-plan":
+        from .module_organization import (
+            build_refactor_validation_plan,
+            format_refactor_validation_plan_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        plan = build_refactor_validation_plan(
+            str(args.path),
+            args.path,
+            args.action,
+            args.module,
+            new_name=args.new_name,
+            port_name=args.port_name,
+            direction=args.direction,
+            width=args.width,
+            destination=args.destination,
+        )
+        if args.format == "json":
+            json.dump(plan, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_refactor_validation_plan_text(plan))
         return 0
 
     if args.command == "xsim-log":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -152,6 +152,16 @@ PROPOSAL_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+VALIDATION_PLAN_LIMITATIONS: tuple[str, ...] = (
+    "proposal-only validation planning metadata",
+    "scanner-based module and refactor preflight data only",
+    "emits command descriptors as fixed argument arrays for later review",
+    "does not execute validation commands or shell commands",
+    "does not apply refactors, write files, move files, or generate patches",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 _REFACTOR_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
     "rename-module": ("new_name",),
     "extract-port": ("port_name", "direction"),
@@ -274,6 +284,27 @@ def _module_context_safety_flags() -> dict[str, bool]:
         "runs_shell": False,
         "invokes_pccx_lab": False,
         "invokes_launcher": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _validation_plan_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "emits_command_descriptors": True,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
         "provider_calls": False,
         "hardware_access": False,
         "telemetry": False,
@@ -1409,6 +1440,276 @@ def build_refactor_proposal(
     }
 
 
+def _json_cli_argv(command: str, path: Path, *args: str) -> list[str]:
+    return [
+        "python",
+        "-m",
+        "pccx_ide_cli",
+        command,
+        str(path),
+        *args,
+        "--format",
+        "json",
+    ]
+
+
+def _refactor_plan_argv(path: Path, requested: dict[str, Any]) -> list[str]:
+    args = [
+        "--action",
+        requested["action"],
+        "--module",
+        requested["module"],
+    ]
+    for field, option in (
+        ("new_name", "--new-name"),
+        ("port_name", "--port-name"),
+        ("direction", "--direction"),
+        ("width", "--width"),
+        ("destination", "--destination"),
+    ):
+        if requested[field]:
+            args.extend([option, str(requested[field])])
+    return _json_cli_argv("refactor-plan", path, *args)
+
+
+def _validation_command_descriptor(
+    command_id: str,
+    phase: str,
+    purpose: str,
+    argv: list[str],
+) -> dict[str, Any]:
+    return {
+        "approval_required": True,
+        "argv": argv,
+        "fixed_argv": True,
+        "id": command_id,
+        "phase": phase,
+        "purpose": purpose,
+        "runner": "user-approved",
+        "shell": False,
+        "state": "proposed-not-run",
+    }
+
+
+def _pre_change_validation_commands(
+    path: Path,
+    requested: dict[str, Any],
+) -> list[dict[str, Any]]:
+    module_name = requested["module"]
+    return [
+        _validation_command_descriptor(
+            "module-context",
+            "pre-change-review",
+            "Refresh target module context before reviewing any edit.",
+            _json_cli_argv("module-context", path, "--module", module_name),
+        ),
+        _validation_command_descriptor(
+            "refactor-impact",
+            "pre-change-review",
+            "Refresh declaration and reference review targets for the proposal.",
+            _json_cli_argv("refactor-impact", path, "--module", module_name),
+        ),
+        _validation_command_descriptor(
+            "refactor-plan",
+            "pre-change-review",
+            "Refresh the proposal-only refactor plan with the requested inputs.",
+            _refactor_plan_argv(path, requested),
+        ),
+    ]
+
+
+def _post_change_validation_commands(
+    path: Path,
+    requested: dict[str, Any],
+) -> list[dict[str, Any]]:
+    module_name = requested["module"]
+    commands = [
+        _validation_command_descriptor(
+            "organization",
+            "post-change-local-validation",
+            "Rebuild scanner-based module boundaries and hierarchy after edits.",
+            _json_cli_argv("organization", path),
+        ),
+        _validation_command_descriptor(
+            "module-summary",
+            "post-change-local-validation",
+            "Rebuild conservative module header and port summaries after edits.",
+            _json_cli_argv("module-summary", path),
+        ),
+        _validation_command_descriptor(
+            "dependencies",
+            "post-change-local-validation",
+            "Rebuild direct dependency summaries after edits.",
+            _json_cli_argv("dependencies", path),
+        ),
+    ]
+    if path.is_file():
+        commands.append(
+            _validation_command_descriptor(
+                "check",
+                "post-change-local-validation",
+                "Run the built-in local diagnostics check after edits.",
+                _json_cli_argv("check", path),
+            )
+        )
+
+    action = requested["action"]
+    if action == "rename-module" and requested["new_name"]:
+        commands.append(
+            _validation_command_descriptor(
+                "locate-new-module",
+                "post-change-local-validation",
+                "Confirm the renamed module declaration can be located after edits.",
+                _json_cli_argv(
+                    "locate",
+                    path,
+                    str(requested["new_name"]),
+                    "--kind",
+                    "module",
+                ),
+            )
+        )
+    elif action == "extract-port":
+        commands.append(
+            _validation_command_descriptor(
+                "port-usage",
+                "post-change-local-validation",
+                "Review target port declarations and dependent usage sites after edits.",
+                _json_cli_argv("port-usage", path, "--module", module_name),
+            )
+        )
+    elif action == "move-module" and requested["destination"]:
+        destination = Path(str(requested["destination"]))
+        commands.extend(
+            [
+                _validation_command_descriptor(
+                    "organization-destination",
+                    "post-change-local-validation",
+                    "Review scanner data for the planned destination file after the move.",
+                    _json_cli_argv("organization", destination),
+                ),
+                _validation_command_descriptor(
+                    "check-destination",
+                    "post-change-local-validation",
+                    "Run the built-in local diagnostics check on the destination file after the move.",
+                    _json_cli_argv("check", destination),
+                ),
+            ]
+        )
+    return commands
+
+
+def _validation_groups(
+    path: Path,
+    requested: dict[str, Any],
+    preflight: dict[str, Any],
+) -> list[dict[str, Any]]:
+    pre_change = _pre_change_validation_commands(path, requested)
+    post_change = (
+        []
+        if preflight["status"] == "blocked"
+        else _post_change_validation_commands(path, requested)
+    )
+    return [
+        {
+            "blocked_by": [],
+            "command_count": len(pre_change),
+            "commands": pre_change,
+            "phase": "pre-change-review",
+            "status": "proposal-only",
+        },
+        {
+            "blocked_by": list(preflight["reasons"]),
+            "command_count": len(post_change),
+            "commands": post_change,
+            "phase": "post-change-local-validation",
+            "status": (
+                "blocked"
+                if preflight["status"] == "blocked"
+                else "proposal-only"
+            ),
+        },
+    ]
+
+
+def build_refactor_validation_plan(
+    source: str,
+    path: Path,
+    action: str,
+    module_name: str,
+    *,
+    new_name: str | None = None,
+    port_name: str | None = None,
+    direction: str | None = None,
+    width: str | None = None,
+    destination: str | None = None,
+) -> dict[str, Any]:
+    proposal = build_refactor_proposal(
+        source,
+        path,
+        action,
+        module_name,
+        new_name=new_name,
+        port_name=port_name,
+        direction=direction,
+        width=width,
+        destination=destination,
+    )
+    impact = build_refactor_impact_view(source, path, module_name)
+    preflight = proposal["preflight"]
+    requested = proposal["requested_change"]
+    groups = _validation_groups(path, requested, preflight)
+
+    return {
+        "action": action,
+        "approval": {
+            "approved_runner_required": True,
+            "requires_explicit_user_approval_before_run": True,
+            "requires_explicit_user_approval_before_write": True,
+        },
+        "command_descriptor_count": sum(
+            group["command_count"]
+            for group in groups
+        ),
+        "kind": "module-refactor-validation-plan",
+        "limitations": list(VALIDATION_PLAN_LIMITATIONS),
+        "module": proposal["module"],
+        "preflight": {
+            "reasons": list(preflight["reasons"]),
+            "requires_approval_before_write": preflight[
+                "requires_approval_before_write"
+            ],
+            "requires_explicit_approval_before_run": True,
+            "status": preflight["status"],
+        },
+        "refactor_proposal": {
+            "kind": proposal["kind"],
+            "planned_step_count": len(proposal["planned_steps"]),
+            "proposal_state": proposal["proposal_state"],
+            "requested_change": requested,
+            "writes_files": proposal["writes_files"],
+        },
+        "review_context": {
+            "direct_dependency_count": impact["direct_dependency_count"],
+            "direct_dependent_count": impact["direct_dependent_count"],
+            "review_target_count": len(impact["review_targets"]),
+            "unresolved_dependency_count": impact["unresolved_dependency_count"],
+        },
+        "safety": _validation_plan_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "target": module_name,
+        "tool": "pccx-ide-cli",
+        "validation_groups": groups,
+        "validation_state": (
+            "blocked"
+            if preflight["status"] == "blocked"
+            else "proposal-only"
+        ),
+        "writes_files": False,
+    }
+
+
 def format_refactor_proposal_text(proposal: dict[str, Any]) -> str:
     lines = [
         f"source: {proposal['source']}",
@@ -1431,6 +1732,34 @@ def format_refactor_proposal_text(proposal: dict[str, Any]) -> str:
         for step in proposal["planned_steps"]:
             lines.append(f"plan: {step}")
     lines.append("no patch, validation, lab, launcher, provider, or hardware execution")
+    return "\n".join(lines) + "\n"
+
+
+def format_refactor_validation_plan_text(plan: dict[str, Any]) -> str:
+    lines = [
+        f"source: {plan['source']}",
+        f"target: {plan['target']}",
+        f"action: {plan['action']}",
+        f"validation plan: {plan['validation_state']}",
+        f"preflight: {plan['preflight']['status']}",
+        "writes files: no",
+        "runs validation: no",
+    ]
+    for reason in plan["preflight"]["reasons"]:
+        lines.append(f"blocked: {reason}")
+    for group in plan["validation_groups"]:
+        lines.append(f"{group['phase']}: {group['status']}")
+        if not group["commands"]:
+            lines.append("  commands: none")
+        for command in group["commands"]:
+            lines.append(
+                f"  {command['id']}: {' '.join(command['argv'])} "
+                "(proposed-not-run)"
+            )
+    lines.append(
+        "no validation, shell, refactor, patch, file write, lab, launcher, "
+        "vendor tool, provider, or hardware execution"
+    )
     return "\n".join(lines) + "\n"
 
 

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -26,6 +26,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_summary_view,
     build_refactor_impact_view,
     build_refactor_proposal,
+    build_refactor_validation_plan,
     format_module_dependency_text,
     format_module_context_text,
     format_module_hierarchy_text,
@@ -34,6 +35,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_module_summary_text,
     format_refactor_impact_text,
     format_refactor_proposal_text,
+    format_refactor_validation_plan_text,
 )
 
 
@@ -421,6 +423,70 @@ def test_build_refactor_proposal_extract_port_requires_direction():
     assert proposal["safety"]["writes_files"] is False
 
 
+def test_build_refactor_validation_plan_is_proposal_only():
+    plan = build_refactor_validation_plan(
+        str(FIXTURE),
+        FIXTURE,
+        "rename-module",
+        "leaf_mod",
+        new_name="leaf_mod_next",
+    )
+
+    assert plan["kind"] == "module-refactor-validation-plan"
+    assert plan["validation_state"] == "proposal-only"
+    assert plan["preflight"]["status"] == "ready-for-review"
+    assert plan["writes_files"] is False
+    assert plan["refactor_proposal"]["requested_change"]["new_name"] == "leaf_mod_next"
+    assert plan["review_context"]["review_target_count"] == 2
+    assert plan["command_descriptor_count"] == 8
+    groups = {group["phase"]: group for group in plan["validation_groups"]}
+    assert groups["pre-change-review"]["command_count"] == 3
+    assert groups["post-change-local-validation"]["command_count"] == 5
+    locate_command = groups["post-change-local-validation"]["commands"][-1]
+    assert locate_command["id"] == "locate-new-module"
+    assert locate_command["argv"] == [
+        "python",
+        "-m",
+        "pccx_ide_cli",
+        "locate",
+        str(FIXTURE),
+        "leaf_mod_next",
+        "--kind",
+        "module",
+        "--format",
+        "json",
+    ]
+    assert locate_command["state"] == "proposed-not-run"
+    assert locate_command["shell"] is False
+    assert plan["safety"]["read_only"] is True
+    assert plan["safety"]["emits_command_descriptors"] is True
+    assert plan["safety"]["runs_validation"] is False
+    assert plan["safety"]["runs_shell"] is False
+    assert plan["safety"]["invokes_pccx_lab"] is False
+    assert plan["safety"]["invokes_launcher"] is False
+    assert plan["safety"]["hardware_access"] is False
+
+
+def test_build_refactor_validation_plan_blocks_post_change_commands():
+    plan = build_refactor_validation_plan(
+        str(FIXTURE),
+        FIXTURE,
+        "extract-port",
+        "top_mod",
+        port_name="valid_i",
+    )
+
+    assert plan["validation_state"] == "blocked"
+    assert "missing required direction" in plan["preflight"]["reasons"]
+    groups = {group["phase"]: group for group in plan["validation_groups"]}
+    assert groups["pre-change-review"]["command_count"] == 3
+    assert groups["post-change-local-validation"]["status"] == "blocked"
+    assert groups["post-change-local-validation"]["commands"] == []
+    assert groups["post-change-local-validation"]["blocked_by"] == [
+        "missing required direction"
+    ]
+
+
 def test_format_module_organization_text_mentions_boundary_and_hierarchy():
     export = build_module_organization_export(str(FIXTURE), FIXTURE)
     text = format_module_organization_text(export)
@@ -515,6 +581,25 @@ def test_format_refactor_proposal_text_mentions_no_execution():
     assert "preflight: ready-for-review" in text
     assert "writes files: no" in text
     assert "no patch, validation, lab, launcher, provider, or hardware execution" in text
+
+
+def test_format_refactor_validation_plan_text_mentions_no_execution():
+    plan = build_refactor_validation_plan(
+        str(FIXTURE),
+        FIXTURE,
+        "move-module",
+        "leaf_mod",
+        destination="rtl/leaf_mod.sv",
+    )
+    text = format_refactor_validation_plan_text(plan)
+
+    assert "validation plan: proposal-only" in text
+    assert "pre-change-review: proposal-only" in text
+    assert "post-change-local-validation: proposal-only" in text
+    assert "organization-destination:" in text
+    assert "writes files: no" in text
+    assert "runs validation: no" in text
+    assert "no validation, shell, refactor, patch, file write" in text
 
 
 def test_cli_organization_json():
@@ -723,6 +808,48 @@ def test_cli_refactor_plan_text():
     assert "writes files: no" in result.stdout
 
 
+def test_cli_validation_plan_json():
+    result = _run_cli(
+        "validation-plan",
+        str(FIXTURE),
+        "--action",
+        "rename-module",
+        "--module",
+        "leaf_mod",
+        "--new-name",
+        "leaf_mod_next",
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-refactor-validation-plan"
+    assert payload["validation_state"] == "proposal-only"
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["runs_validation"] is False
+
+
+def test_cli_validation_plan_text():
+    result = _run_cli(
+        "validation-plan",
+        str(FIXTURE),
+        "--action",
+        "extract-port",
+        "--module",
+        "top_mod",
+        "--port-name",
+        "valid_i",
+        "--direction",
+        "input",
+        "--format",
+        "text",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "validation plan: proposal-only" in result.stdout
+    assert "runs validation: no" in result.stdout
+    assert "port-usage:" in result.stdout
+
+
 def test_cli_organization_missing_path_exits_nonzero():
     result = _run_cli("organization", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
@@ -780,6 +907,21 @@ def test_cli_module_context_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_validation_plan_missing_path_exits_nonzero():
+    result = _run_cli(
+        "validation-plan",
+        str(FIXTURE.parent / "missing.sv"),
+        "--action",
+        "rename-module",
+        "--module",
+        "leaf_mod",
+        "--new-name",
+        "leaf_mod_next",
+    )
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_docs_cover_organization_flow_and_limits():
     contract = CONTRACT_DOC.read_text(encoding="utf-8")
     workflow = WORKFLOW_DOC.read_text(encoding="utf-8")
@@ -790,6 +932,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "port-usage <path>" in contract
     assert "module-context <path>" in contract
     assert "refactor-impact <path>" in contract
+    assert "validation-plan <path>" in contract
     assert "MODULE_ORGANIZATION_WORKFLOW.md" in contract
     assert "proposal-only" in workflow
     assert "module-hierarchy-view" in workflow
@@ -798,5 +941,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-port-usage-view" in workflow
     assert "module-context-bundle" in workflow
     assert "module-refactor-impact-view" in workflow
+    assert "module-refactor-validation-plan" in workflow
+    assert "proposed-not-run" in workflow
     assert "does not write files" in workflow
     assert "not a full SystemVerilog parser" in workflow


### PR DESCRIPTION
## Summary
- Add a proposal-only `validation-plan` CLI surface for module refactor requests.
- Emit fixed-argv command descriptors with explicit approval metadata and blocked post-change plans when refactor preflight fails.
- Document the boundary and add tests plus editor bridge smoke coverage.

## Validation
- `python3 -m pytest tests/test_module_organization.py`
- `python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py`
- `bash scripts/editor-bridge-smoke.sh`
- `python3 -m pytest`
- `bash -n scripts/*.sh`
- `git diff --check`
- `bash scripts/vscode-adapter-smoke.sh`
- `python3 scripts/check-source-headers.py`
- Local claim scan matching CI pattern

Refs #8