### PR TITLE
Add refactor review packet surface

### DIFF
--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -52,6 +52,7 @@ python -m pccx_ide_cli port-usage <path> --module <name> --format json
 python -m pccx_ide_cli module-context <path> --module <name> --format json
 python -m pccx_ide_cli refactor-impact <path> --module <name> --format json
 python -m pccx_ide_cli validation-plan <path> --action rename-module --module <name> --new-name <name> --format json
+python -m pccx_ide_cli refactor-review <path> --action rename-module --module <name> --new-name <name> --format json
 
 # Opt-in pccx-lab diagnostics backend
 python -m pccx_ide_cli check <sv-file> --backend pccx-lab --format json
@@ -208,6 +209,12 @@ refactor requests. It returns fixed argument-array command descriptors with
 validation, run shell commands, apply edits, invoke pccx-lab or the launcher,
 run vendor tools, call providers, touch hardware, or perform automatic
 repository actions.
+`refactor-review` emits a summary-only review packet over module context,
+refactor proposal, and validation-plan metadata. It summarizes validation
+descriptor phases and command IDs, but does not include command argv, execute
+validation, run shell commands, apply edits, invoke pccx-lab or the launcher,
+run vendor tools, call providers, touch hardware, or perform automatic
+repository actions.
 
 For existing xsim logs, the VS Code prototype can consume the checked
 `problems from-xsim-log` JSON as a read-only status/context summary.  The
@@ -226,8 +233,9 @@ xsim path, and text surface sketches is documented in
 - Scanner-based scaffolds, not full SystemVerilog parsing.
 - Module organization, header/port summaries, port usage summaries,
   refactor impact review, refactor planning, and validation planning are
-  scanner-based; they are not semantic elaboration and do not apply
-  refactors or execute validation.
+  scanner-based; refactor review packets are summary-only over those surfaces.
+  They are not semantic elaboration and do not apply refactors or execute
+  validation.
 - No LSP server in this repository today.
 - No published editor extension or marketplace packaging is implemented
   here.

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -4,13 +4,13 @@
 
 This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
-`module-summary`, `port-usage`, `module-context`, `refactor-impact`, and
-`validation-plan` CLI surfaces that report module boundary spans,
+`module-summary`, `port-usage`, `module-context`, `refactor-impact`,
+`validation-plan`, and `refactor-review` CLI surfaces that report module boundary spans,
 scanner-based hierarchy data, direct dependency impact data, conservative
 module header/port summaries, target port usage summaries, target module
 context bundles, target-specific refactor impact data, and proposal-only
-validation command descriptors for editor navigation and reviewed
-refactoring planning.
+validation command descriptors plus a summary-only review packet for editor
+navigation and reviewed refactoring planning.
 
 It is not a full SystemVerilog parser, not semantic elaboration, not an LSP
 implementation, and not a write-capable refactoring engine.
@@ -38,6 +38,9 @@ python -m pccx_ide_cli refactor-plan <path> --action move-module --module <name>
 python -m pccx_ide_cli validation-plan <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli validation-plan <path> --action extract-port --module <name> --port-name <name> --direction input --format text
 python -m pccx_ide_cli validation-plan <path> --action move-module --module <name> --destination rtl/<name>.sv --format json
+python -m pccx_ide_cli refactor-review <path> --action rename-module --module <name> --new-name <name> --format json
+python -m pccx_ide_cli refactor-review <path> --action extract-port --module <name> --port-name <name> --direction input --format text
+python -m pccx_ide_cli refactor-review <path> --action move-module --module <name> --destination rtl/<name>.sv --format json
 ```
 
 `<path>` may be a `.sv` / `.v` file or a directory. Directory scans follow the
@@ -551,6 +554,60 @@ generate patches, invoke `pccx-lab`, invoke the launcher, run vendor tools,
 call providers, touch hardware, upload telemetry, or perform automatic
 repository actions.
 
+## Refactor Review Packet
+
+`refactor-review` adds a summary-only review packet over the existing
+`module-context`, `refactor-plan`, and `validation-plan` boundaries. It is a
+one-call packet for editor review panes and maintainer handoff notes before
+any write-capable helper exists.
+
+Example shape:
+
+```json
+{
+  "kind": "module-refactor-review-packet",
+  "packet_state": "proposal-only",
+  "review_state": "ready-for-review",
+  "action": "rename-module",
+  "writes_files": false,
+  "context_summary": {
+    "context_state": "available_as_data",
+    "summary_available": true,
+    "review_target_count": 2,
+    "usage_site_count": 1
+  },
+  "proposal_summary": {
+    "planned_step_count": 4,
+    "writes_files": false
+  },
+  "validation_summary": {
+    "validation_state": "proposal-only",
+    "command_descriptor_count": 8,
+    "phases": []
+  },
+  "safety": {
+    "read_only": true,
+    "summarizes_command_descriptors": true,
+    "emits_command_descriptors": false,
+    "writes_files": false,
+    "runs_validation": false,
+    "runs_shell": false,
+    "invokes_pccx_lab": false,
+    "invokes_launcher": false,
+    "hardware_access": false
+  }
+}
+```
+
+The packet intentionally summarizes validation descriptors by phase and command
+ID only. It does not include command argv; consumers that need the fixed-argv
+descriptor list should call `validation-plan` directly.
+
+This boundary does not write files, apply refactors, move files, generate
+patches, run validation, execute shell commands, invoke `pccx-lab`, invoke the
+launcher, run vendor tools, call providers, touch hardware, upload telemetry,
+or perform automatic repository actions.
+
 ## Limitations
 
 - Scanner-based module declarations and `endmodule` matching only.
@@ -568,4 +625,4 @@ with read-only module boundary detection, a focused hierarchy view, a
 direct dependency view, conservative module header/port summaries,
 target-specific port usage summaries, target-specific module context
 bundles, target-specific refactor impact review data, and a
-proposal-only refactoring and validation planning boundary.
+proposal-only refactoring, validation planning, and review packet boundary.

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -37,6 +37,7 @@ run_json module-port-usage-view port-usage fixtures/organization/hierarchy_top.s
 run_json module-refactor-impact-view refactor-impact fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
 run_json module-refactor-proposal refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 run_json module-refactor-validation-plan validation-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
+run_json module-refactor-review-packet refactor-review fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 
 bash scripts/check-editor-bridge-examples.sh
 

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -373,6 +373,62 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    refactor_review_cmd = sub.add_parser(
+        "refactor-review",
+        help=(
+            "Emit a summary-only review packet for a refactor proposal "
+            "and validation plan."
+        ),
+    )
+    refactor_review_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    refactor_review_cmd.add_argument(
+        "--action",
+        choices=("rename-module", "extract-port", "move-module"),
+        required=True,
+        help="Refactor proposal kind to summarize for review.",
+    )
+    refactor_review_cmd.add_argument(
+        "--module",
+        required=True,
+        help="Exact module name to use as the review target.",
+    )
+    refactor_review_cmd.add_argument(
+        "--new-name",
+        default=None,
+        help="New module name for rename-module review packets.",
+    )
+    refactor_review_cmd.add_argument(
+        "--port-name",
+        default=None,
+        help="Port name for extract-port review packets.",
+    )
+    refactor_review_cmd.add_argument(
+        "--direction",
+        choices=("input", "output", "inout"),
+        default=None,
+        help="Port direction for extract-port review packets.",
+    )
+    refactor_review_cmd.add_argument(
+        "--width",
+        default=None,
+        help="Optional port width text for extract-port review packets.",
+    )
+    refactor_review_cmd.add_argument(
+        "--destination",
+        default=None,
+        help="Relative destination path for move-module review packets.",
+    )
+    refactor_review_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     xsim_log = sub.add_parser(
         "xsim-log",
         help="Parse an existing xsim-style log file into diagnostics-like output.",
@@ -767,6 +823,34 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_refactor_validation_plan_text(plan))
+        return 0
+
+    if args.command == "refactor-review":
+        from .module_organization import (
+            build_refactor_review_packet,
+            format_refactor_review_packet_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        packet = build_refactor_review_packet(
+            str(args.path),
+            args.path,
+            args.action,
+            args.module,
+            new_name=args.new_name,
+            port_name=args.port_name,
+            direction=args.direction,
+            width=args.width,
+            destination=args.destination,
+        )
+        if args.format == "json":
+            json.dump(packet, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_refactor_review_packet_text(packet))
         return 0
 
     if args.command == "xsim-log":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -162,6 +162,16 @@ VALIDATION_PLAN_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+REVIEW_PACKET_LIMITATIONS: tuple[str, ...] = (
+    "proposal-only refactor review packet metadata",
+    "summary-only bundle over existing scanner-based views",
+    "does not include command argv; use validation-plan for command descriptors",
+    "does not execute validation commands or shell commands",
+    "does not apply refactors, write files, move files, or generate patches",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 _REFACTOR_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
     "rename-module": ("new_name",),
     "extract-port": ("port_name", "direction"),
@@ -295,6 +305,28 @@ def _validation_plan_safety_flags() -> dict[str, bool]:
     return {
         "read_only": True,
         "emits_command_descriptors": True,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _review_packet_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "summarizes_command_descriptors": True,
+        "emits_command_descriptors": False,
         "writes_files": False,
         "moves_files": False,
         "applies_refactor": False,
@@ -1710,6 +1742,124 @@ def build_refactor_validation_plan(
     }
 
 
+def _review_context_summary(context: dict[str, Any]) -> dict[str, Any]:
+    dependency = context["dependency_context"]
+    port = context["port_context"]
+    refactor = context["refactor_context"]
+    summary = context["summary_context"]
+    return {
+        "context_state": context["context_state"],
+        "direct_dependency_count": dependency["direct_dependency_count"],
+        "direct_dependent_count": dependency["direct_dependent_count"],
+        "port_count": port["port_count"],
+        "review_target_count": refactor["review_target_count"],
+        "summary_available": summary is not None,
+        "summary_readiness": (
+            summary["readiness"]["state"]
+            if summary is not None
+            else "unavailable"
+        ),
+        "unresolved_dependency_count": dependency["unresolved_dependency_count"],
+        "usage_site_count": port["usage_site_count"],
+    }
+
+
+def _review_validation_summary(validation: dict[str, Any]) -> dict[str, Any]:
+    phases = []
+    for group in validation["validation_groups"]:
+        phases.append({
+            "blocked_by": list(group["blocked_by"]),
+            "command_ids": [
+                command["id"]
+                for command in group["commands"]
+            ],
+            "phase": group["phase"],
+            "status": group["status"],
+        })
+    return {
+        "command_descriptor_count": validation["command_descriptor_count"],
+        "phases": phases,
+        "validation_state": validation["validation_state"],
+    }
+
+
+def build_refactor_review_packet(
+    source: str,
+    path: Path,
+    action: str,
+    module_name: str,
+    *,
+    new_name: str | None = None,
+    port_name: str | None = None,
+    direction: str | None = None,
+    width: str | None = None,
+    destination: str | None = None,
+) -> dict[str, Any]:
+    proposal = build_refactor_proposal(
+        source,
+        path,
+        action,
+        module_name,
+        new_name=new_name,
+        port_name=port_name,
+        direction=direction,
+        width=width,
+        destination=destination,
+    )
+    context = build_module_context_bundle(source, path, module_name)
+    validation = build_refactor_validation_plan(
+        source,
+        path,
+        action,
+        module_name,
+        new_name=new_name,
+        port_name=port_name,
+        direction=direction,
+        width=width,
+        destination=destination,
+    )
+    preflight = proposal["preflight"]
+
+    return {
+        "action": action,
+        "approval": {
+            "requires_explicit_user_approval_before_run": True,
+            "requires_explicit_user_approval_before_write": True,
+        },
+        "context_summary": _review_context_summary(context),
+        "kind": "module-refactor-review-packet",
+        "limitations": list(REVIEW_PACKET_LIMITATIONS),
+        "module": proposal["module"],
+        "packet_state": "proposal-only",
+        "preflight": {
+            "reasons": list(preflight["reasons"]),
+            "requires_approval_before_write": preflight[
+                "requires_approval_before_write"
+            ],
+            "requires_explicit_approval_before_run": True,
+            "status": preflight["status"],
+        },
+        "proposal_summary": {
+            "planned_step_count": len(proposal["planned_steps"]),
+            "planned_steps": proposal["planned_steps"],
+            "requested_change": proposal["requested_change"],
+            "writes_files": proposal["writes_files"],
+        },
+        "review_state": (
+            "blocked"
+            if preflight["status"] == "blocked"
+            else "ready-for-review"
+        ),
+        "safety": _review_packet_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "target": module_name,
+        "tool": "pccx-ide-cli",
+        "validation_summary": _review_validation_summary(validation),
+        "writes_files": False,
+    }
+
+
 def format_refactor_proposal_text(proposal: dict[str, Any]) -> str:
     lines = [
         f"source: {proposal['source']}",
@@ -1759,6 +1909,49 @@ def format_refactor_validation_plan_text(plan: dict[str, Any]) -> str:
     lines.append(
         "no validation, shell, refactor, patch, file write, lab, launcher, "
         "vendor tool, provider, or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_refactor_review_packet_text(packet: dict[str, Any]) -> str:
+    context = packet["context_summary"]
+    validation = packet["validation_summary"]
+    lines = [
+        f"source: {packet['source']}",
+        f"target: {packet['target']}",
+        f"action: {packet['action']}",
+        f"review packet: {packet['packet_state']}",
+        f"review state: {packet['review_state']}",
+        f"preflight: {packet['preflight']['status']}",
+        "writes files: no",
+        "runs validation: no",
+        f"context: {context['context_state']}",
+        f"summary: {context['summary_readiness']}",
+        (
+            f"dependencies: {context['direct_dependency_count']}; "
+            f"dependents: {context['direct_dependent_count']}; "
+            f"unresolved: {context['unresolved_dependency_count']}"
+        ),
+        (
+            f"ports: {context['port_count']}; "
+            f"usage sites: {context['usage_site_count']}; "
+            f"review targets: {context['review_target_count']}"
+        ),
+        f"validation descriptors: {validation['command_descriptor_count']}",
+    ]
+    for phase in validation["phases"]:
+        command_ids = ", ".join(phase["command_ids"]) or "none"
+        lines.append(
+            f"validation phase: {phase['phase']} "
+            f"({phase['status']}): {command_ids}"
+        )
+    for step in packet["proposal_summary"]["planned_steps"]:
+        lines.append(f"plan: {step}")
+    for reason in packet["preflight"]["reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(
+        "summary-only: no command argv, validation, shell, refactor, patch, "
+        "file write, lab, launcher, vendor tool, provider, or hardware execution"
     )
     return "\n".join(lines) + "\n"
 

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -26,6 +26,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_summary_view,
     build_refactor_impact_view,
     build_refactor_proposal,
+    build_refactor_review_packet,
     build_refactor_validation_plan,
     format_module_dependency_text,
     format_module_context_text,
@@ -35,6 +36,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_module_summary_text,
     format_refactor_impact_text,
     format_refactor_proposal_text,
+    format_refactor_review_packet_text,
     format_refactor_validation_plan_text,
 )
 
@@ -487,6 +489,75 @@ def test_build_refactor_validation_plan_blocks_post_change_commands():
     ]
 
 
+def test_build_refactor_review_packet_summarizes_existing_views():
+    packet = build_refactor_review_packet(
+        str(FIXTURE),
+        FIXTURE,
+        "rename-module",
+        "leaf_mod",
+        new_name="leaf_mod_next",
+    )
+
+    assert packet["kind"] == "module-refactor-review-packet"
+    assert packet["packet_state"] == "proposal-only"
+    assert packet["review_state"] == "ready-for-review"
+    assert packet["preflight"]["status"] == "ready-for-review"
+    assert packet["writes_files"] is False
+    assert packet["proposal_summary"]["requested_change"]["new_name"] == "leaf_mod_next"
+    assert packet["proposal_summary"]["planned_step_count"] == 4
+    assert packet["context_summary"] == {
+        "context_state": "available_as_data",
+        "direct_dependency_count": 0,
+        "direct_dependent_count": 1,
+        "port_count": 1,
+        "review_target_count": 2,
+        "summary_available": True,
+        "summary_readiness": "ready-for-review",
+        "unresolved_dependency_count": 0,
+        "usage_site_count": 1,
+    }
+    assert packet["validation_summary"]["command_descriptor_count"] == 8
+    phases = {phase["phase"]: phase for phase in packet["validation_summary"]["phases"]}
+    assert phases["pre-change-review"]["command_ids"] == [
+        "module-context",
+        "refactor-impact",
+        "refactor-plan",
+    ]
+    assert phases["post-change-local-validation"]["command_ids"][-1] == (
+        "locate-new-module"
+    )
+    assert packet["safety"]["read_only"] is True
+    assert packet["safety"]["summarizes_command_descriptors"] is True
+    assert packet["safety"]["emits_command_descriptors"] is False
+    assert packet["safety"]["writes_files"] is False
+    assert packet["safety"]["runs_validation"] is False
+    assert packet["safety"]["runs_shell"] is False
+    assert packet["safety"]["invokes_pccx_lab"] is False
+    assert packet["safety"]["invokes_launcher"] is False
+    assert packet["safety"]["hardware_access"] is False
+
+
+def test_build_refactor_review_packet_reports_blocked_state():
+    packet = build_refactor_review_packet(
+        str(FIXTURE),
+        FIXTURE,
+        "extract-port",
+        "top_mod",
+        port_name="valid_i",
+    )
+
+    assert packet["review_state"] == "blocked"
+    assert "missing required direction" in packet["preflight"]["reasons"]
+    phases = {phase["phase"]: phase for phase in packet["validation_summary"]["phases"]}
+    assert phases["pre-change-review"]["command_ids"] == [
+        "module-context",
+        "refactor-impact",
+        "refactor-plan",
+    ]
+    assert phases["post-change-local-validation"]["status"] == "blocked"
+    assert phases["post-change-local-validation"]["command_ids"] == []
+
+
 def test_format_module_organization_text_mentions_boundary_and_hierarchy():
     export = build_module_organization_export(str(FIXTURE), FIXTURE)
     text = format_module_organization_text(export)
@@ -600,6 +671,26 @@ def test_format_refactor_validation_plan_text_mentions_no_execution():
     assert "writes files: no" in text
     assert "runs validation: no" in text
     assert "no validation, shell, refactor, patch, file write" in text
+
+
+def test_format_refactor_review_packet_text_mentions_summary_only_boundary():
+    packet = build_refactor_review_packet(
+        str(FIXTURE),
+        FIXTURE,
+        "rename-module",
+        "leaf_mod",
+        new_name="leaf_mod_next",
+    )
+    text = format_refactor_review_packet_text(packet)
+
+    assert "review packet: proposal-only" in text
+    assert "review state: ready-for-review" in text
+    assert "validation descriptors: 8" in text
+    assert "validation phase: pre-change-review" in text
+    assert "module-context, refactor-impact, refactor-plan" in text
+    assert "writes files: no" in text
+    assert "runs validation: no" in text
+    assert "summary-only: no command argv" in text
 
 
 def test_cli_organization_json():
@@ -850,6 +941,49 @@ def test_cli_validation_plan_text():
     assert "port-usage:" in result.stdout
 
 
+def test_cli_refactor_review_json():
+    result = _run_cli(
+        "refactor-review",
+        str(FIXTURE),
+        "--action",
+        "rename-module",
+        "--module",
+        "leaf_mod",
+        "--new-name",
+        "leaf_mod_next",
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-refactor-review-packet"
+    assert payload["review_state"] == "ready-for-review"
+    assert payload["context_summary"]["review_target_count"] == 2
+    assert payload["validation_summary"]["command_descriptor_count"] == 8
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["runs_validation"] is False
+
+
+def test_cli_refactor_review_text():
+    result = _run_cli(
+        "refactor-review",
+        str(FIXTURE),
+        "--action",
+        "move-module",
+        "--module",
+        "leaf_mod",
+        "--destination",
+        "rtl/leaf_mod.sv",
+        "--format",
+        "text",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "review packet: proposal-only" in result.stdout
+    assert "review state: ready-for-review" in result.stdout
+    assert "validation descriptors:" in result.stdout
+    assert "summary-only: no command argv" in result.stdout
+
+
 def test_cli_organization_missing_path_exits_nonzero():
     result = _run_cli("organization", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
@@ -922,6 +1056,21 @@ def test_cli_validation_plan_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_refactor_review_missing_path_exits_nonzero():
+    result = _run_cli(
+        "refactor-review",
+        str(FIXTURE.parent / "missing.sv"),
+        "--action",
+        "rename-module",
+        "--module",
+        "leaf_mod",
+        "--new-name",
+        "leaf_mod_next",
+    )
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_docs_cover_organization_flow_and_limits():
     contract = CONTRACT_DOC.read_text(encoding="utf-8")
     workflow = WORKFLOW_DOC.read_text(encoding="utf-8")
@@ -933,6 +1082,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-context <path>" in contract
     assert "refactor-impact <path>" in contract
     assert "validation-plan <path>" in contract
+    assert "refactor-review <path>" in contract
     assert "MODULE_ORGANIZATION_WORKFLOW.md" in contract
     assert "proposal-only" in workflow
     assert "module-hierarchy-view" in workflow
@@ -942,6 +1092,8 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-context-bundle" in workflow
     assert "module-refactor-impact-view" in workflow
     assert "module-refactor-validation-plan" in workflow
+    assert "module-refactor-review-packet" in workflow
     assert "proposed-not-run" in workflow
+    assert "summary-only review packet" in workflow
     assert "does not write files" in workflow
     assert "not a full SystemVerilog parser" in workflow


### PR DESCRIPTION
## Summary
- Add a proposal-only `refactor-review` CLI surface for module refactor requests.
- Summarize module context, refactor proposal, and validation-plan metadata without command argv or execution.
- Document the boundary and add tests plus editor bridge smoke coverage.

## Validation
- `python3 -m pytest tests/test_module_organization.py`
- `python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py`
- `bash scripts/editor-bridge-smoke.sh`
- `python3 -m pytest`
- `bash -n scripts/*.sh`
- `git diff --check`
- `bash scripts/vscode-adapter-smoke.sh`
- `python3 scripts/check-source-headers.py`
- Local claim scan matching CI pattern

Refs #8