### PR TITLE
Add refactor approval decision boundary

### DIFF
--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -53,6 +53,7 @@ python -m pccx_ide_cli module-context <path> --module <name> --format json
 python -m pccx_ide_cli refactor-impact <path> --module <name> --format json
 python -m pccx_ide_cli validation-plan <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli refactor-review <path> --action rename-module --module <name> --new-name <name> --format json
+python -m pccx_ide_cli refactor-approval <path> --action rename-module --module <name> --new-name <name> --format json
 
 # Opt-in pccx-lab diagnostics backend
 python -m pccx_ide_cli check <sv-file> --backend pccx-lab --format json
@@ -215,6 +216,12 @@ descriptor phases and command IDs, but does not include command argv, execute
 validation, run shell commands, apply edits, invoke pccx-lab or the launcher,
 run vendor tools, call providers, touch hardware, or perform automatic
 repository actions.
+`refactor-approval` emits proposal-only approval decision metadata over the
+review packet. It records an unapproved or blocked decision gate and summarizes
+review and validation state without command argv; it does not grant approval,
+execute validation, run shell commands, apply edits, write files, invoke
+pccx-lab or the launcher, run vendor tools, call providers, touch hardware, or
+perform automatic repository actions.
 
 For existing xsim logs, the VS Code prototype can consume the checked
 `problems from-xsim-log` JSON as a read-only status/context summary.  The

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -5,12 +5,13 @@
 This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
 `module-summary`, `port-usage`, `module-context`, `refactor-impact`,
-`validation-plan`, and `refactor-review` CLI surfaces that report module boundary spans,
-scanner-based hierarchy data, direct dependency impact data, conservative
-module header/port summaries, target port usage summaries, target module
-context bundles, target-specific refactor impact data, and proposal-only
-validation command descriptors plus a summary-only review packet for editor
-navigation and reviewed refactoring planning.
+`validation-plan`, `refactor-review`, and `refactor-approval` CLI surfaces
+that report module boundary spans, scanner-based hierarchy data, direct
+dependency impact data, conservative module header/port summaries, target port
+usage summaries, target module context bundles, target-specific refactor impact
+data, proposal-only validation command descriptors, a summary-only review
+packet, and approval decision metadata for editor navigation and reviewed
+refactoring planning.
 
 It is not a full SystemVerilog parser, not semantic elaboration, not an LSP
 implementation, and not a write-capable refactoring engine.
@@ -41,6 +42,9 @@ python -m pccx_ide_cli validation-plan <path> --action move-module --module <nam
 python -m pccx_ide_cli refactor-review <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli refactor-review <path> --action extract-port --module <name> --port-name <name> --direction input --format text
 python -m pccx_ide_cli refactor-review <path> --action move-module --module <name> --destination rtl/<name>.sv --format json
+python -m pccx_ide_cli refactor-approval <path> --action rename-module --module <name> --new-name <name> --format json
+python -m pccx_ide_cli refactor-approval <path> --action extract-port --module <name> --port-name <name> --direction input --format text
+python -m pccx_ide_cli refactor-approval <path> --action move-module --module <name> --destination rtl/<name>.sv --format json
 ```
 
 `<path>` may be a `.sv` / `.v` file or a directory. Directory scans follow the
@@ -607,6 +611,62 @@ This boundary does not write files, apply refactors, move files, generate
 patches, run validation, execute shell commands, invoke `pccx-lab`, invoke the
 launcher, run vendor tools, call providers, touch hardware, upload telemetry,
 or perform automatic repository actions.
+
+## Refactor Approval Decision
+
+`refactor-approval` adds proposal-only approval decision metadata over the
+existing `refactor-review` packet. It is a one-call gate for editor review
+panes and maintainer handoff notes to show that no approval has been recorded,
+or that the preflight is blocked, before any write-capable helper exists.
+
+Example shape:
+
+```json
+{
+  "kind": "module-refactor-approval-decision",
+  "decision_state": "not-approved",
+  "action": "rename-module",
+  "writes_files": false,
+  "approval_decision": {
+    "approved": false,
+    "approver": "not-recorded",
+    "decision": "not-approved",
+    "reason": "explicit approval not recorded",
+    "requires_explicit_user_approval_before_run": true,
+    "requires_explicit_user_approval_before_write": true
+  },
+  "packet_summary": {
+    "kind": "module-refactor-review-packet",
+    "review_state": "ready-for-review",
+    "validation_state": "proposal-only",
+    "command_descriptor_count": 8,
+    "validation_phases": []
+  },
+  "safety": {
+    "read_only": true,
+    "decision_metadata_only": true,
+    "approval_granted": false,
+    "summarizes_command_descriptors": true,
+    "emits_command_descriptors": false,
+    "writes_files": false,
+    "runs_validation": false,
+    "runs_shell": false,
+    "invokes_pccx_lab": false,
+    "invokes_launcher": false,
+    "hardware_access": false
+  }
+}
+```
+
+The decision intentionally records `approved: false`. It summarizes validation
+descriptor phases by command ID only and does not include command argv;
+consumers that need the fixed-argv descriptor list should call
+`validation-plan` directly.
+
+This boundary does not write files, apply refactors, move files, generate
+patches, run validation, execute shell commands, invoke `pccx-lab`, invoke the
+launcher, run vendor tools, call providers, touch hardware, upload telemetry,
+grant approval, or perform automatic repository actions.
 
 ## Limitations
 

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -38,6 +38,7 @@ run_json module-refactor-impact-view refactor-impact fixtures/organization/hiera
 run_json module-refactor-proposal refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 run_json module-refactor-validation-plan validation-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 run_json module-refactor-review-packet refactor-review fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
+run_json module-refactor-approval-decision refactor-approval fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 
 bash scripts/check-editor-bridge-examples.sh
 

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -429,6 +429,62 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    refactor_approval_cmd = sub.add_parser(
+        "refactor-approval",
+        help=(
+            "Emit proposal-only approval decision metadata for a "
+            "refactor review packet."
+        ),
+    )
+    refactor_approval_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    refactor_approval_cmd.add_argument(
+        "--action",
+        choices=("rename-module", "extract-port", "move-module"),
+        required=True,
+        help="Refactor proposal kind to gate for approval.",
+    )
+    refactor_approval_cmd.add_argument(
+        "--module",
+        required=True,
+        help="Exact module name to use as the approval target.",
+    )
+    refactor_approval_cmd.add_argument(
+        "--new-name",
+        default=None,
+        help="New module name for rename-module approval decisions.",
+    )
+    refactor_approval_cmd.add_argument(
+        "--port-name",
+        default=None,
+        help="Port name for extract-port approval decisions.",
+    )
+    refactor_approval_cmd.add_argument(
+        "--direction",
+        choices=("input", "output", "inout"),
+        default=None,
+        help="Port direction for extract-port approval decisions.",
+    )
+    refactor_approval_cmd.add_argument(
+        "--width",
+        default=None,
+        help="Optional port width text for extract-port approval decisions.",
+    )
+    refactor_approval_cmd.add_argument(
+        "--destination",
+        default=None,
+        help="Relative destination path for move-module approval decisions.",
+    )
+    refactor_approval_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     xsim_log = sub.add_parser(
         "xsim-log",
         help="Parse an existing xsim-style log file into diagnostics-like output.",
@@ -851,6 +907,34 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_refactor_review_packet_text(packet))
+        return 0
+
+    if args.command == "refactor-approval":
+        from .module_organization import (
+            build_refactor_approval_decision,
+            format_refactor_approval_decision_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        decision = build_refactor_approval_decision(
+            str(args.path),
+            args.path,
+            args.action,
+            args.module,
+            new_name=args.new_name,
+            port_name=args.port_name,
+            direction=args.direction,
+            width=args.width,
+            destination=args.destination,
+        )
+        if args.format == "json":
+            json.dump(decision, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_refactor_approval_decision_text(decision))
         return 0
 
     if args.command == "xsim-log":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -172,6 +172,16 @@ REVIEW_PACKET_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+APPROVAL_DECISION_LIMITATIONS: tuple[str, ...] = (
+    "proposal-only refactor approval decision metadata",
+    "records an unapproved decision gate over the review packet",
+    "does not include command argv; use validation-plan for command descriptors",
+    "does not execute validation commands or shell commands",
+    "does not apply refactors, write files, move files, or generate patches",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 _REFACTOR_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
     "rename-module": ("new_name",),
     "extract-port": ("port_name", "direction"),
@@ -325,6 +335,30 @@ def _validation_plan_safety_flags() -> dict[str, bool]:
 def _review_packet_safety_flags() -> dict[str, bool]:
     return {
         "read_only": True,
+        "summarizes_command_descriptors": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _approval_decision_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "decision_metadata_only": True,
+        "approval_granted": False,
         "summarizes_command_descriptors": True,
         "emits_command_descriptors": False,
         "writes_files": False,
@@ -1860,6 +1894,100 @@ def build_refactor_review_packet(
     }
 
 
+def _approval_packet_summary(packet: dict[str, Any]) -> dict[str, Any]:
+    context = packet["context_summary"]
+    validation = packet["validation_summary"]
+    phases = []
+    for phase in validation["phases"]:
+        phases.append({
+            "command_ids": list(phase["command_ids"]),
+            "phase": phase["phase"],
+            "status": phase["status"],
+        })
+    return {
+        "command_descriptor_count": validation["command_descriptor_count"],
+        "context_state": context["context_state"],
+        "kind": packet["kind"],
+        "packet_state": packet["packet_state"],
+        "review_state": packet["review_state"],
+        "review_target_count": context["review_target_count"],
+        "validation_phases": phases,
+        "validation_state": validation["validation_state"],
+    }
+
+
+def build_refactor_approval_decision(
+    source: str,
+    path: Path,
+    action: str,
+    module_name: str,
+    *,
+    new_name: str | None = None,
+    port_name: str | None = None,
+    direction: str | None = None,
+    width: str | None = None,
+    destination: str | None = None,
+) -> dict[str, Any]:
+    packet = build_refactor_review_packet(
+        source,
+        path,
+        action,
+        module_name,
+        new_name=new_name,
+        port_name=port_name,
+        direction=direction,
+        width=width,
+        destination=destination,
+    )
+    preflight = packet["preflight"]
+    decision_state = (
+        "blocked"
+        if preflight["status"] == "blocked"
+        else "not-approved"
+    )
+    reason = (
+        "preflight blocked"
+        if preflight["status"] == "blocked"
+        else "explicit approval not recorded"
+    )
+
+    return {
+        "action": action,
+        "approval_decision": {
+            "approved": False,
+            "approver": "not-recorded",
+            "decision": decision_state,
+            "reason": reason,
+            "requires_explicit_user_approval_before_run": True,
+            "requires_explicit_user_approval_before_write": True,
+        },
+        "decision_state": decision_state,
+        "kind": "module-refactor-approval-decision",
+        "limitations": list(APPROVAL_DECISION_LIMITATIONS),
+        "module": packet["module"],
+        "packet_summary": _approval_packet_summary(packet),
+        "preflight": {
+            "reasons": list(preflight["reasons"]),
+            "requires_approval_before_write": preflight[
+                "requires_approval_before_write"
+            ],
+            "requires_explicit_approval_before_run": True,
+            "status": preflight["status"],
+        },
+        "proposal_summary": {
+            "planned_step_count": packet["proposal_summary"]["planned_step_count"],
+            "requested_change": packet["proposal_summary"]["requested_change"],
+            "writes_files": packet["proposal_summary"]["writes_files"],
+        },
+        "safety": _approval_decision_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "target": module_name,
+        "tool": "pccx-ide-cli",
+        "writes_files": False,
+    }
+
+
 def format_refactor_proposal_text(proposal: dict[str, Any]) -> str:
     lines = [
         f"source: {proposal['source']}",
@@ -1952,6 +2080,38 @@ def format_refactor_review_packet_text(packet: dict[str, Any]) -> str:
     lines.append(
         "summary-only: no command argv, validation, shell, refactor, patch, "
         "file write, lab, launcher, vendor tool, provider, or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_refactor_approval_decision_text(decision: dict[str, Any]) -> str:
+    approval = decision["approval_decision"]
+    packet = decision["packet_summary"]
+    lines = [
+        f"source: {decision['source']}",
+        f"target: {decision['target']}",
+        f"action: {decision['action']}",
+        f"approval decision: {approval['decision']}",
+        "approved: no",
+        f"review state: {packet['review_state']}",
+        f"preflight: {decision['preflight']['status']}",
+        "writes files: no",
+        "runs validation: no",
+        f"validation descriptors: {packet['command_descriptor_count']}",
+    ]
+    for phase in packet["validation_phases"]:
+        command_ids = ", ".join(phase["command_ids"]) or "none"
+        lines.append(
+            f"validation phase: {phase['phase']} "
+            f"({phase['status']}): {command_ids}"
+        )
+    for reason in decision["preflight"]["reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"reason: {approval['reason']}")
+    lines.append(
+        "decision metadata only: no command argv, validation, shell, "
+        "refactor, patch, file write, lab, launcher, vendor tool, provider, "
+        "or hardware execution"
     )
     return "\n".join(lines) + "\n"
 

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -24,10 +24,12 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_organization_export,
     build_module_port_usage_view,
     build_module_summary_view,
+    build_refactor_approval_decision,
     build_refactor_impact_view,
     build_refactor_proposal,
     build_refactor_review_packet,
     build_refactor_validation_plan,
+    format_refactor_approval_decision_text,
     format_module_dependency_text,
     format_module_context_text,
     format_module_hierarchy_text,
@@ -558,6 +560,70 @@ def test_build_refactor_review_packet_reports_blocked_state():
     assert phases["post-change-local-validation"]["command_ids"] == []
 
 
+def test_build_refactor_approval_decision_records_unapproved_gate():
+    decision = build_refactor_approval_decision(
+        str(FIXTURE),
+        FIXTURE,
+        "rename-module",
+        "leaf_mod",
+        new_name="leaf_mod_next",
+    )
+
+    assert decision["kind"] == "module-refactor-approval-decision"
+    assert decision["decision_state"] == "not-approved"
+    assert decision["approval_decision"]["approved"] is False
+    assert decision["approval_decision"]["approver"] == "not-recorded"
+    assert decision["approval_decision"]["reason"] == (
+        "explicit approval not recorded"
+    )
+    assert decision["preflight"]["status"] == "ready-for-review"
+    assert decision["writes_files"] is False
+    assert decision["packet_summary"]["kind"] == "module-refactor-review-packet"
+    assert decision["packet_summary"]["review_state"] == "ready-for-review"
+    assert decision["packet_summary"]["command_descriptor_count"] == 8
+    assert decision["packet_summary"]["validation_phases"][0]["command_ids"] == [
+        "module-context",
+        "refactor-impact",
+        "refactor-plan",
+    ]
+    assert decision["proposal_summary"]["requested_change"]["new_name"] == (
+        "leaf_mod_next"
+    )
+    assert decision["safety"]["read_only"] is True
+    assert decision["safety"]["decision_metadata_only"] is True
+    assert decision["safety"]["approval_granted"] is False
+    assert decision["safety"]["summarizes_command_descriptors"] is True
+    assert decision["safety"]["emits_command_descriptors"] is False
+    assert decision["safety"]["writes_files"] is False
+    assert decision["safety"]["runs_validation"] is False
+    assert decision["safety"]["runs_shell"] is False
+    assert decision["safety"]["invokes_pccx_lab"] is False
+    assert decision["safety"]["invokes_launcher"] is False
+    assert decision["safety"]["hardware_access"] is False
+    assert '"argv"' not in json.dumps(decision)
+
+
+def test_build_refactor_approval_decision_reports_blocked_preflight():
+    decision = build_refactor_approval_decision(
+        str(FIXTURE),
+        FIXTURE,
+        "extract-port",
+        "top_mod",
+        port_name="valid_i",
+    )
+
+    assert decision["decision_state"] == "blocked"
+    assert decision["approval_decision"]["approved"] is False
+    assert decision["approval_decision"]["reason"] == "preflight blocked"
+    assert "missing required direction" in decision["preflight"]["reasons"]
+    phases = {
+        phase["phase"]: phase
+        for phase in decision["packet_summary"]["validation_phases"]
+    }
+    assert phases["post-change-local-validation"]["status"] == "blocked"
+    assert phases["post-change-local-validation"]["command_ids"] == []
+
+
 def test_format_module_organization_text_mentions_boundary_and_hierarchy():
     export = build_module_organization_export(str(FIXTURE), FIXTURE)
     text = format_module_organization_text(export)
@@ -691,6 +757,25 @@ def test_format_refactor_review_packet_text_mentions_summary_only_boundary():
     assert "writes files: no" in text
     assert "runs validation: no" in text
     assert "summary-only: no command argv" in text
+
+
+def test_format_refactor_approval_decision_text_mentions_unapproved_boundary():
+    decision = build_refactor_approval_decision(
+        str(FIXTURE),
+        FIXTURE,
+        "move-module",
+        "leaf_mod",
+        destination="rtl/leaf_mod.sv",
+    )
+    text = format_refactor_approval_decision_text(decision)
+
+    assert "approval decision: not-approved" in text
+    assert "approved: no" in text
+    assert "review state: ready-for-review" in text
+    assert "validation descriptors:" in text
+    assert "writes files: no" in text
+    assert "runs validation: no" in text
+    assert "decision metadata only: no command argv" in text
 
 
 def test_cli_organization_json():
@@ -984,6 +1069,51 @@ def test_cli_refactor_review_text():
     assert "summary-only: no command argv" in result.stdout
 
 
+def test_cli_refactor_approval_json():
+    result = _run_cli(
+        "refactor-approval",
+        str(FIXTURE),
+        "--action",
+        "rename-module",
+        "--module",
+        "leaf_mod",
+        "--new-name",
+        "leaf_mod_next",
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-refactor-approval-decision"
+    assert payload["decision_state"] == "not-approved"
+    assert payload["approval_decision"]["approved"] is False
+    assert payload["packet_summary"]["review_state"] == "ready-for-review"
+    assert payload["packet_summary"]["command_descriptor_count"] == 8
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_refactor_approval_text():
+    result = _run_cli(
+        "refactor-approval",
+        str(FIXTURE),
+        "--action",
+        "extract-port",
+        "--module",
+        "top_mod",
+        "--port-name",
+        "valid_i",
+        "--format",
+        "text",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "approval decision: blocked" in result.stdout
+    assert "approved: no" in result.stdout
+    assert "blocked: missing required direction" in result.stdout
+    assert "decision metadata only: no command argv" in result.stdout
+
+
 def test_cli_organization_missing_path_exits_nonzero():
     result = _run_cli("organization", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
@@ -1071,6 +1201,21 @@ def test_cli_refactor_review_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_refactor_approval_missing_path_exits_nonzero():
+    result = _run_cli(
+        "refactor-approval",
+        str(FIXTURE.parent / "missing.sv"),
+        "--action",
+        "rename-module",
+        "--module",
+        "leaf_mod",
+        "--new-name",
+        "leaf_mod_next",
+    )
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_docs_cover_organization_flow_and_limits():
     contract = CONTRACT_DOC.read_text(encoding="utf-8")
     workflow = WORKFLOW_DOC.read_text(encoding="utf-8")
@@ -1083,6 +1228,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "refactor-impact <path>" in contract
     assert "validation-plan <path>" in contract
     assert "refactor-review <path>" in contract
+    assert "refactor-approval <path>" in contract
     assert "MODULE_ORGANIZATION_WORKFLOW.md" in contract
     assert "proposal-only" in workflow
     assert "module-hierarchy-view" in workflow
@@ -1093,7 +1239,9 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-refactor-impact-view" in workflow
     assert "module-refactor-validation-plan" in workflow
     assert "module-refactor-review-packet" in workflow
+    assert "module-refactor-approval-decision" in workflow
     assert "proposed-not-run" in workflow
     assert "summary-only review packet" in workflow
+    assert "approval decision metadata" in workflow
     assert "does not write files" in workflow
     assert "not a full SystemVerilog parser" in workflow


### PR DESCRIPTION
## Summary
- Add a proposal-only `refactor-approval` CLI surface and `module-refactor-approval-decision` JSON envelope.
- Record blocked or not-approved decision metadata over the review packet with `approved: false`.
- Keep the boundary summary-only: no command argv, file writes, refactor application, validation execution, shell execution, vendor tools, providers, hardware access, telemetry, or automatic repository actions.
- Update the editor bridge contract, module organization workflow docs, smoke coverage, and tests.

Refs #8

## Validation
- `PYTHONPATH=src pytest -q`
- `PYTHONPATH=src pytest -q tests/test_module_organization.py`
- `python3 -m py_compile $(find src tests scripts -name '*.py' -print | sort)`
- `bash -n scripts/check-editor-bridge-examples.sh scripts/editor-bridge-smoke.sh scripts/vscode-adapter-smoke.sh scripts/vscode-extension-host-smoke.sh`
- `python3 scripts/check-source-headers.py`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- local claim scan matching `.github/workflows/ci.yml`
- `git diff --check`
- `git diff --cached --check`
