### PR TITLE
Add refactor application request boundary

### DIFF
--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -54,6 +54,7 @@ python -m pccx_ide_cli refactor-impact <path> --module <name> --format json
 python -m pccx_ide_cli validation-plan <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli refactor-review <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli refactor-approval <path> --action rename-module --module <name> --new-name <name> --format json
+python -m pccx_ide_cli refactor-application <path> --action rename-module --module <name> --new-name <name> --format json
 
 # Opt-in pccx-lab diagnostics backend
 python -m pccx_ide_cli check <sv-file> --backend pccx-lab --format json
@@ -222,6 +223,12 @@ review and validation state without command argv; it does not grant approval,
 execute validation, run shell commands, apply edits, write files, invoke
 pccx-lab or the launcher, run vendor tools, call providers, touch hardware, or
 perform automatic repository actions.
+`refactor-application` emits proposal-only application request metadata over
+the approval decision. It records a not-accepted or blocked application gate
+with `accepted: false` and `applied: false`; it does not include command argv,
+accept a write request, apply edits, execute validation, run shell commands,
+write files, invoke pccx-lab or the launcher, run vendor tools, call providers,
+touch hardware, or perform automatic repository actions.
 
 For existing xsim logs, the VS Code prototype can consume the checked
 `problems from-xsim-log` JSON as a read-only status/context summary.  The
@@ -240,9 +247,9 @@ xsim path, and text surface sketches is documented in
 - Scanner-based scaffolds, not full SystemVerilog parsing.
 - Module organization, header/port summaries, port usage summaries,
   refactor impact review, refactor planning, and validation planning are
-  scanner-based; refactor review packets are summary-only over those surfaces.
-  They are not semantic elaboration and do not apply refactors or execute
-  validation.
+  scanner-based; refactor review packets, approval decisions, and application
+  requests are summary-only metadata over those surfaces. They are not semantic
+  elaboration and do not apply refactors or execute validation.
 - No LSP server in this repository today.
 - No published editor extension or marketplace packaging is implemented
   here.

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -5,13 +5,14 @@
 This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
 `module-summary`, `port-usage`, `module-context`, `refactor-impact`,
-`validation-plan`, `refactor-review`, and `refactor-approval` CLI surfaces
+`validation-plan`, `refactor-review`, `refactor-approval`, and
+`refactor-application` CLI surfaces
 that report module boundary spans, scanner-based hierarchy data, direct
 dependency impact data, conservative module header/port summaries, target port
 usage summaries, target module context bundles, target-specific refactor impact
 data, proposal-only validation command descriptors, a summary-only review
-packet, and approval decision metadata for editor navigation and reviewed
-refactoring planning.
+packet, approval decision metadata, and application request metadata for editor
+navigation and reviewed refactoring planning.
 
 It is not a full SystemVerilog parser, not semantic elaboration, not an LSP
 implementation, and not a write-capable refactoring engine.
@@ -45,6 +46,9 @@ python -m pccx_ide_cli refactor-review <path> --action move-module --module <nam
 python -m pccx_ide_cli refactor-approval <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli refactor-approval <path> --action extract-port --module <name> --port-name <name> --direction input --format text
 python -m pccx_ide_cli refactor-approval <path> --action move-module --module <name> --destination rtl/<name>.sv --format json
+python -m pccx_ide_cli refactor-application <path> --action rename-module --module <name> --new-name <name> --format json
+python -m pccx_ide_cli refactor-application <path> --action extract-port --module <name> --port-name <name> --direction input --format text
+python -m pccx_ide_cli refactor-application <path> --action move-module --module <name> --destination rtl/<name>.sv --format json
 ```
 
 `<path>` may be a `.sv` / `.v` file or a directory. Directory scans follow the
@@ -668,6 +672,68 @@ patches, run validation, execute shell commands, invoke `pccx-lab`, invoke the
 launcher, run vendor tools, call providers, touch hardware, upload telemetry,
 grant approval, or perform automatic repository actions.
 
+## Refactor Application Request
+
+`refactor-application` adds proposal-only application request metadata over the
+existing `refactor-approval` decision. It is a one-call gate for editor review
+panes and maintainer handoff notes to show that a reviewed refactor still has
+not been accepted for write execution and has not been applied.
+
+Example shape:
+
+```json
+{
+  "kind": "module-refactor-application-request",
+  "application_state": "not-accepted",
+  "action": "rename-module",
+  "writes_files": false,
+  "application_request": {
+    "accepted": false,
+    "applied": false,
+    "decision": "not-accepted",
+    "reason": "approval not granted",
+    "required_approval_decision": "not-approved",
+    "result": "not_applied",
+    "requires_explicit_user_approval_before_run": true,
+    "requires_explicit_user_approval_before_write": true
+  },
+  "approval_summary": {
+    "kind": "module-refactor-approval-decision",
+    "approved": false,
+    "decision_state": "not-approved",
+    "review_state": "ready-for-review",
+    "validation_state": "proposal-only",
+    "command_descriptor_count": 8,
+    "validation_phases": []
+  },
+  "safety": {
+    "read_only": true,
+    "application_metadata_only": true,
+    "approval_granted": false,
+    "request_accepted": false,
+    "summarizes_command_descriptors": true,
+    "emits_command_descriptors": false,
+    "writes_files": false,
+    "runs_validation": false,
+    "runs_shell": false,
+    "invokes_pccx_lab": false,
+    "invokes_launcher": false,
+    "hardware_access": false
+  }
+}
+```
+
+The request intentionally records `accepted: false` and `applied: false`.
+It summarizes the approval decision and validation descriptor phases by command
+ID only and does not include command argv; consumers that need the fixed-argv
+descriptor list should call `validation-plan` directly.
+
+This boundary does not write files, apply refactors, move files, generate
+patches, run validation, execute shell commands, invoke `pccx-lab`, invoke the
+launcher, run vendor tools, call providers, touch hardware, upload telemetry,
+accept an application request, apply a refactor, grant approval, or perform
+automatic repository actions.
+
 ## Limitations
 
 - Scanner-based module declarations and `endmodule` matching only.
@@ -685,4 +751,5 @@ with read-only module boundary detection, a focused hierarchy view, a
 direct dependency view, conservative module header/port summaries,
 target-specific port usage summaries, target-specific module context
 bundles, target-specific refactor impact review data, and a
-proposal-only refactoring, validation planning, and review packet boundary.
+proposal-only refactoring, validation planning, review packet, approval
+decision, and application request boundary.

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -39,6 +39,7 @@ run_json module-refactor-proposal refactor-plan fixtures/organization/hierarchy_
 run_json module-refactor-validation-plan validation-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 run_json module-refactor-review-packet refactor-review fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 run_json module-refactor-approval-decision refactor-approval fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
+run_json module-refactor-application-request refactor-application fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 
 bash scripts/check-editor-bridge-examples.sh
 

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -485,6 +485,62 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    refactor_application_cmd = sub.add_parser(
+        "refactor-application",
+        help=(
+            "Emit proposal-only application request metadata for a "
+            "refactor approval decision."
+        ),
+    )
+    refactor_application_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    refactor_application_cmd.add_argument(
+        "--action",
+        choices=("rename-module", "extract-port", "move-module"),
+        required=True,
+        help="Refactor proposal kind to gate for application.",
+    )
+    refactor_application_cmd.add_argument(
+        "--module",
+        required=True,
+        help="Exact module name to use as the application target.",
+    )
+    refactor_application_cmd.add_argument(
+        "--new-name",
+        default=None,
+        help="New module name for rename-module application requests.",
+    )
+    refactor_application_cmd.add_argument(
+        "--port-name",
+        default=None,
+        help="Port name for extract-port application requests.",
+    )
+    refactor_application_cmd.add_argument(
+        "--direction",
+        choices=("input", "output", "inout"),
+        default=None,
+        help="Port direction for extract-port application requests.",
+    )
+    refactor_application_cmd.add_argument(
+        "--width",
+        default=None,
+        help="Optional port width text for extract-port application requests.",
+    )
+    refactor_application_cmd.add_argument(
+        "--destination",
+        default=None,
+        help="Relative destination path for move-module application requests.",
+    )
+    refactor_application_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     xsim_log = sub.add_parser(
         "xsim-log",
         help="Parse an existing xsim-style log file into diagnostics-like output.",
@@ -935,6 +991,34 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_refactor_approval_decision_text(decision))
+        return 0
+
+    if args.command == "refactor-application":
+        from .module_organization import (
+            build_refactor_application_request,
+            format_refactor_application_request_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        request = build_refactor_application_request(
+            str(args.path),
+            args.path,
+            args.action,
+            args.module,
+            new_name=args.new_name,
+            port_name=args.port_name,
+            direction=args.direction,
+            width=args.width,
+            destination=args.destination,
+        )
+        if args.format == "json":
+            json.dump(request, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_refactor_application_request_text(request))
         return 0
 
     if args.command == "xsim-log":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -182,6 +182,16 @@ APPROVAL_DECISION_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+APPLICATION_REQUEST_LIMITATIONS: tuple[str, ...] = (
+    "proposal-only refactor application request metadata",
+    "records a not-accepted application gate over the approval decision",
+    "does not include command argv; use validation-plan for command descriptors",
+    "does not execute validation commands or shell commands",
+    "does not apply refactors, write files, move files, or generate patches",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 _REFACTOR_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
     "rename-module": ("new_name",),
     "extract-port": ("port_name", "direction"),
@@ -359,6 +369,31 @@ def _approval_decision_safety_flags() -> dict[str, bool]:
         "read_only": True,
         "decision_metadata_only": True,
         "approval_granted": False,
+        "summarizes_command_descriptors": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _application_request_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "application_metadata_only": True,
+        "approval_granted": False,
+        "request_accepted": False,
         "summarizes_command_descriptors": True,
         "emits_command_descriptors": False,
         "writes_files": False,
@@ -1988,6 +2023,102 @@ def build_refactor_approval_decision(
     }
 
 
+def _application_approval_summary(decision: dict[str, Any]) -> dict[str, Any]:
+    packet = decision["packet_summary"]
+    phases = []
+    for phase in packet["validation_phases"]:
+        phases.append({
+            "command_ids": list(phase["command_ids"]),
+            "phase": phase["phase"],
+            "status": phase["status"],
+        })
+    return {
+        "approved": decision["approval_decision"]["approved"],
+        "command_descriptor_count": packet["command_descriptor_count"],
+        "decision_state": decision["decision_state"],
+        "kind": decision["kind"],
+        "reason": decision["approval_decision"]["reason"],
+        "review_state": packet["review_state"],
+        "validation_phases": phases,
+        "validation_state": packet["validation_state"],
+    }
+
+
+def build_refactor_application_request(
+    source: str,
+    path: Path,
+    action: str,
+    module_name: str,
+    *,
+    new_name: str | None = None,
+    port_name: str | None = None,
+    direction: str | None = None,
+    width: str | None = None,
+    destination: str | None = None,
+) -> dict[str, Any]:
+    decision = build_refactor_approval_decision(
+        source,
+        path,
+        action,
+        module_name,
+        new_name=new_name,
+        port_name=port_name,
+        direction=direction,
+        width=width,
+        destination=destination,
+    )
+    preflight = decision["preflight"]
+    approval = decision["approval_decision"]
+    application_state = (
+        "blocked"
+        if preflight["status"] == "blocked"
+        else "not-accepted"
+    )
+    reason = (
+        "preflight blocked"
+        if preflight["status"] == "blocked"
+        else "approval not granted"
+    )
+
+    return {
+        "action": action,
+        "application_request": {
+            "accepted": False,
+            "applied": False,
+            "decision": application_state,
+            "reason": reason,
+            "required_approval_decision": approval["decision"],
+            "requires_explicit_user_approval_before_run": True,
+            "requires_explicit_user_approval_before_write": True,
+            "result": "not_applied",
+        },
+        "application_state": application_state,
+        "approval_summary": _application_approval_summary(decision),
+        "kind": "module-refactor-application-request",
+        "limitations": list(APPLICATION_REQUEST_LIMITATIONS),
+        "module": decision["module"],
+        "preflight": {
+            "reasons": list(preflight["reasons"]),
+            "requires_approval_before_write": preflight[
+                "requires_approval_before_write"
+            ],
+            "requires_explicit_approval_before_run": True,
+            "status": preflight["status"],
+        },
+        "proposal_summary": {
+            "planned_step_count": decision["proposal_summary"]["planned_step_count"],
+            "requested_change": decision["proposal_summary"]["requested_change"],
+            "writes_files": decision["proposal_summary"]["writes_files"],
+        },
+        "safety": _application_request_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "target": module_name,
+        "tool": "pccx-ide-cli",
+        "writes_files": False,
+    }
+
+
 def format_refactor_proposal_text(proposal: dict[str, Any]) -> str:
     lines = [
         f"source: {proposal['source']}",
@@ -2110,6 +2241,40 @@ def format_refactor_approval_decision_text(decision: dict[str, Any]) -> str:
     lines.append(f"reason: {approval['reason']}")
     lines.append(
         "decision metadata only: no command argv, validation, shell, "
+        "refactor, patch, file write, lab, launcher, vendor tool, provider, "
+        "or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_refactor_application_request_text(request: dict[str, Any]) -> str:
+    application = request["application_request"]
+    approval = request["approval_summary"]
+    lines = [
+        f"source: {request['source']}",
+        f"target: {request['target']}",
+        f"action: {request['action']}",
+        f"application request: {application['decision']}",
+        "accepted: no",
+        "applied: no",
+        f"approval decision: {approval['decision_state']}",
+        f"review state: {approval['review_state']}",
+        f"preflight: {request['preflight']['status']}",
+        "writes files: no",
+        "runs validation: no",
+        f"validation descriptors: {approval['command_descriptor_count']}",
+    ]
+    for phase in approval["validation_phases"]:
+        command_ids = ", ".join(phase["command_ids"]) or "none"
+        lines.append(
+            f"validation phase: {phase['phase']} "
+            f"({phase['status']}): {command_ids}"
+        )
+    for reason in request["preflight"]["reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"reason: {application['reason']}")
+    lines.append(
+        "application metadata only: no command argv, validation, shell, "
         "refactor, patch, file write, lab, launcher, vendor tool, provider, "
         "or hardware execution"
     )

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -25,11 +25,13 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_port_usage_view,
     build_module_summary_view,
     build_refactor_approval_decision,
+    build_refactor_application_request,
     build_refactor_impact_view,
     build_refactor_proposal,
     build_refactor_review_packet,
     build_refactor_validation_plan,
     format_refactor_approval_decision_text,
+    format_refactor_application_request_text,
     format_module_dependency_text,
     format_module_context_text,
     format_module_hierarchy_text,
@@ -624,6 +626,72 @@ def test_build_refactor_approval_decision_reports_blocked_preflight():
     assert phases["post-change-local-validation"]["command_ids"] == []
 
 
+def test_build_refactor_application_request_records_not_accepted_gate():
+    request = build_refactor_application_request(
+        str(FIXTURE),
+        FIXTURE,
+        "rename-module",
+        "leaf_mod",
+        new_name="leaf_mod_next",
+    )
+
+    assert request["kind"] == "module-refactor-application-request"
+    assert request["application_state"] == "not-accepted"
+    assert request["application_request"]["accepted"] is False
+    assert request["application_request"]["applied"] is False
+    assert request["application_request"]["result"] == "not_applied"
+    assert request["application_request"]["reason"] == "approval not granted"
+    assert request["application_request"]["required_approval_decision"] == (
+        "not-approved"
+    )
+    assert request["preflight"]["status"] == "ready-for-review"
+    assert request["writes_files"] is False
+    assert request["approval_summary"]["kind"] == "module-refactor-approval-decision"
+    assert request["approval_summary"]["approved"] is False
+    assert request["approval_summary"]["decision_state"] == "not-approved"
+    assert request["approval_summary"]["review_state"] == "ready-for-review"
+    assert request["approval_summary"]["command_descriptor_count"] == 8
+    assert request["proposal_summary"]["requested_change"]["new_name"] == (
+        "leaf_mod_next"
+    )
+    assert request["safety"]["read_only"] is True
+    assert request["safety"]["application_metadata_only"] is True
+    assert request["safety"]["request_accepted"] is False
+    assert request["safety"]["approval_granted"] is False
+    assert request["safety"]["summarizes_command_descriptors"] is True
+    assert request["safety"]["emits_command_descriptors"] is False
+    assert request["safety"]["writes_files"] is False
+    assert request["safety"]["applies_refactor"] is False
+    assert request["safety"]["runs_validation"] is False
+    assert request["safety"]["runs_shell"] is False
+    assert request["safety"]["invokes_pccx_lab"] is False
+    assert request["safety"]["invokes_launcher"] is False
+    assert request["safety"]["hardware_access"] is False
+    assert '"argv"' not in json.dumps(request)
+
+
+def test_build_refactor_application_request_reports_blocked_preflight():
+    request = build_refactor_application_request(
+        str(FIXTURE),
+        FIXTURE,
+        "extract-port",
+        "top_mod",
+        port_name="valid_i",
+    )
+
+    assert request["application_state"] == "blocked"
+    assert request["application_request"]["accepted"] is False
+    assert request["application_request"]["applied"] is False
+    assert request["application_request"]["reason"] == "preflight blocked"
+    assert "missing required direction" in request["preflight"]["reasons"]
+    phases = {
+        phase["phase"]: phase
+        for phase in request["approval_summary"]["validation_phases"]
+    }
+    assert phases["post-change-local-validation"]["status"] == "blocked"
+    assert phases["post-change-local-validation"]["command_ids"] == []
+
+
 def test_format_module_organization_text_mentions_boundary_and_hierarchy():
     export = build_module_organization_export(str(FIXTURE), FIXTURE)
     text = format_module_organization_text(export)
@@ -776,6 +844,27 @@ def test_format_refactor_approval_decision_text_mentions_unapproved_boundary():
     assert "writes files: no" in text
     assert "runs validation: no" in text
     assert "decision metadata only: no command argv" in text
+
+
+def test_format_refactor_application_request_text_mentions_not_applied_boundary():
+    request = build_refactor_application_request(
+        str(FIXTURE),
+        FIXTURE,
+        "move-module",
+        "leaf_mod",
+        destination="rtl/leaf_mod.sv",
+    )
+    text = format_refactor_application_request_text(request)
+
+    assert "application request: not-accepted" in text
+    assert "accepted: no" in text
+    assert "applied: no" in text
+    assert "approval decision: not-approved" in text
+    assert "review state: ready-for-review" in text
+    assert "validation descriptors:" in text
+    assert "writes files: no" in text
+    assert "runs validation: no" in text
+    assert "application metadata only: no command argv" in text
 
 
 def test_cli_organization_json():
@@ -1114,6 +1203,53 @@ def test_cli_refactor_approval_text():
     assert "decision metadata only: no command argv" in result.stdout
 
 
+def test_cli_refactor_application_json():
+    result = _run_cli(
+        "refactor-application",
+        str(FIXTURE),
+        "--action",
+        "rename-module",
+        "--module",
+        "leaf_mod",
+        "--new-name",
+        "leaf_mod_next",
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-refactor-application-request"
+    assert payload["application_state"] == "not-accepted"
+    assert payload["application_request"]["accepted"] is False
+    assert payload["application_request"]["applied"] is False
+    assert payload["approval_summary"]["decision_state"] == "not-approved"
+    assert payload["approval_summary"]["command_descriptor_count"] == 8
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_refactor_application_text():
+    result = _run_cli(
+        "refactor-application",
+        str(FIXTURE),
+        "--action",
+        "extract-port",
+        "--module",
+        "top_mod",
+        "--port-name",
+        "valid_i",
+        "--format",
+        "text",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "application request: blocked" in result.stdout
+    assert "accepted: no" in result.stdout
+    assert "applied: no" in result.stdout
+    assert "blocked: missing required direction" in result.stdout
+    assert "application metadata only: no command argv" in result.stdout
+
+
 def test_cli_organization_missing_path_exits_nonzero():
     result = _run_cli("organization", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
@@ -1216,6 +1352,21 @@ def test_cli_refactor_approval_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_refactor_application_missing_path_exits_nonzero():
+    result = _run_cli(
+        "refactor-application",
+        str(FIXTURE.parent / "missing.sv"),
+        "--action",
+        "rename-module",
+        "--module",
+        "leaf_mod",
+        "--new-name",
+        "leaf_mod_next",
+    )
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_docs_cover_organization_flow_and_limits():
     contract = CONTRACT_DOC.read_text(encoding="utf-8")
     workflow = WORKFLOW_DOC.read_text(encoding="utf-8")
@@ -1229,6 +1380,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "validation-plan <path>" in contract
     assert "refactor-review <path>" in contract
     assert "refactor-approval <path>" in contract
+    assert "refactor-application <path>" in contract
     assert "MODULE_ORGANIZATION_WORKFLOW.md" in contract
     assert "proposal-only" in workflow
     assert "module-hierarchy-view" in workflow
@@ -1240,8 +1392,10 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-refactor-validation-plan" in workflow
     assert "module-refactor-review-packet" in workflow
     assert "module-refactor-approval-decision" in workflow
+    assert "module-refactor-application-request" in workflow
     assert "proposed-not-run" in workflow
     assert "summary-only review packet" in workflow
     assert "approval decision metadata" in workflow
+    assert "application request metadata" in workflow
     assert "does not write files" in workflow
     assert "not a full SystemVerilog parser" in workflow


### PR DESCRIPTION
## Summary
- add a proposal-only `refactor-application` CLI surface for a post-approval application request gate
- record `accepted: false`, `applied: false`, and `not_applied` metadata while summarizing the approval decision without command argv
- document the pre-stable boundary and add unit/CLI/smoke coverage

Refs #8

## Validation
- `PYTHONPATH=src pytest -q tests/test_module_organization.py`
- `PYTHONPATH=src pytest -q`
- `python3 -m py_compile $(find src tests scripts -name '*.py' -print | sort)`
- `bash -n scripts/check-editor-bridge-examples.sh scripts/editor-bridge-smoke.sh scripts/vscode-adapter-smoke.sh scripts/vscode-extension-host-smoke.sh`
- `python3 scripts/check-source-headers.py`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- local claim-scan pattern from CI
- `PYTHONPATH=src python3 -m pccx_ide_cli refactor-application fixtures/organization/hierarchy_top.sv --action rename-module --module leaf_mod --new-name leaf_mod_next --format json | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d["kind"]=="module-refactor-application-request"; assert d["application_request"]["accepted"] is False; assert d["application_request"]["applied"] is False; assert d["safety"]["writes_files"] is False'`
- `PYTHONPATH=src python3 -m pccx_ide_cli refactor-application fixtures/organization/hierarchy_top.sv --action extract-port --module top_mod --port-name valid_i --format text | grep -q 'application request: blocked'`
- `git diff --check && git diff --cached --check`
