### PR TITLE
Add refactor application result boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ python -m pccx_ide_cli refactor-impact fixtures/organization/hierarchy_top.sv --
 # Refactoring proposal export (pre-stable, proposal-only)
 python -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 python -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action extract-port --module top_mod --port-name valid_i --direction input --format text
+python -m pccx_ide_cli validation-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
+python -m pccx_ide_cli refactor-review fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
+python -m pccx_ide_cli refactor-approval fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
+python -m pccx_ide_cli refactor-application fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
+python -m pccx_ide_cli refactor-result fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 
 # xsim log handoff scaffold (parses existing log files only)
 python -m pccx_ide_cli xsim-log fixtures/xsim/mixed.log --format json
@@ -220,6 +225,13 @@ It records requested inputs, a bounded preflight status, and planned
 review steps, but it does not write files, apply patches, run validation,
 invoke `pccx-lab` or the launcher, call providers, touch hardware, or
 perform automatic repository actions.
+`validation-plan`, `refactor-review`, `refactor-approval`,
+`refactor-application`, and `refactor-result` extend that reviewed flow with
+proposal-only validation descriptors, summary-only review data, unapproved
+approval gates, not-accepted application request metadata, and not-applied
+result receipts. They do not execute validation, run shell commands, apply
+edits, generate patches, write files, invoke `pccx-lab` or the launcher, call
+providers, touch hardware, or perform automatic repository actions.
 
 `xsim-log` is an early handoff scaffold. It parses existing synthetic
 xsim-style log files into diagnostics-like JSON or text output. It does

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -55,6 +55,7 @@ python -m pccx_ide_cli validation-plan <path> --action rename-module --module <n
 python -m pccx_ide_cli refactor-review <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli refactor-approval <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli refactor-application <path> --action rename-module --module <name> --new-name <name> --format json
+python -m pccx_ide_cli refactor-result <path> --action rename-module --module <name> --new-name <name> --format json
 
 # Opt-in pccx-lab diagnostics backend
 python -m pccx_ide_cli check <sv-file> --backend pccx-lab --format json
@@ -229,6 +230,13 @@ with `accepted: false` and `applied: false`; it does not include command argv,
 accept a write request, apply edits, execute validation, run shell commands,
 write files, invoke pccx-lab or the launcher, run vendor tools, call providers,
 touch hardware, or perform automatic repository actions.
+`refactor-result` emits proposal-only application result metadata over the
+application request. It records a not-applied or blocked result receipt with no
+write attempt, no generated patch, no changed files, no validation run, and no
+rollback requirement; it does not include command argv, accept a write request,
+apply edits, execute validation, run shell commands, write files, invoke
+pccx-lab or the launcher, run vendor tools, call providers, touch hardware, or
+perform automatic repository actions.
 
 For existing xsim logs, the VS Code prototype can consume the checked
 `problems from-xsim-log` JSON as a read-only status/context summary.  The
@@ -247,9 +255,10 @@ xsim path, and text surface sketches is documented in
 - Scanner-based scaffolds, not full SystemVerilog parsing.
 - Module organization, header/port summaries, port usage summaries,
   refactor impact review, refactor planning, and validation planning are
-  scanner-based; refactor review packets, approval decisions, and application
-  requests are summary-only metadata over those surfaces. They are not semantic
-  elaboration and do not apply refactors or execute validation.
+  scanner-based; refactor review packets, approval decisions, application
+  requests, and application results are summary-only metadata over those
+  surfaces. They are not semantic elaboration and do not apply refactors or
+  execute validation.
 - No LSP server in this repository today.
 - No published editor extension or marketplace packaging is implemented
   here.

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -6,13 +6,14 @@ This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
 `module-summary`, `port-usage`, `module-context`, `refactor-impact`,
 `validation-plan`, `refactor-review`, `refactor-approval`, and
-`refactor-application` CLI surfaces
+`refactor-application`, and `refactor-result` CLI surfaces
 that report module boundary spans, scanner-based hierarchy data, direct
 dependency impact data, conservative module header/port summaries, target port
 usage summaries, target module context bundles, target-specific refactor impact
 data, proposal-only validation command descriptors, a summary-only review
-packet, approval decision metadata, and application request metadata for editor
-navigation and reviewed refactoring planning.
+packet, approval decision metadata, application request metadata, and
+application result metadata for editor navigation and reviewed refactoring
+planning.
 
 It is not a full SystemVerilog parser, not semantic elaboration, not an LSP
 implementation, and not a write-capable refactoring engine.
@@ -49,6 +50,9 @@ python -m pccx_ide_cli refactor-approval <path> --action move-module --module <n
 python -m pccx_ide_cli refactor-application <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli refactor-application <path> --action extract-port --module <name> --port-name <name> --direction input --format text
 python -m pccx_ide_cli refactor-application <path> --action move-module --module <name> --destination rtl/<name>.sv --format json
+python -m pccx_ide_cli refactor-result <path> --action rename-module --module <name> --new-name <name> --format json
+python -m pccx_ide_cli refactor-result <path> --action extract-port --module <name> --port-name <name> --direction input --format text
+python -m pccx_ide_cli refactor-result <path> --action move-module --module <name> --destination rtl/<name>.sv --format json
 ```
 
 `<path>` may be a `.sv` / `.v` file or a directory. Directory scans follow the
@@ -734,6 +738,77 @@ launcher, run vendor tools, call providers, touch hardware, upload telemetry,
 accept an application request, apply a refactor, grant approval, or perform
 automatic repository actions.
 
+## Refactor Application Result
+
+`refactor-result` adds proposal-only application result metadata over the
+existing `refactor-application` request. It is a one-call receipt for editor
+review panes and maintainer handoff notes to show that the request did not
+attempt a write, did not generate a patch, did not change files, did not run
+validation, and does not require rollback.
+
+Example shape:
+
+```json
+{
+  "kind": "module-refactor-application-result",
+  "result_state": "not-applied",
+  "action": "rename-module",
+  "writes_files": false,
+  "application_result": {
+    "result": "not_applied",
+    "result_state": "not-applied",
+    "write_attempted": false,
+    "patch_generated": false,
+    "files_changed": [],
+    "file_change_count": 0,
+    "validation_run": false,
+    "validation_result": "not_run",
+    "rollback_required": false,
+    "rollback_performed": false,
+    "reason": "application request not accepted"
+  },
+  "application_summary": {
+    "kind": "module-refactor-application-request",
+    "application_state": "not-accepted",
+    "accepted": false,
+    "applied": false,
+    "approval_decision_state": "not-approved",
+    "validation_state": "proposal-only",
+    "command_descriptor_count": 8,
+    "validation_phases": []
+  },
+  "safety": {
+    "read_only": true,
+    "application_result_metadata_only": true,
+    "approval_granted": false,
+    "request_accepted": false,
+    "write_attempted": false,
+    "summarizes_command_descriptors": true,
+    "emits_command_descriptors": false,
+    "writes_files": false,
+    "generates_patch": false,
+    "runs_validation": false,
+    "runs_shell": false,
+    "rollback_required": false,
+    "invokes_pccx_lab": false,
+    "invokes_launcher": false,
+    "hardware_access": false
+  }
+}
+```
+
+The result intentionally records `write_attempted: false`,
+`patch_generated: false`, and an empty `files_changed` list. It summarizes the
+application request and validation descriptor phases by command ID only and
+does not include command argv; consumers that need the fixed-argv descriptor
+list should call `validation-plan` directly.
+
+This boundary does not write files, apply refactors, move files, generate
+patches, run validation, execute shell commands, invoke `pccx-lab`, invoke the
+launcher, run vendor tools, call providers, touch hardware, upload telemetry,
+accept an application request, apply a refactor, perform rollback, grant
+approval, or perform automatic repository actions.
+
 ## Limitations
 
 - Scanner-based module declarations and `endmodule` matching only.
@@ -752,4 +827,4 @@ direct dependency view, conservative module header/port summaries,
 target-specific port usage summaries, target-specific module context
 bundles, target-specific refactor impact review data, and a
 proposal-only refactoring, validation planning, review packet, approval
-decision, and application request boundary.
+decision, application request, and application result boundary.

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -40,6 +40,7 @@ run_json module-refactor-validation-plan validation-plan fixtures/organization/h
 run_json module-refactor-review-packet refactor-review fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 run_json module-refactor-approval-decision refactor-approval fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 run_json module-refactor-application-request refactor-application fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
+run_json module-refactor-application-result refactor-result fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 
 bash scripts/check-editor-bridge-examples.sh
 

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -541,6 +541,62 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    refactor_result_cmd = sub.add_parser(
+        "refactor-result",
+        help=(
+            "Emit proposal-only application result metadata for a "
+            "refactor application request."
+        ),
+    )
+    refactor_result_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    refactor_result_cmd.add_argument(
+        "--action",
+        choices=("rename-module", "extract-port", "move-module"),
+        required=True,
+        help="Refactor proposal kind to summarize as a result.",
+    )
+    refactor_result_cmd.add_argument(
+        "--module",
+        required=True,
+        help="Exact module name to use as the result target.",
+    )
+    refactor_result_cmd.add_argument(
+        "--new-name",
+        default=None,
+        help="New module name for rename-module application results.",
+    )
+    refactor_result_cmd.add_argument(
+        "--port-name",
+        default=None,
+        help="Port name for extract-port application results.",
+    )
+    refactor_result_cmd.add_argument(
+        "--direction",
+        choices=("input", "output", "inout"),
+        default=None,
+        help="Port direction for extract-port application results.",
+    )
+    refactor_result_cmd.add_argument(
+        "--width",
+        default=None,
+        help="Optional port width text for extract-port application results.",
+    )
+    refactor_result_cmd.add_argument(
+        "--destination",
+        default=None,
+        help="Relative destination path for move-module application results.",
+    )
+    refactor_result_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     xsim_log = sub.add_parser(
         "xsim-log",
         help="Parse an existing xsim-style log file into diagnostics-like output.",
@@ -1019,6 +1075,34 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_refactor_application_request_text(request))
+        return 0
+
+    if args.command == "refactor-result":
+        from .module_organization import (
+            build_refactor_application_result,
+            format_refactor_application_result_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        result = build_refactor_application_result(
+            str(args.path),
+            args.path,
+            args.action,
+            args.module,
+            new_name=args.new_name,
+            port_name=args.port_name,
+            direction=args.direction,
+            width=args.width,
+            destination=args.destination,
+        )
+        if args.format == "json":
+            json.dump(result, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_refactor_application_result_text(result))
         return 0
 
     if args.command == "xsim-log":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -192,6 +192,17 @@ APPLICATION_REQUEST_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+APPLICATION_RESULT_LIMITATIONS: tuple[str, ...] = (
+    "proposal-only refactor application result metadata",
+    "records a not-applied result receipt over the application request",
+    "does not include command argv; use validation-plan for command descriptors",
+    "does not execute validation commands or shell commands",
+    "does not apply refactors, write files, move files, generate patches, "
+    "or roll back files",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 _REFACTOR_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
     "rename-module": ("new_name",),
     "extract-port": ("port_name", "direction"),
@@ -403,6 +414,33 @@ def _application_request_safety_flags() -> dict[str, bool]:
         "generates_patch": False,
         "runs_validation": False,
         "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _application_result_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "application_result_metadata_only": True,
+        "approval_granted": False,
+        "request_accepted": False,
+        "write_attempted": False,
+        "summarizes_command_descriptors": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "rollback_required": False,
         "invokes_pccx_lab": False,
         "invokes_launcher": False,
         "invokes_vendor_tools": False,
@@ -2119,6 +2157,115 @@ def build_refactor_application_request(
     }
 
 
+def _result_application_summary(request: dict[str, Any]) -> dict[str, Any]:
+    approval = request["approval_summary"]
+    phases = []
+    for phase in approval["validation_phases"]:
+        phases.append({
+            "command_ids": list(phase["command_ids"]),
+            "phase": phase["phase"],
+            "status": phase["status"],
+        })
+    return {
+        "accepted": request["application_request"]["accepted"],
+        "application_state": request["application_state"],
+        "applied": request["application_request"]["applied"],
+        "approval_decision_state": approval["decision_state"],
+        "approval_granted": approval["approved"],
+        "command_descriptor_count": approval["command_descriptor_count"],
+        "decision": request["application_request"]["decision"],
+        "kind": request["kind"],
+        "reason": request["application_request"]["reason"],
+        "required_approval_decision": request["application_request"][
+            "required_approval_decision"
+        ],
+        "review_state": approval["review_state"],
+        "validation_phases": phases,
+        "validation_state": approval["validation_state"],
+    }
+
+
+def build_refactor_application_result(
+    source: str,
+    path: Path,
+    action: str,
+    module_name: str,
+    *,
+    new_name: str | None = None,
+    port_name: str | None = None,
+    direction: str | None = None,
+    width: str | None = None,
+    destination: str | None = None,
+) -> dict[str, Any]:
+    request = build_refactor_application_request(
+        source,
+        path,
+        action,
+        module_name,
+        new_name=new_name,
+        port_name=port_name,
+        direction=direction,
+        width=width,
+        destination=destination,
+    )
+    preflight = request["preflight"]
+    result_state = (
+        "blocked"
+        if preflight["status"] == "blocked"
+        else "not-applied"
+    )
+    reason = (
+        "preflight blocked"
+        if preflight["status"] == "blocked"
+        else "application request not accepted"
+    )
+
+    return {
+        "action": action,
+        "application_result": {
+            "applied": False,
+            "file_change_count": 0,
+            "files_changed": [],
+            "patch_generated": False,
+            "reason": reason,
+            "result": "not_applied",
+            "result_state": result_state,
+            "rollback_performed": False,
+            "rollback_required": False,
+            "source_application_state": request["application_state"],
+            "validation_result": "not_run",
+            "validation_run": False,
+            "write_attempted": False,
+        },
+        "application_summary": _result_application_summary(request),
+        "kind": "module-refactor-application-result",
+        "limitations": list(APPLICATION_RESULT_LIMITATIONS),
+        "module": request["module"],
+        "preflight": {
+            "reasons": list(preflight["reasons"]),
+            "requires_approval_before_write": preflight[
+                "requires_approval_before_write"
+            ],
+            "requires_explicit_approval_before_run": True,
+            "status": preflight["status"],
+        },
+        "proposal_summary": {
+            "planned_step_count": request["proposal_summary"][
+                "planned_step_count"
+            ],
+            "requested_change": request["proposal_summary"]["requested_change"],
+            "writes_files": request["proposal_summary"]["writes_files"],
+        },
+        "result_state": result_state,
+        "safety": _application_result_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "target": module_name,
+        "tool": "pccx-ide-cli",
+        "writes_files": False,
+    }
+
+
 def format_refactor_proposal_text(proposal: dict[str, Any]) -> str:
     lines = [
         f"source: {proposal['source']}",
@@ -2277,6 +2424,47 @@ def format_refactor_application_request_text(request: dict[str, Any]) -> str:
         "application metadata only: no command argv, validation, shell, "
         "refactor, patch, file write, lab, launcher, vendor tool, provider, "
         "or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_refactor_application_result_text(result: dict[str, Any]) -> str:
+    application_result = result["application_result"]
+    application = result["application_summary"]
+    lines = [
+        f"source: {result['source']}",
+        f"target: {result['target']}",
+        f"action: {result['action']}",
+        f"application result: {application_result['result_state']}",
+        f"result: {application_result['result']}",
+        f"application request: {application['application_state']}",
+        "accepted: no",
+        "applied: no",
+        "write attempted: no",
+        "patch generated: no",
+        "files changed: 0",
+        "validation run: no",
+        "rollback required: no",
+        f"approval decision: {application['approval_decision_state']}",
+        f"review state: {application['review_state']}",
+        f"preflight: {result['preflight']['status']}",
+        "writes files: no",
+        "runs validation: no",
+        f"validation descriptors: {application['command_descriptor_count']}",
+    ]
+    for phase in application["validation_phases"]:
+        command_ids = ", ".join(phase["command_ids"]) or "none"
+        lines.append(
+            f"validation phase: {phase['phase']} "
+            f"({phase['status']}): {command_ids}"
+        )
+    for reason in result["preflight"]["reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"reason: {application_result['reason']}")
+    lines.append(
+        "result metadata only: no command argv, validation, shell, "
+        "refactor, patch, file write, rollback, lab, launcher, vendor tool, "
+        "provider, or hardware execution"
     )
     return "\n".join(lines) + "\n"
 

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -25,12 +25,14 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_port_usage_view,
     build_module_summary_view,
     build_refactor_approval_decision,
+    build_refactor_application_result,
     build_refactor_application_request,
     build_refactor_impact_view,
     build_refactor_proposal,
     build_refactor_review_packet,
     build_refactor_validation_plan,
     format_refactor_approval_decision_text,
+    format_refactor_application_result_text,
     format_refactor_application_request_text,
     format_module_dependency_text,
     format_module_context_text,
@@ -692,6 +694,82 @@ def test_build_refactor_application_request_reports_blocked_preflight():
     assert phases["post-change-local-validation"]["command_ids"] == []
 
 
+def test_build_refactor_application_result_records_not_applied_receipt():
+    result = build_refactor_application_result(
+        str(FIXTURE),
+        FIXTURE,
+        "rename-module",
+        "leaf_mod",
+        new_name="leaf_mod_next",
+    )
+
+    assert result["kind"] == "module-refactor-application-result"
+    assert result["result_state"] == "not-applied"
+    assert result["application_result"]["result"] == "not_applied"
+    assert result["application_result"]["write_attempted"] is False
+    assert result["application_result"]["patch_generated"] is False
+    assert result["application_result"]["files_changed"] == []
+    assert result["application_result"]["file_change_count"] == 0
+    assert result["application_result"]["validation_run"] is False
+    assert result["application_result"]["validation_result"] == "not_run"
+    assert result["application_result"]["rollback_required"] is False
+    assert result["application_result"]["rollback_performed"] is False
+    assert result["preflight"]["status"] == "ready-for-review"
+    assert result["writes_files"] is False
+    assert result["application_summary"]["kind"] == (
+        "module-refactor-application-request"
+    )
+    assert result["application_summary"]["application_state"] == "not-accepted"
+    assert result["application_summary"]["accepted"] is False
+    assert result["application_summary"]["applied"] is False
+    assert result["application_summary"]["approval_decision_state"] == (
+        "not-approved"
+    )
+    assert result["application_summary"]["command_descriptor_count"] == 8
+    assert result["proposal_summary"]["requested_change"]["new_name"] == (
+        "leaf_mod_next"
+    )
+    assert result["safety"]["read_only"] is True
+    assert result["safety"]["application_result_metadata_only"] is True
+    assert result["safety"]["write_attempted"] is False
+    assert result["safety"]["request_accepted"] is False
+    assert result["safety"]["approval_granted"] is False
+    assert result["safety"]["summarizes_command_descriptors"] is True
+    assert result["safety"]["emits_command_descriptors"] is False
+    assert result["safety"]["writes_files"] is False
+    assert result["safety"]["generates_patch"] is False
+    assert result["safety"]["applies_refactor"] is False
+    assert result["safety"]["runs_validation"] is False
+    assert result["safety"]["rollback_required"] is False
+    assert result["safety"]["runs_shell"] is False
+    assert result["safety"]["invokes_pccx_lab"] is False
+    assert result["safety"]["invokes_launcher"] is False
+    assert result["safety"]["hardware_access"] is False
+    assert '"argv"' not in json.dumps(result)
+
+
+def test_build_refactor_application_result_reports_blocked_preflight():
+    result = build_refactor_application_result(
+        str(FIXTURE),
+        FIXTURE,
+        "extract-port",
+        "top_mod",
+        port_name="valid_i",
+    )
+
+    assert result["result_state"] == "blocked"
+    assert result["application_result"]["result"] == "not_applied"
+    assert result["application_result"]["reason"] == "preflight blocked"
+    assert result["application_result"]["write_attempted"] is False
+    assert "missing required direction" in result["preflight"]["reasons"]
+    phases = {
+        phase["phase"]: phase
+        for phase in result["application_summary"]["validation_phases"]
+    }
+    assert phases["post-change-local-validation"]["status"] == "blocked"
+    assert phases["post-change-local-validation"]["command_ids"] == []
+
+
 def test_format_module_organization_text_mentions_boundary_and_hierarchy():
     export = build_module_organization_export(str(FIXTURE), FIXTURE)
     text = format_module_organization_text(export)
@@ -865,6 +943,30 @@ def test_format_refactor_application_request_text_mentions_not_applied_boundary(
     assert "writes files: no" in text
     assert "runs validation: no" in text
     assert "application metadata only: no command argv" in text
+
+
+def test_format_refactor_application_result_text_mentions_result_receipt():
+    result = build_refactor_application_result(
+        str(FIXTURE),
+        FIXTURE,
+        "move-module",
+        "leaf_mod",
+        destination="rtl/leaf_mod.sv",
+    )
+    text = format_refactor_application_result_text(result)
+
+    assert "application result: not-applied" in text
+    assert "result: not_applied" in text
+    assert "application request: not-accepted" in text
+    assert "write attempted: no" in text
+    assert "patch generated: no" in text
+    assert "files changed: 0" in text
+    assert "validation run: no" in text
+    assert "rollback required: no" in text
+    assert "approval decision: not-approved" in text
+    assert "writes files: no" in text
+    assert "runs validation: no" in text
+    assert "result metadata only: no command argv" in text
 
 
 def test_cli_organization_json():
@@ -1250,6 +1352,61 @@ def test_cli_refactor_application_text():
     assert "application metadata only: no command argv" in result.stdout
 
 
+def test_cli_refactor_result_json():
+    result = _run_cli(
+        "refactor-result",
+        str(FIXTURE),
+        "--action",
+        "rename-module",
+        "--module",
+        "leaf_mod",
+        "--new-name",
+        "leaf_mod_next",
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-refactor-application-result"
+    assert payload["result_state"] == "not-applied"
+    assert payload["application_result"]["result"] == "not_applied"
+    assert payload["application_result"]["write_attempted"] is False
+    assert payload["application_result"]["patch_generated"] is False
+    assert payload["application_result"]["files_changed"] == []
+    assert payload["application_result"]["validation_run"] is False
+    assert payload["application_result"]["rollback_required"] is False
+    assert payload["application_summary"]["application_state"] == "not-accepted"
+    assert payload["application_summary"]["command_descriptor_count"] == 8
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["generates_patch"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_refactor_result_text():
+    result = _run_cli(
+        "refactor-result",
+        str(FIXTURE),
+        "--action",
+        "extract-port",
+        "--module",
+        "top_mod",
+        "--port-name",
+        "valid_i",
+        "--format",
+        "text",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "application result: blocked" in result.stdout
+    assert "write attempted: no" in result.stdout
+    assert "patch generated: no" in result.stdout
+    assert "files changed: 0" in result.stdout
+    assert "validation run: no" in result.stdout
+    assert "rollback required: no" in result.stdout
+    assert "blocked: missing required direction" in result.stdout
+    assert "result metadata only: no command argv" in result.stdout
+
+
 def test_cli_organization_missing_path_exits_nonzero():
     result = _run_cli("organization", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
@@ -1367,6 +1524,21 @@ def test_cli_refactor_application_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_refactor_result_missing_path_exits_nonzero():
+    result = _run_cli(
+        "refactor-result",
+        str(FIXTURE.parent / "missing.sv"),
+        "--action",
+        "rename-module",
+        "--module",
+        "leaf_mod",
+        "--new-name",
+        "leaf_mod_next",
+    )
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_docs_cover_organization_flow_and_limits():
     contract = CONTRACT_DOC.read_text(encoding="utf-8")
     workflow = WORKFLOW_DOC.read_text(encoding="utf-8")
@@ -1381,6 +1553,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "refactor-review <path>" in contract
     assert "refactor-approval <path>" in contract
     assert "refactor-application <path>" in contract
+    assert "refactor-result <path>" in contract
     assert "MODULE_ORGANIZATION_WORKFLOW.md" in contract
     assert "proposal-only" in workflow
     assert "module-hierarchy-view" in workflow
@@ -1393,9 +1566,11 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-refactor-review-packet" in workflow
     assert "module-refactor-approval-decision" in workflow
     assert "module-refactor-application-request" in workflow
+    assert "module-refactor-application-result" in workflow
     assert "proposed-not-run" in workflow
     assert "summary-only review packet" in workflow
     assert "approval decision metadata" in workflow
     assert "application request metadata" in workflow
+    assert "application result metadata" in workflow
     assert "does not write files" in workflow
     assert "not a full SystemVerilog parser" in workflow


### PR DESCRIPTION
## Summary
- add a proposal-only refactor-result CLI boundary over refactor-application
- record not-applied result metadata with no write attempt, patch generation, changed files, validation run, rollback, lab, launcher, provider, or hardware execution
- document the new boundary and extend module organization/editor bridge smoke coverage

Refs #8

## Validation
- PYTHONPATH=src pytest -q tests/test_module_organization.py
- PYTHONPATH=src pytest -q
- PYTHONPATH=src python3 -m pccx_ide_cli refactor-result fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
- PYTHONPATH=src python3 -m pccx_ide_cli refactor-result fixtures/organization/hierarchy_top.sv --action extract-port --module top_mod --port-name valid_i --format text
- python3 -m py_compile over src, tests, and scripts Python files
- bash -n scripts/check-editor-bridge-examples.sh scripts/editor-bridge-smoke.sh scripts/vscode-adapter-smoke.sh scripts/vscode-extension-host-smoke.sh
- python3 scripts/check-source-headers.py
- bash scripts/check-editor-bridge-examples.sh
- bash scripts/editor-bridge-smoke.sh
- bash scripts/vscode-adapter-smoke.sh
- local forbidden-claim scan
- git diff --check
- git diff --cached --check
