### PR TITLE
Add refactor handoff summary boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ python -m pccx_ide_cli refactor-review fixtures/organization/hierarchy_top.sv --
 python -m pccx_ide_cli refactor-approval fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 python -m pccx_ide_cli refactor-application fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 python -m pccx_ide_cli refactor-result fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
+python -m pccx_ide_cli refactor-handoff fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 
 # xsim log handoff scaffold (parses existing log files only)
 python -m pccx_ide_cli xsim-log fixtures/xsim/mixed.log --format json
@@ -226,12 +227,15 @@ review steps, but it does not write files, apply patches, run validation,
 invoke `pccx-lab` or the launcher, call providers, touch hardware, or
 perform automatic repository actions.
 `validation-plan`, `refactor-review`, `refactor-approval`,
-`refactor-application`, and `refactor-result` extend that reviewed flow with
+`refactor-application`, `refactor-result`, and `refactor-handoff` extend that
+reviewed flow with
 proposal-only validation descriptors, summary-only review data, unapproved
 approval gates, not-accepted application request metadata, and not-applied
-result receipts. They do not execute validation, run shell commands, apply
-edits, generate patches, write files, invoke `pccx-lab` or the launcher, call
-providers, touch hardware, or perform automatic repository actions.
+result receipts, plus summary-only handoff metadata. They do not execute
+validation, run shell commands, apply edits, generate patches, write files,
+publish public text, create pull requests, write comments, mutate projects,
+invoke `pccx-lab` or the launcher, call providers, touch hardware, or perform
+automatic repository actions.
 
 `xsim-log` is an early handoff scaffold. It parses existing synthetic
 xsim-style log files into diagnostics-like JSON or text output. It does

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -56,6 +56,7 @@ python -m pccx_ide_cli refactor-review <path> --action rename-module --module <n
 python -m pccx_ide_cli refactor-approval <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli refactor-application <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli refactor-result <path> --action rename-module --module <name> --new-name <name> --format json
+python -m pccx_ide_cli refactor-handoff <path> --action rename-module --module <name> --new-name <name> --format json
 
 # Opt-in pccx-lab diagnostics backend
 python -m pccx_ide_cli check <sv-file> --backend pccx-lab --format json
@@ -237,6 +238,14 @@ rollback requirement; it does not include command argv, accept a write request,
 apply edits, execute validation, run shell commands, write files, invoke
 pccx-lab or the launcher, run vendor tools, call providers, touch hardware, or
 perform automatic repository actions.
+`refactor-handoff` emits summary-only refactor handoff metadata over the
+application result receipt. It records ready-for-review or blocked handoff
+state with no public text publication, no pull request creation, no comment
+writing, no project mutation, no write attempt, no generated patch, no changed
+files, no validation run, and no rollback requirement; it does not include
+command argv, accept a write request, apply edits, execute validation, run
+shell commands, write files, invoke pccx-lab or the launcher, run vendor tools,
+call providers, touch hardware, or perform automatic repository actions.
 
 For existing xsim logs, the VS Code prototype can consume the checked
 `problems from-xsim-log` JSON as a read-only status/context summary.  The
@@ -256,7 +265,8 @@ xsim path, and text surface sketches is documented in
 - Module organization, header/port summaries, port usage summaries,
   refactor impact review, refactor planning, and validation planning are
   scanner-based; refactor review packets, approval decisions, application
-  requests, and application results are summary-only metadata over those
+  requests, application results, and handoff summaries are summary-only
+  metadata over those
   surfaces. They are not semantic elaboration and do not apply refactors or
   execute validation.
 - No LSP server in this repository today.

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -6,14 +6,14 @@ This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
 `module-summary`, `port-usage`, `module-context`, `refactor-impact`,
 `validation-plan`, `refactor-review`, `refactor-approval`, and
-`refactor-application`, and `refactor-result` CLI surfaces
+`refactor-application`, `refactor-result`, and `refactor-handoff` CLI surfaces
 that report module boundary spans, scanner-based hierarchy data, direct
 dependency impact data, conservative module header/port summaries, target port
 usage summaries, target module context bundles, target-specific refactor impact
 data, proposal-only validation command descriptors, a summary-only review
 packet, approval decision metadata, application request metadata, and
-application result metadata for editor navigation and reviewed refactoring
-planning.
+application result metadata plus refactor handoff metadata for editor
+navigation and reviewed refactoring planning.
 
 It is not a full SystemVerilog parser, not semantic elaboration, not an LSP
 implementation, and not a write-capable refactoring engine.
@@ -53,6 +53,9 @@ python -m pccx_ide_cli refactor-application <path> --action move-module --module
 python -m pccx_ide_cli refactor-result <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli refactor-result <path> --action extract-port --module <name> --port-name <name> --direction input --format text
 python -m pccx_ide_cli refactor-result <path> --action move-module --module <name> --destination rtl/<name>.sv --format json
+python -m pccx_ide_cli refactor-handoff <path> --action rename-module --module <name> --new-name <name> --format json
+python -m pccx_ide_cli refactor-handoff <path> --action extract-port --module <name> --port-name <name> --direction input --format text
+python -m pccx_ide_cli refactor-handoff <path> --action move-module --module <name> --destination rtl/<name>.sv --format json
 ```
 
 `<path>` may be a `.sv` / `.v` file or a directory. Directory scans follow the
@@ -809,6 +812,96 @@ launcher, run vendor tools, call providers, touch hardware, upload telemetry,
 accept an application request, apply a refactor, perform rollback, grant
 approval, or perform automatic repository actions.
 
+## Refactor Handoff Summary
+
+`refactor-handoff` adds summary-only refactor handoff metadata over the
+existing `refactor-result` receipt. It is intended for editor review panes and
+maintainer handoff notes that need a compact statement of what did not happen:
+no write attempt, no generated patch, no changed files, no validation run, no
+rollback requirement, no public text publication, no pull request creation, no
+comment writing, and no project mutation.
+
+Example shape:
+
+```json
+{
+  "kind": "module-refactor-handoff-summary",
+  "handoff_state": "ready-for-review",
+  "action": "rename-module",
+  "writes_files": false,
+  "handoff_summary": {
+    "state": "ready-for-review",
+    "result_state": "not-applied",
+    "result": "not_applied",
+    "recommended_next_step": "review validation plan before any approval or application",
+    "ready_for_maintainer_review": true,
+    "public_text_ready": false,
+    "pull_request_ready": false,
+    "comment_ready": false,
+    "files_changed": 0,
+    "write_attempted": false,
+    "patch_generated": false,
+    "validation_run": false,
+    "rollback_required": false
+  },
+  "application_result_summary": {
+    "kind": "module-refactor-application-result",
+    "result_state": "not-applied",
+    "application_result": "not_applied",
+    "write_attempted": false,
+    "patch_generated": false,
+    "file_change_count": 0,
+    "validation_run": false,
+    "validation_result": "not_run",
+    "rollback_required": false,
+    "approval_decision_state": "not-approved",
+    "review_state": "ready-for-review",
+    "validation_state": "proposal-only",
+    "command_descriptor_count": 8,
+    "validation_phases": []
+  },
+  "blocked_actions": [
+    "file-write",
+    "patch-generation",
+    "refactor-application",
+    "validation-run",
+    "shell-command",
+    "pull-request-create",
+    "comment-write",
+    "project-mutation"
+  ],
+  "safety": {
+    "read_only": true,
+    "handoff_summary_only": true,
+    "approval_granted": false,
+    "request_accepted": false,
+    "write_attempted": false,
+    "public_text_published": false,
+    "pull_request_created": false,
+    "comment_written": false,
+    "project_mutation": false,
+    "writes_files": false,
+    "generates_patch": false,
+    "runs_validation": false,
+    "runs_shell": false,
+    "invokes_pccx_lab": false,
+    "invokes_launcher": false,
+    "hardware_access": false
+  }
+}
+```
+
+The handoff intentionally summarizes validation descriptor phases by command ID
+only and does not include command argv; consumers that need the fixed-argv
+descriptor list should call `validation-plan` directly.
+
+This boundary does not write files, apply refactors, move files, generate
+patches, run validation, execute shell commands, invoke `pccx-lab`, invoke the
+launcher, run vendor tools, call providers, touch hardware, upload telemetry,
+publish public text, create pull requests, write comments, mutate projects,
+accept an application request, apply a refactor, perform rollback, grant
+approval, or perform automatic repository actions.
+
 ## Limitations
 
 - Scanner-based module declarations and `endmodule` matching only.
@@ -827,4 +920,5 @@ direct dependency view, conservative module header/port summaries,
 target-specific port usage summaries, target-specific module context
 bundles, target-specific refactor impact review data, and a
 proposal-only refactoring, validation planning, review packet, approval
-decision, application request, and application result boundary.
+decision, application request, application result, and handoff summary
+boundary.

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -41,6 +41,7 @@ run_json module-refactor-review-packet refactor-review fixtures/organization/hie
 run_json module-refactor-approval-decision refactor-approval fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 run_json module-refactor-application-request refactor-application fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 run_json module-refactor-application-result refactor-result fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
+run_json module-refactor-handoff-summary refactor-handoff fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 
 bash scripts/check-editor-bridge-examples.sh
 

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -597,6 +597,59 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    refactor_handoff_cmd = sub.add_parser(
+        "refactor-handoff",
+        help="Emit summary-only handoff metadata for a refactor result.",
+    )
+    refactor_handoff_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    refactor_handoff_cmd.add_argument(
+        "--action",
+        choices=("rename-module", "extract-port", "move-module"),
+        required=True,
+        help="Refactor proposal kind to summarize for handoff.",
+    )
+    refactor_handoff_cmd.add_argument(
+        "--module",
+        required=True,
+        help="Exact module name to use as the handoff target.",
+    )
+    refactor_handoff_cmd.add_argument(
+        "--new-name",
+        default=None,
+        help="New module name for rename-module handoff summaries.",
+    )
+    refactor_handoff_cmd.add_argument(
+        "--port-name",
+        default=None,
+        help="Port name for extract-port handoff summaries.",
+    )
+    refactor_handoff_cmd.add_argument(
+        "--direction",
+        choices=("input", "output", "inout"),
+        default=None,
+        help="Port direction for extract-port handoff summaries.",
+    )
+    refactor_handoff_cmd.add_argument(
+        "--width",
+        default=None,
+        help="Optional port width text for extract-port handoff summaries.",
+    )
+    refactor_handoff_cmd.add_argument(
+        "--destination",
+        default=None,
+        help="Relative destination path for move-module handoff summaries.",
+    )
+    refactor_handoff_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     xsim_log = sub.add_parser(
         "xsim-log",
         help="Parse an existing xsim-style log file into diagnostics-like output.",
@@ -1103,6 +1156,34 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_refactor_application_result_text(result))
+        return 0
+
+    if args.command == "refactor-handoff":
+        from .module_organization import (
+            build_refactor_handoff_summary,
+            format_refactor_handoff_summary_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        summary = build_refactor_handoff_summary(
+            str(args.path),
+            args.path,
+            args.action,
+            args.module,
+            new_name=args.new_name,
+            port_name=args.port_name,
+            direction=args.direction,
+            width=args.width,
+            destination=args.destination,
+        )
+        if args.format == "json":
+            json.dump(summary, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_refactor_handoff_summary_text(summary))
         return 0
 
     if args.command == "xsim-log":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -203,6 +203,18 @@ APPLICATION_RESULT_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+HANDOFF_SUMMARY_LIMITATIONS: tuple[str, ...] = (
+    "summary-only refactor handoff metadata",
+    "summarizes a not-applied application result for editor review and maintainer handoff",
+    "does not include command argv; use validation-plan for command descriptors",
+    "does not publish public text, create pull requests, write comments, or mutate projects",
+    "does not execute validation commands or shell commands",
+    "does not apply refactors, write files, move files, generate patches, "
+    "or roll back files",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 _REFACTOR_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
     "rename-module": ("new_name",),
     "extract-port": ("port_name", "direction"),
@@ -441,6 +453,37 @@ def _application_result_safety_flags() -> dict[str, bool]:
         "runs_validation": False,
         "runs_shell": False,
         "rollback_required": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _handoff_summary_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "handoff_summary_only": True,
+        "approval_granted": False,
+        "request_accepted": False,
+        "write_attempted": False,
+        "summarizes_command_descriptors": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "rollback_required": False,
+        "public_text_published": False,
+        "pull_request_created": False,
+        "comment_written": False,
+        "project_mutation": False,
         "invokes_pccx_lab": False,
         "invokes_launcher": False,
         "invokes_vendor_tools": False,
@@ -2266,6 +2309,152 @@ def build_refactor_application_result(
     }
 
 
+def _handoff_application_result_summary(
+    result: dict[str, Any],
+) -> dict[str, Any]:
+    application = result["application_summary"]
+    phases = []
+    for phase in application["validation_phases"]:
+        phases.append({
+            "command_ids": list(phase["command_ids"]),
+            "phase": phase["phase"],
+            "status": phase["status"],
+        })
+    return {
+        "application_result": result["application_result"]["result"],
+        "approval_decision_state": application["approval_decision_state"],
+        "command_descriptor_count": application["command_descriptor_count"],
+        "file_change_count": result["application_result"]["file_change_count"],
+        "kind": result["kind"],
+        "patch_generated": result["application_result"]["patch_generated"],
+        "result_state": result["result_state"],
+        "review_state": application["review_state"],
+        "rollback_required": result["application_result"]["rollback_required"],
+        "validation_phases": phases,
+        "validation_result": result["application_result"]["validation_result"],
+        "validation_run": result["application_result"]["validation_run"],
+        "validation_state": application["validation_state"],
+        "write_attempted": result["application_result"]["write_attempted"],
+    }
+
+
+def build_refactor_handoff_summary(
+    source: str,
+    path: Path,
+    action: str,
+    module_name: str,
+    *,
+    new_name: str | None = None,
+    port_name: str | None = None,
+    direction: str | None = None,
+    width: str | None = None,
+    destination: str | None = None,
+) -> dict[str, Any]:
+    result = build_refactor_application_result(
+        source,
+        path,
+        action,
+        module_name,
+        new_name=new_name,
+        port_name=port_name,
+        direction=direction,
+        width=width,
+        destination=destination,
+    )
+    preflight = result["preflight"]
+    handoff_state = (
+        "blocked"
+        if preflight["status"] == "blocked"
+        else "ready-for-review"
+    )
+    recommended_next_step = (
+        "resolve refactor preflight blockers before handoff"
+        if handoff_state == "blocked"
+        else "review validation plan before any approval or application"
+    )
+
+    return {
+        "action": action,
+        "application_result_summary": _handoff_application_result_summary(
+            result
+        ),
+        "blocked_actions": [
+            "file-write",
+            "patch-generation",
+            "refactor-application",
+            "validation-run",
+            "shell-command",
+            "pull-request-create",
+            "comment-write",
+            "project-mutation",
+            "pccx-lab-invocation",
+            "launcher-invocation",
+            "vendor-tool-invocation",
+            "provider-call",
+            "hardware-access",
+        ],
+        "handoff_state": handoff_state,
+        "handoff_summary": {
+            "comment_ready": False,
+            "files_changed": 0,
+            "patch_generated": False,
+            "public_text_ready": False,
+            "pull_request_ready": False,
+            "ready_for_maintainer_review": preflight["status"] != "blocked",
+            "recommended_next_step": recommended_next_step,
+            "result": result["application_result"]["result"],
+            "result_state": result["result_state"],
+            "rollback_required": False,
+            "state": handoff_state,
+            "validation_run": False,
+            "write_attempted": False,
+        },
+        "kind": "module-refactor-handoff-summary",
+        "limitations": list(HANDOFF_SUMMARY_LIMITATIONS),
+        "module": result["module"],
+        "preflight": {
+            "reasons": list(preflight["reasons"]),
+            "requires_approval_before_write": preflight[
+                "requires_approval_before_write"
+            ],
+            "requires_explicit_approval_before_run": True,
+            "status": preflight["status"],
+        },
+        "proposal_summary": {
+            "planned_step_count": result["proposal_summary"][
+                "planned_step_count"
+            ],
+            "requested_change": result["proposal_summary"]["requested_change"],
+            "writes_files": result["proposal_summary"]["writes_files"],
+        },
+        "review_notes": [
+            {
+                "note_id": "approval-not-granted",
+                "state": result["application_summary"][
+                    "approval_decision_state"
+                ],
+                "summary": (
+                    "No approval has been granted for the requested refactor."
+                ),
+            },
+            {
+                "note_id": "no-write-attempt",
+                "state": "not_applied",
+                "summary": (
+                    "No write attempt, patch generation, validation run, "
+                    "or rollback occurred."
+                ),
+            },
+        ],
+        "safety": _handoff_summary_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "target": module_name,
+        "tool": "pccx-ide-cli",
+        "writes_files": False,
+    }
+
+
 def format_refactor_proposal_text(proposal: dict[str, Any]) -> str:
     lines = [
         f"source: {proposal['source']}",
@@ -2465,6 +2654,49 @@ def format_refactor_application_result_text(result: dict[str, Any]) -> str:
         "result metadata only: no command argv, validation, shell, "
         "refactor, patch, file write, rollback, lab, launcher, vendor tool, "
         "provider, or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_refactor_handoff_summary_text(summary: dict[str, Any]) -> str:
+    handoff = summary["handoff_summary"]
+    result = summary["application_result_summary"]
+    lines = [
+        f"source: {summary['source']}",
+        f"target: {summary['target']}",
+        f"action: {summary['action']}",
+        f"refactor handoff: {summary['handoff_state']}",
+        f"application result: {result['result_state']}",
+        f"result: {result['application_result']}",
+        "write attempted: no",
+        "patch generated: no",
+        "files changed: 0",
+        "validation run: no",
+        "rollback required: no",
+        "public text ready: no",
+        "pull request ready: no",
+        "comment ready: no",
+        f"approval decision: {result['approval_decision_state']}",
+        f"review state: {result['review_state']}",
+        f"preflight: {summary['preflight']['status']}",
+        "writes files: no",
+        "runs validation: no",
+        f"validation descriptors: {result['command_descriptor_count']}",
+    ]
+    for phase in result["validation_phases"]:
+        command_ids = ", ".join(phase["command_ids"]) or "none"
+        lines.append(
+            f"validation phase: {phase['phase']} "
+            f"({phase['status']}): {command_ids}"
+        )
+    for reason in summary["preflight"]["reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"next step: {handoff['recommended_next_step']}")
+    lines.append(
+        "summary-only handoff: no command argv, public text, pull request, "
+        "comment, project mutation, validation, shell, refactor, patch, "
+        "file write, rollback, lab, launcher, vendor tool, provider, or "
+        "hardware execution"
     )
     return "\n".join(lines) + "\n"
 

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -27,6 +27,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_refactor_approval_decision,
     build_refactor_application_result,
     build_refactor_application_request,
+    build_refactor_handoff_summary,
     build_refactor_impact_view,
     build_refactor_proposal,
     build_refactor_review_packet,
@@ -34,6 +35,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_refactor_approval_decision_text,
     format_refactor_application_result_text,
     format_refactor_application_request_text,
+    format_refactor_handoff_summary_text,
     format_module_dependency_text,
     format_module_context_text,
     format_module_hierarchy_text,
@@ -770,6 +772,82 @@ def test_build_refactor_application_result_reports_blocked_preflight():
     assert phases["post-change-local-validation"]["command_ids"] == []
 
 
+def test_build_refactor_handoff_summary_records_summary_only_handoff():
+    summary = build_refactor_handoff_summary(
+        str(FIXTURE),
+        FIXTURE,
+        "rename-module",
+        "leaf_mod",
+        new_name="leaf_mod_next",
+    )
+
+    assert summary["kind"] == "module-refactor-handoff-summary"
+    assert summary["handoff_state"] == "ready-for-review"
+    assert summary["handoff_summary"]["public_text_ready"] is False
+    assert summary["handoff_summary"]["pull_request_ready"] is False
+    assert summary["handoff_summary"]["comment_ready"] is False
+    assert summary["handoff_summary"]["files_changed"] == 0
+    assert summary["handoff_summary"]["write_attempted"] is False
+    assert summary["handoff_summary"]["patch_generated"] is False
+    assert summary["handoff_summary"]["validation_run"] is False
+    assert summary["handoff_summary"]["rollback_required"] is False
+    assert summary["application_result_summary"]["kind"] == (
+        "module-refactor-application-result"
+    )
+    assert summary["application_result_summary"]["application_result"] == (
+        "not_applied"
+    )
+    assert summary["application_result_summary"]["result_state"] == (
+        "not-applied"
+    )
+    assert summary["application_result_summary"]["write_attempted"] is False
+    assert summary["application_result_summary"]["patch_generated"] is False
+    assert summary["application_result_summary"]["file_change_count"] == 0
+    assert summary["application_result_summary"]["validation_run"] is False
+    assert summary["application_result_summary"]["rollback_required"] is False
+    assert "pull-request-create" in summary["blocked_actions"]
+    assert "comment-write" in summary["blocked_actions"]
+    assert "project-mutation" in summary["blocked_actions"]
+    assert summary["safety"]["read_only"] is True
+    assert summary["safety"]["handoff_summary_only"] is True
+    assert summary["safety"]["public_text_published"] is False
+    assert summary["safety"]["pull_request_created"] is False
+    assert summary["safety"]["comment_written"] is False
+    assert summary["safety"]["project_mutation"] is False
+    assert summary["safety"]["writes_files"] is False
+    assert summary["safety"]["generates_patch"] is False
+    assert summary["safety"]["runs_validation"] is False
+    assert summary["safety"]["runs_shell"] is False
+    assert summary["safety"]["invokes_pccx_lab"] is False
+    assert summary["safety"]["invokes_launcher"] is False
+    assert summary["safety"]["hardware_access"] is False
+    assert '"argv"' not in json.dumps(summary)
+
+
+def test_build_refactor_handoff_summary_reports_blocked_preflight():
+    summary = build_refactor_handoff_summary(
+        str(FIXTURE),
+        FIXTURE,
+        "extract-port",
+        "top_mod",
+        port_name="valid_i",
+    )
+
+    assert summary["handoff_state"] == "blocked"
+    assert summary["handoff_summary"]["ready_for_maintainer_review"] is False
+    assert summary["handoff_summary"]["recommended_next_step"] == (
+        "resolve refactor preflight blockers before handoff"
+    )
+    assert summary["application_result_summary"]["result_state"] == "blocked"
+    assert "missing required direction" in summary["preflight"]["reasons"]
+    phases = {
+        phase["phase"]: phase
+        for phase in summary["application_result_summary"]["validation_phases"]
+    }
+    assert phases["post-change-local-validation"]["status"] == "blocked"
+    assert phases["post-change-local-validation"]["command_ids"] == []
+
+
 def test_format_module_organization_text_mentions_boundary_and_hierarchy():
     export = build_module_organization_export(str(FIXTURE), FIXTURE)
     text = format_module_organization_text(export)
@@ -967,6 +1045,32 @@ def test_format_refactor_application_result_text_mentions_result_receipt():
     assert "writes files: no" in text
     assert "runs validation: no" in text
     assert "result metadata only: no command argv" in text
+
+
+def test_format_refactor_handoff_summary_text_mentions_summary_only_boundary():
+    summary = build_refactor_handoff_summary(
+        str(FIXTURE),
+        FIXTURE,
+        "move-module",
+        "leaf_mod",
+        destination="rtl/leaf_mod.sv",
+    )
+    text = format_refactor_handoff_summary_text(summary)
+
+    assert "refactor handoff: ready-for-review" in text
+    assert "application result: not-applied" in text
+    assert "write attempted: no" in text
+    assert "patch generated: no" in text
+    assert "files changed: 0" in text
+    assert "validation run: no" in text
+    assert "rollback required: no" in text
+    assert "public text ready: no" in text
+    assert "pull request ready: no" in text
+    assert "comment ready: no" in text
+    assert "approval decision: not-approved" in text
+    assert "writes files: no" in text
+    assert "runs validation: no" in text
+    assert "summary-only handoff: no command argv" in text
 
 
 def test_cli_organization_json():
@@ -1407,6 +1511,68 @@ def test_cli_refactor_result_text():
     assert "result metadata only: no command argv" in result.stdout
 
 
+def test_cli_refactor_handoff_json():
+    result = _run_cli(
+        "refactor-handoff",
+        str(FIXTURE),
+        "--action",
+        "rename-module",
+        "--module",
+        "leaf_mod",
+        "--new-name",
+        "leaf_mod_next",
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-refactor-handoff-summary"
+    assert payload["handoff_state"] == "ready-for-review"
+    assert payload["handoff_summary"]["public_text_ready"] is False
+    assert payload["handoff_summary"]["pull_request_ready"] is False
+    assert payload["handoff_summary"]["comment_ready"] is False
+    assert payload["application_result_summary"]["kind"] == (
+        "module-refactor-application-result"
+    )
+    assert payload["application_result_summary"]["application_result"] == (
+        "not_applied"
+    )
+    assert payload["safety"]["handoff_summary_only"] is True
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["generates_patch"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert payload["safety"]["pull_request_created"] is False
+    assert payload["safety"]["comment_written"] is False
+    assert payload["safety"]["project_mutation"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_refactor_handoff_text():
+    result = _run_cli(
+        "refactor-handoff",
+        str(FIXTURE),
+        "--action",
+        "extract-port",
+        "--module",
+        "top_mod",
+        "--port-name",
+        "valid_i",
+        "--format",
+        "text",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "refactor handoff: blocked" in result.stdout
+    assert "write attempted: no" in result.stdout
+    assert "patch generated: no" in result.stdout
+    assert "files changed: 0" in result.stdout
+    assert "validation run: no" in result.stdout
+    assert "public text ready: no" in result.stdout
+    assert "pull request ready: no" in result.stdout
+    assert "comment ready: no" in result.stdout
+    assert "blocked: missing required direction" in result.stdout
+    assert "summary-only handoff: no command argv" in result.stdout
+
+
 def test_cli_organization_missing_path_exits_nonzero():
     result = _run_cli("organization", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
@@ -1539,6 +1705,21 @@ def test_cli_refactor_result_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_refactor_handoff_missing_path_exits_nonzero():
+    result = _run_cli(
+        "refactor-handoff",
+        str(FIXTURE.parent / "missing.sv"),
+        "--action",
+        "rename-module",
+        "--module",
+        "leaf_mod",
+        "--new-name",
+        "leaf_mod_next",
+    )
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_docs_cover_organization_flow_and_limits():
     contract = CONTRACT_DOC.read_text(encoding="utf-8")
     workflow = WORKFLOW_DOC.read_text(encoding="utf-8")
@@ -1554,6 +1735,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "refactor-approval <path>" in contract
     assert "refactor-application <path>" in contract
     assert "refactor-result <path>" in contract
+    assert "refactor-handoff <path>" in contract
     assert "MODULE_ORGANIZATION_WORKFLOW.md" in contract
     assert "proposal-only" in workflow
     assert "module-hierarchy-view" in workflow
@@ -1567,10 +1749,12 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-refactor-approval-decision" in workflow
     assert "module-refactor-application-request" in workflow
     assert "module-refactor-application-result" in workflow
+    assert "module-refactor-handoff-summary" in workflow
     assert "proposed-not-run" in workflow
     assert "summary-only review packet" in workflow
     assert "approval decision metadata" in workflow
     assert "application request metadata" in workflow
     assert "application result metadata" in workflow
+    assert "refactor handoff metadata" in workflow
     assert "does not write files" in workflow
     assert "not a full SystemVerilog parser" in workflow


### PR DESCRIPTION
Refs #8

Summary:
- Add `refactor-handoff` as a summary-only handoff boundary over `refactor-result`.
- Record that no writes, patches, validation run, rollback, public text, PR creation, comments, project mutation, provider calls, launcher/lab invocation, or hardware access occurred.
- Document the command in README, workflow, editor bridge contract, and editor bridge smoke coverage.
- Add unit and CLI tests for JSON/text output, blocked preflight handling, and no `argv` key in the handoff JSON.

Validation:
- `PYTHONPATH=src pytest -q tests/test_module_organization.py`
- `PYTHONPATH=src pytest -q`
- `PYTHONPATH=src python3 -m pccx_ide_cli refactor-handoff fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli refactor-handoff fixtures/organization/hierarchy_top.sv --action extract-port --module top_mod --port-name valid_i --format text`
- `python3 -m py_compile $(find src tests scripts -name '*.py' -print | sort)`\n- `bash -n scripts/check-editor-bridge-examples.sh scripts/editor-bridge-smoke.sh scripts/vscode-adapter-smoke.sh scripts/vscode-extension-host-smoke.sh`\n- `python3 scripts/check-source-headers.py`\n- `bash scripts/check-editor-bridge-examples.sh`\n- `bash scripts/editor-bridge-smoke.sh`\n- `bash scripts/vscode-adapter-smoke.sh`\n- local claim scan matching CI pattern\n- `git diff --check`\n- `git diff --cached --check`\n\nNote:\n- `scripts/vscode-extension-host-smoke.sh` was not enabled as a blocking runtime smoke; by default it exits with its opt-in notice.