### PR TITLE
Add refactor checklist boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ python -m pccx_ide_cli refactor-approval fixtures/organization/hierarchy_top.sv 
 python -m pccx_ide_cli refactor-application fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 python -m pccx_ide_cli refactor-result fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 python -m pccx_ide_cli refactor-handoff fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
+python -m pccx_ide_cli refactor-checklist fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 
 # xsim log handoff scaffold (parses existing log files only)
 python -m pccx_ide_cli xsim-log fixtures/xsim/mixed.log --format json
@@ -227,15 +228,15 @@ review steps, but it does not write files, apply patches, run validation,
 invoke `pccx-lab` or the launcher, call providers, touch hardware, or
 perform automatic repository actions.
 `validation-plan`, `refactor-review`, `refactor-approval`,
-`refactor-application`, `refactor-result`, and `refactor-handoff` extend that
-reviewed flow with
+`refactor-application`, `refactor-result`, `refactor-handoff`, and
+`refactor-checklist` extend that reviewed flow with
 proposal-only validation descriptors, summary-only review data, unapproved
 approval gates, not-accepted application request metadata, and not-applied
-result receipts, plus summary-only handoff metadata. They do not execute
-validation, run shell commands, apply edits, generate patches, write files,
-publish public text, create pull requests, write comments, mutate projects,
-invoke `pccx-lab` or the launcher, call providers, touch hardware, or perform
-automatic repository actions.
+result receipts, plus summary-only handoff and checklist metadata. They do not
+execute validation, run shell commands, apply edits, generate patches, write
+files, publish public text, create pull requests, write comments, mutate
+projects, invoke `pccx-lab` or the launcher, call providers, touch hardware, or
+perform automatic repository actions.
 
 `xsim-log` is an early handoff scaffold. It parses existing synthetic
 xsim-style log files into diagnostics-like JSON or text output. It does

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -57,6 +57,7 @@ python -m pccx_ide_cli refactor-approval <path> --action rename-module --module 
 python -m pccx_ide_cli refactor-application <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli refactor-result <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli refactor-handoff <path> --action rename-module --module <name> --new-name <name> --format json
+python -m pccx_ide_cli refactor-checklist <path> --action rename-module --module <name> --new-name <name> --format json
 
 # Opt-in pccx-lab diagnostics backend
 python -m pccx_ide_cli check <sv-file> --backend pccx-lab --format json
@@ -246,6 +247,14 @@ files, no validation run, and no rollback requirement; it does not include
 command argv, accept a write request, apply edits, execute validation, run
 shell commands, write files, invoke pccx-lab or the launcher, run vendor tools,
 call providers, touch hardware, or perform automatic repository actions.
+`refactor-checklist` emits summary-only checklist metadata over the refactor
+handoff. It records preflight, context review, validation-plan review, approval
+gate, application gate, and handoff review items without command argv; it does
+not grant approval, accept application requests, apply edits, execute
+validation, run shell commands, write files, publish public text, create pull
+requests, write comments, mutate projects, invoke pccx-lab or the launcher,
+run vendor tools, call providers, touch hardware, or perform automatic
+repository actions.
 
 For existing xsim logs, the VS Code prototype can consume the checked
 `problems from-xsim-log` JSON as a read-only status/context summary.  The
@@ -265,7 +274,7 @@ xsim path, and text surface sketches is documented in
 - Module organization, header/port summaries, port usage summaries,
   refactor impact review, refactor planning, and validation planning are
   scanner-based; refactor review packets, approval decisions, application
-  requests, application results, and handoff summaries are summary-only
+  requests, application results, handoff summaries, and checklists are summary-only
   metadata over those
   surfaces. They are not semantic elaboration and do not apply refactors or
   execute validation.

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -6,14 +6,15 @@ This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
 `module-summary`, `port-usage`, `module-context`, `refactor-impact`,
 `validation-plan`, `refactor-review`, `refactor-approval`, and
-`refactor-application`, `refactor-result`, and `refactor-handoff` CLI surfaces
+`refactor-application`, `refactor-result`, `refactor-handoff`, and
+`refactor-checklist` CLI surfaces
 that report module boundary spans, scanner-based hierarchy data, direct
 dependency impact data, conservative module header/port summaries, target port
 usage summaries, target module context bundles, target-specific refactor impact
 data, proposal-only validation command descriptors, a summary-only review
 packet, approval decision metadata, application request metadata, and
-application result metadata plus refactor handoff metadata for editor
-navigation and reviewed refactoring planning.
+application result metadata plus refactor handoff metadata and refactor
+checklist metadata for editor navigation and reviewed refactoring planning.
 
 It is not a full SystemVerilog parser, not semantic elaboration, not an LSP
 implementation, and not a write-capable refactoring engine.
@@ -56,6 +57,9 @@ python -m pccx_ide_cli refactor-result <path> --action move-module --module <nam
 python -m pccx_ide_cli refactor-handoff <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli refactor-handoff <path> --action extract-port --module <name> --port-name <name> --direction input --format text
 python -m pccx_ide_cli refactor-handoff <path> --action move-module --module <name> --destination rtl/<name>.sv --format json
+python -m pccx_ide_cli refactor-checklist <path> --action rename-module --module <name> --new-name <name> --format json
+python -m pccx_ide_cli refactor-checklist <path> --action extract-port --module <name> --port-name <name> --direction input --format text
+python -m pccx_ide_cli refactor-checklist <path> --action move-module --module <name> --destination rtl/<name>.sv --format json
 ```
 
 `<path>` may be a `.sv` / `.v` file or a directory. Directory scans follow the
@@ -450,6 +454,7 @@ inputs for later helpers:
 - target-specific module context bundles
 - target-specific refactor impact review data
 - planned helper names for rename, extract-port, and move-module workflows
+- summary-only checklist metadata for maintainer review
 
 The CLI does not write files, apply patches, rename symbols, move modules,
 edit ports, run validation, execute shell commands, invoke `pccx-lab`, invoke
@@ -902,6 +907,76 @@ publish public text, create pull requests, write comments, mutate projects,
 accept an application request, apply a refactor, perform rollback, grant
 approval, or perform automatic repository actions.
 
+## Refactor Checklist Summary
+
+`refactor-checklist` adds summary-only refactor checklist metadata over the
+existing `refactor-handoff` summary. It is intended for editor review panes and
+maintainer notes that need a compact list of gates before any write-capable
+helper exists.
+
+Example shape:
+
+```json
+{
+  "kind": "module-refactor-checklist-summary",
+  "checklist_state": "ready-for-review",
+  "action": "rename-module",
+  "writes_files": false,
+  "checklist_items": [
+    {
+      "item_id": "preflight",
+      "status": "ready-for-review",
+      "required": true,
+      "complete": true
+    },
+    {
+      "item_id": "approval-gate",
+      "status": "not-approved",
+      "required": true,
+      "complete": false
+    }
+  ],
+  "handoff_summary": {
+    "kind": "module-refactor-handoff-summary",
+    "handoff_state": "ready-for-review",
+    "ready_for_maintainer_review": true
+  },
+  "result_summary": {
+    "application_result": "not_applied",
+    "write_attempted": false,
+    "patch_generated": false,
+    "file_change_count": 0,
+    "validation_run": false,
+    "rollback_required": false,
+    "command_descriptor_count": 8
+  },
+  "safety": {
+    "read_only": true,
+    "checklist_summary_only": true,
+    "approval_granted": false,
+    "request_accepted": false,
+    "writes_files": false,
+    "generates_patch": false,
+    "runs_validation": false,
+    "runs_shell": false,
+    "invokes_pccx_lab": false,
+    "invokes_launcher": false,
+    "hardware_access": false
+  }
+}
+```
+
+The checklist intentionally summarizes review gates and command descriptor
+counts only. It does not include command argv; consumers that need the
+fixed-argv descriptor list should call `validation-plan` directly.
+
+This boundary does not write files, apply refactors, move files, generate
+patches, run validation, execute shell commands, invoke `pccx-lab`, invoke the
+launcher, run vendor tools, call providers, touch hardware, upload telemetry,
+publish public text, create pull requests, write comments, mutate projects,
+accept an application request, apply a refactor, perform rollback, grant
+approval, or perform automatic repository actions.
+
 ## Limitations
 
 - Scanner-based module declarations and `endmodule` matching only.
@@ -920,5 +995,5 @@ direct dependency view, conservative module header/port summaries,
 target-specific port usage summaries, target-specific module context
 bundles, target-specific refactor impact review data, and a
 proposal-only refactoring, validation planning, review packet, approval
-decision, application request, application result, and handoff summary
-boundary.
+decision, application request, application result, handoff summary, and
+checklist summary boundary.

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -650,6 +650,59 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    refactor_checklist_cmd = sub.add_parser(
+        "refactor-checklist",
+        help="Emit summary-only checklist metadata for refactor review.",
+    )
+    refactor_checklist_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    refactor_checklist_cmd.add_argument(
+        "--action",
+        choices=("rename-module", "extract-port", "move-module"),
+        required=True,
+        help="Refactor proposal kind to summarize as a review checklist.",
+    )
+    refactor_checklist_cmd.add_argument(
+        "--module",
+        required=True,
+        help="Exact module name to use as the checklist target.",
+    )
+    refactor_checklist_cmd.add_argument(
+        "--new-name",
+        default=None,
+        help="New module name for rename-module checklists.",
+    )
+    refactor_checklist_cmd.add_argument(
+        "--port-name",
+        default=None,
+        help="Port name for extract-port checklists.",
+    )
+    refactor_checklist_cmd.add_argument(
+        "--direction",
+        choices=("input", "output", "inout"),
+        default=None,
+        help="Port direction for extract-port checklists.",
+    )
+    refactor_checklist_cmd.add_argument(
+        "--width",
+        default=None,
+        help="Optional port width text for extract-port checklists.",
+    )
+    refactor_checklist_cmd.add_argument(
+        "--destination",
+        default=None,
+        help="Relative destination path for move-module checklists.",
+    )
+    refactor_checklist_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     xsim_log = sub.add_parser(
         "xsim-log",
         help="Parse an existing xsim-style log file into diagnostics-like output.",
@@ -1184,6 +1237,34 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_refactor_handoff_summary_text(summary))
+        return 0
+
+    if args.command == "refactor-checklist":
+        from .module_organization import (
+            build_refactor_checklist_summary,
+            format_refactor_checklist_summary_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        checklist = build_refactor_checklist_summary(
+            str(args.path),
+            args.path,
+            args.action,
+            args.module,
+            new_name=args.new_name,
+            port_name=args.port_name,
+            direction=args.direction,
+            width=args.width,
+            destination=args.destination,
+        )
+        if args.format == "json":
+            json.dump(checklist, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_refactor_checklist_summary_text(checklist))
         return 0
 
     if args.command == "xsim-log":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -215,6 +215,20 @@ HANDOFF_SUMMARY_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+CHECKLIST_SUMMARY_LIMITATIONS: tuple[str, ...] = (
+    "summary-only refactor checklist metadata",
+    "summarizes the existing refactor handoff for maintainer review",
+    "does not include command argv; use validation-plan for command descriptors",
+    "does not record approval, accept application requests, or apply refactors",
+    "does not execute validation commands or shell commands",
+    "does not apply refactors, write files, move files, generate patches, "
+    "or roll back files",
+    "does not publish public text, create pull requests, write comments, "
+    "or mutate projects",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 _REFACTOR_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
     "rename-module": ("new_name",),
     "extract-port": ("port_name", "direction"),
@@ -467,6 +481,37 @@ def _handoff_summary_safety_flags() -> dict[str, bool]:
     return {
         "read_only": True,
         "handoff_summary_only": True,
+        "approval_granted": False,
+        "request_accepted": False,
+        "write_attempted": False,
+        "summarizes_command_descriptors": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "rollback_required": False,
+        "public_text_published": False,
+        "pull_request_created": False,
+        "comment_written": False,
+        "project_mutation": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _checklist_summary_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "checklist_summary_only": True,
         "approval_granted": False,
         "request_accepted": False,
         "write_attempted": False,
@@ -2455,6 +2500,155 @@ def build_refactor_handoff_summary(
     }
 
 
+def _checklist_items(handoff: dict[str, Any]) -> list[dict[str, Any]]:
+    preflight = handoff["preflight"]
+    result = handoff["application_result_summary"]
+    handoff_summary = handoff["handoff_summary"]
+    preflight_ready = preflight["status"] != "blocked"
+
+    return [
+        {
+            "complete": preflight_ready,
+            "item_id": "preflight",
+            "required": True,
+            "status": preflight["status"],
+            "summary": (
+                "Refactor preflight metadata is ready for review."
+                if preflight_ready
+                else "Resolve refactor preflight blockers before review."
+            ),
+        },
+        {
+            "complete": False,
+            "item_id": "context-review",
+            "required": True,
+            "status": (
+                "pending-maintainer-review"
+                if preflight_ready
+                else "blocked-by-preflight"
+            ),
+            "summary": (
+                "Review module context, dependency impact, port usage, "
+                "and target references before any approval."
+            ),
+        },
+        {
+            "command_descriptor_count": result["command_descriptor_count"],
+            "complete": False,
+            "item_id": "validation-plan-review",
+            "required": True,
+            "status": (
+                "pending-maintainer-review"
+                if preflight_ready
+                else "blocked-by-preflight"
+            ),
+            "summary": (
+                "Review validation descriptor IDs before any explicit "
+                "validation run."
+            ),
+        },
+        {
+            "complete": False,
+            "item_id": "approval-gate",
+            "required": True,
+            "status": result["approval_decision_state"],
+            "summary": "Explicit approval has not been recorded.",
+        },
+        {
+            "complete": False,
+            "item_id": "application-gate",
+            "required": True,
+            "status": result["application_result"],
+            "summary": (
+                "Application remains not applied; no write attempt, patch, "
+                "validation run, or rollback occurred."
+            ),
+            "write_attempted": result["write_attempted"],
+        },
+        {
+            "complete": False,
+            "item_id": "handoff-review",
+            "required": True,
+            "status": handoff["handoff_state"],
+            "summary": handoff_summary["recommended_next_step"],
+        },
+    ]
+
+
+def build_refactor_checklist_summary(
+    source: str,
+    path: Path,
+    action: str,
+    module_name: str,
+    *,
+    new_name: str | None = None,
+    port_name: str | None = None,
+    direction: str | None = None,
+    width: str | None = None,
+    destination: str | None = None,
+) -> dict[str, Any]:
+    handoff = build_refactor_handoff_summary(
+        source,
+        path,
+        action,
+        module_name,
+        new_name=new_name,
+        port_name=port_name,
+        direction=direction,
+        width=width,
+        destination=destination,
+    )
+    handoff_summary = handoff["handoff_summary"]
+    result = handoff["application_result_summary"]
+
+    return {
+        "action": action,
+        "blocked_actions": [
+            *handoff["blocked_actions"],
+            "approval-grant",
+            "application-accept",
+        ],
+        "checklist_items": _checklist_items(handoff),
+        "checklist_state": handoff["handoff_state"],
+        "handoff_summary": {
+            "handoff_state": handoff["handoff_state"],
+            "kind": handoff["kind"],
+            "ready_for_maintainer_review": handoff_summary[
+                "ready_for_maintainer_review"
+            ],
+            "recommended_next_step": handoff_summary["recommended_next_step"],
+            "result_state": handoff_summary["result_state"],
+        },
+        "kind": "module-refactor-checklist-summary",
+        "limitations": list(CHECKLIST_SUMMARY_LIMITATIONS),
+        "module": handoff["module"],
+        "preflight": {
+            "reasons": list(handoff["preflight"]["reasons"]),
+            "requires_approval_before_write": handoff["preflight"][
+                "requires_approval_before_write"
+            ],
+            "requires_explicit_approval_before_run": True,
+            "status": handoff["preflight"]["status"],
+        },
+        "result_summary": {
+            "approval_decision_state": result["approval_decision_state"],
+            "application_result": result["application_result"],
+            "command_descriptor_count": result["command_descriptor_count"],
+            "file_change_count": result["file_change_count"],
+            "patch_generated": result["patch_generated"],
+            "rollback_required": result["rollback_required"],
+            "validation_run": result["validation_run"],
+            "write_attempted": result["write_attempted"],
+        },
+        "safety": _checklist_summary_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "target": module_name,
+        "tool": "pccx-ide-cli",
+        "writes_files": False,
+    }
+
+
 def format_refactor_proposal_text(proposal: dict[str, Any]) -> str:
     lines = [
         f"source: {proposal['source']}",
@@ -2697,6 +2891,46 @@ def format_refactor_handoff_summary_text(summary: dict[str, Any]) -> str:
         "comment, project mutation, validation, shell, refactor, patch, "
         "file write, rollback, lab, launcher, vendor tool, provider, or "
         "hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_refactor_checklist_summary_text(checklist: dict[str, Any]) -> str:
+    handoff = checklist["handoff_summary"]
+    result = checklist["result_summary"]
+    ready = "yes" if handoff["ready_for_maintainer_review"] else "no"
+    lines = [
+        f"source: {checklist['source']}",
+        f"target: {checklist['target']}",
+        f"action: {checklist['action']}",
+        f"refactor checklist: {checklist['checklist_state']}",
+        f"handoff: {handoff['handoff_state']}",
+        f"ready for maintainer review: {ready}",
+        "write attempted: no",
+        "patch generated: no",
+        "files changed: 0",
+        "validation run: no",
+        "rollback required: no",
+        f"approval decision: {result['approval_decision_state']}",
+        f"application result: {result['application_result']}",
+        f"preflight: {checklist['preflight']['status']}",
+        "writes files: no",
+        "runs validation: no",
+        f"validation descriptors: {result['command_descriptor_count']}",
+    ]
+    for item in checklist["checklist_items"]:
+        lines.append(
+            f"checklist: {item['item_id']} ({item['status']}): "
+            f"{item['summary']}"
+        )
+    for reason in checklist["preflight"]["reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"next step: {handoff['recommended_next_step']}")
+    lines.append(
+        "summary-only checklist: no command argv, approval grant, "
+        "application accept, validation, shell, refactor, patch, file write, "
+        "rollback, public text, pull request, comment, project mutation, lab, "
+        "launcher, vendor tool, provider, or hardware execution"
     )
     return "\n".join(lines) + "\n"
 

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -27,6 +27,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_refactor_approval_decision,
     build_refactor_application_result,
     build_refactor_application_request,
+    build_refactor_checklist_summary,
     build_refactor_handoff_summary,
     build_refactor_impact_view,
     build_refactor_proposal,
@@ -35,6 +36,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_refactor_approval_decision_text,
     format_refactor_application_result_text,
     format_refactor_application_request_text,
+    format_refactor_checklist_summary_text,
     format_refactor_handoff_summary_text,
     format_module_dependency_text,
     format_module_context_text,
@@ -848,6 +850,79 @@ def test_build_refactor_handoff_summary_reports_blocked_preflight():
     assert phases["post-change-local-validation"]["command_ids"] == []
 
 
+def test_build_refactor_checklist_summary_records_summary_only_items():
+    checklist = build_refactor_checklist_summary(
+        str(FIXTURE),
+        FIXTURE,
+        "rename-module",
+        "leaf_mod",
+        new_name="leaf_mod_next",
+    )
+
+    assert checklist["kind"] == "module-refactor-checklist-summary"
+    assert checklist["checklist_state"] == "ready-for-review"
+    assert checklist["handoff_summary"]["kind"] == (
+        "module-refactor-handoff-summary"
+    )
+    assert checklist["handoff_summary"]["ready_for_maintainer_review"] is True
+    assert checklist["result_summary"]["application_result"] == "not_applied"
+    assert checklist["result_summary"]["write_attempted"] is False
+    assert checklist["result_summary"]["patch_generated"] is False
+    assert checklist["result_summary"]["file_change_count"] == 0
+    assert checklist["result_summary"]["validation_run"] is False
+    assert checklist["result_summary"]["rollback_required"] is False
+    assert [item["item_id"] for item in checklist["checklist_items"]] == [
+        "preflight",
+        "context-review",
+        "validation-plan-review",
+        "approval-gate",
+        "application-gate",
+        "handoff-review",
+    ]
+    items = {item["item_id"]: item for item in checklist["checklist_items"]}
+    assert items["preflight"]["complete"] is True
+    assert items["context-review"]["status"] == "pending-maintainer-review"
+    assert items["validation-plan-review"]["command_descriptor_count"] == 8
+    assert items["approval-gate"]["status"] == "not-approved"
+    assert items["application-gate"]["write_attempted"] is False
+    assert "approval-grant" in checklist["blocked_actions"]
+    assert "application-accept" in checklist["blocked_actions"]
+    assert checklist["safety"]["read_only"] is True
+    assert checklist["safety"]["checklist_summary_only"] is True
+    assert checklist["safety"]["approval_granted"] is False
+    assert checklist["safety"]["request_accepted"] is False
+    assert checklist["safety"]["writes_files"] is False
+    assert checklist["safety"]["generates_patch"] is False
+    assert checklist["safety"]["runs_validation"] is False
+    assert checklist["safety"]["runs_shell"] is False
+    assert checklist["safety"]["invokes_pccx_lab"] is False
+    assert checklist["safety"]["invokes_launcher"] is False
+    assert checklist["safety"]["hardware_access"] is False
+    assert '"argv"' not in json.dumps(checklist)
+
+
+def test_build_refactor_checklist_summary_reports_blocked_preflight():
+    checklist = build_refactor_checklist_summary(
+        str(FIXTURE),
+        FIXTURE,
+        "extract-port",
+        "top_mod",
+        port_name="valid_i",
+    )
+
+    assert checklist["checklist_state"] == "blocked"
+    assert checklist["handoff_summary"]["ready_for_maintainer_review"] is False
+    assert checklist["handoff_summary"]["recommended_next_step"] == (
+        "resolve refactor preflight blockers before handoff"
+    )
+    assert "missing required direction" in checklist["preflight"]["reasons"]
+    items = {item["item_id"]: item for item in checklist["checklist_items"]}
+    assert items["preflight"]["status"] == "blocked"
+    assert items["preflight"]["complete"] is False
+    assert items["context-review"]["status"] == "blocked-by-preflight"
+    assert items["validation-plan-review"]["status"] == "blocked-by-preflight"
+
+
 def test_format_module_organization_text_mentions_boundary_and_hierarchy():
     export = build_module_organization_export(str(FIXTURE), FIXTURE)
     text = format_module_organization_text(export)
@@ -1071,6 +1146,33 @@ def test_format_refactor_handoff_summary_text_mentions_summary_only_boundary():
     assert "writes files: no" in text
     assert "runs validation: no" in text
     assert "summary-only handoff: no command argv" in text
+
+
+def test_format_refactor_checklist_summary_text_mentions_summary_only_boundary():
+    checklist = build_refactor_checklist_summary(
+        str(FIXTURE),
+        FIXTURE,
+        "move-module",
+        "leaf_mod",
+        destination="rtl/leaf_mod.sv",
+    )
+    text = format_refactor_checklist_summary_text(checklist)
+
+    assert "refactor checklist: ready-for-review" in text
+    assert "handoff: ready-for-review" in text
+    assert "ready for maintainer review: yes" in text
+    assert "write attempted: no" in text
+    assert "patch generated: no" in text
+    assert "files changed: 0" in text
+    assert "validation run: no" in text
+    assert "rollback required: no" in text
+    assert "approval decision: not-approved" in text
+    assert "application result: not_applied" in text
+    assert "checklist: preflight (ready-for-review)" in text
+    assert "checklist: approval-gate (not-approved)" in text
+    assert "writes files: no" in text
+    assert "runs validation: no" in text
+    assert "summary-only checklist: no command argv" in text
 
 
 def test_cli_organization_json():
@@ -1573,6 +1675,60 @@ def test_cli_refactor_handoff_text():
     assert "summary-only handoff: no command argv" in result.stdout
 
 
+def test_cli_refactor_checklist_json():
+    result = _run_cli(
+        "refactor-checklist",
+        str(FIXTURE),
+        "--action",
+        "rename-module",
+        "--module",
+        "leaf_mod",
+        "--new-name",
+        "leaf_mod_next",
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-refactor-checklist-summary"
+    assert payload["checklist_state"] == "ready-for-review"
+    assert payload["handoff_summary"]["ready_for_maintainer_review"] is True
+    assert payload["result_summary"]["application_result"] == "not_applied"
+    assert payload["result_summary"]["write_attempted"] is False
+    assert payload["result_summary"]["patch_generated"] is False
+    assert payload["result_summary"]["validation_run"] is False
+    assert payload["safety"]["checklist_summary_only"] is True
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["generates_patch"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert payload["safety"]["runs_shell"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_refactor_checklist_text():
+    result = _run_cli(
+        "refactor-checklist",
+        str(FIXTURE),
+        "--action",
+        "extract-port",
+        "--module",
+        "top_mod",
+        "--port-name",
+        "valid_i",
+        "--format",
+        "text",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "refactor checklist: blocked" in result.stdout
+    assert "ready for maintainer review: no" in result.stdout
+    assert "validation run: no" in result.stdout
+    assert "approval decision: blocked" in result.stdout
+    assert "application result: not_applied" in result.stdout
+    assert "checklist: preflight (blocked)" in result.stdout
+    assert "blocked: missing required direction" in result.stdout
+    assert "summary-only checklist: no command argv" in result.stdout
+
+
 def test_cli_organization_missing_path_exits_nonzero():
     result = _run_cli("organization", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
@@ -1720,6 +1876,21 @@ def test_cli_refactor_handoff_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_refactor_checklist_missing_path_exits_nonzero():
+    result = _run_cli(
+        "refactor-checklist",
+        str(FIXTURE.parent / "missing.sv"),
+        "--action",
+        "rename-module",
+        "--module",
+        "leaf_mod",
+        "--new-name",
+        "leaf_mod_next",
+    )
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_docs_cover_organization_flow_and_limits():
     contract = CONTRACT_DOC.read_text(encoding="utf-8")
     workflow = WORKFLOW_DOC.read_text(encoding="utf-8")
@@ -1736,6 +1907,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "refactor-application <path>" in contract
     assert "refactor-result <path>" in contract
     assert "refactor-handoff <path>" in contract
+    assert "refactor-checklist <path>" in contract
     assert "MODULE_ORGANIZATION_WORKFLOW.md" in contract
     assert "proposal-only" in workflow
     assert "module-hierarchy-view" in workflow
@@ -1750,11 +1922,13 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-refactor-application-request" in workflow
     assert "module-refactor-application-result" in workflow
     assert "module-refactor-handoff-summary" in workflow
+    assert "module-refactor-checklist-summary" in workflow
     assert "proposed-not-run" in workflow
     assert "summary-only review packet" in workflow
     assert "approval decision metadata" in workflow
     assert "application request metadata" in workflow
     assert "application result metadata" in workflow
     assert "refactor handoff metadata" in workflow
+    assert "refactor checklist metadata" in workflow
     assert "does not write files" in workflow
     assert "not a full SystemVerilog parser" in workflow


### PR DESCRIPTION
## Summary
- Add a summary-only `refactor-checklist` CLI boundary over the existing refactor handoff summary.
- Report preflight, context review, validation-plan review, approval gate, application gate, and handoff review items without command argv or execution.
- Document the editor bridge/module organization contract and cover the builder, formatter, CLI, missing-path, and docs checks.

## Validation
- `python3 -m pytest -q`
- `python3 -m pytest tests/test_module_organization.py`
- `bash scripts/check-editor-bridge-examples.sh`
- `python3 scripts/check-source-headers.py`
- `git diff --check`
- `git diff --cached --check`
- `PYTHONPATH=src python3 -m pccx_ide_cli refactor-checklist fixtures/organization/hierarchy_top.sv --action rename-module --module leaf_mod --new-name leaf_mod_next --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli refactor-checklist fixtures/organization/hierarchy_top.sv --action extract-port --module top_mod --port-name valid_i --format text`

Refs #8