### PR TITLE
Add refactor session boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ python -m pccx_ide_cli refactor-application fixtures/organization/hierarchy_top.
 python -m pccx_ide_cli refactor-result fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 python -m pccx_ide_cli refactor-handoff fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 python -m pccx_ide_cli refactor-checklist fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
+python -m pccx_ide_cli refactor-session fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json
 
 # xsim log handoff scaffold (parses existing log files only)
 python -m pccx_ide_cli xsim-log fixtures/xsim/mixed.log --format json
@@ -228,11 +229,12 @@ review steps, but it does not write files, apply patches, run validation,
 invoke `pccx-lab` or the launcher, call providers, touch hardware, or
 perform automatic repository actions.
 `validation-plan`, `refactor-review`, `refactor-approval`,
-`refactor-application`, `refactor-result`, `refactor-handoff`, and
-`refactor-checklist` extend that reviewed flow with
+`refactor-application`, `refactor-result`, `refactor-handoff`,
+`refactor-checklist`, and `refactor-session` extend that reviewed flow with
 proposal-only validation descriptors, summary-only review data, unapproved
 approval gates, not-accepted application request metadata, and not-applied
-result receipts, plus summary-only handoff and checklist metadata. They do not
+result receipts, plus summary-only handoff, checklist, and session status
+metadata. They do not
 execute validation, run shell commands, apply edits, generate patches, write
 files, publish public text, create pull requests, write comments, mutate
 projects, invoke `pccx-lab` or the launcher, call providers, touch hardware, or

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -58,6 +58,7 @@ python -m pccx_ide_cli refactor-application <path> --action rename-module --modu
 python -m pccx_ide_cli refactor-result <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli refactor-handoff <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli refactor-checklist <path> --action rename-module --module <name> --new-name <name> --format json
+python -m pccx_ide_cli refactor-session <path> --action rename-module --module <name> --new-name <name> --format json
 
 # Opt-in pccx-lab diagnostics backend
 python -m pccx_ide_cli check <sv-file> --backend pccx-lab --format json
@@ -255,6 +256,13 @@ validation, run shell commands, write files, publish public text, create pull
 requests, write comments, mutate projects, invoke pccx-lab or the launcher,
 run vendor tools, call providers, touch hardware, or perform automatic
 repository actions.
+`refactor-session` emits summary-only session status metadata over that
+checklist. It records the current stage, checklist counts, incomplete required
+items, and next required action without command argv, session persistence,
+status writeback, notification dispatch, approval grants, application
+acceptance, edits, validation, shell execution, public text publication, pull
+request creation, comments, project mutation, pccx-lab or launcher invocation,
+vendor tools, providers, hardware, or automatic repository actions.
 
 For existing xsim logs, the VS Code prototype can consume the checked
 `problems from-xsim-log` JSON as a read-only status/context summary.  The

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -5,16 +5,17 @@
 This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
 `module-summary`, `port-usage`, `module-context`, `refactor-impact`,
-`validation-plan`, `refactor-review`, `refactor-approval`, and
-`refactor-application`, `refactor-result`, `refactor-handoff`, and
-`refactor-checklist` CLI surfaces
+`validation-plan`, `refactor-review`, `refactor-approval`,
+`refactor-application`, `refactor-result`, `refactor-handoff`,
+`refactor-checklist`, and `refactor-session` CLI surfaces
 that report module boundary spans, scanner-based hierarchy data, direct
 dependency impact data, conservative module header/port summaries, target port
 usage summaries, target module context bundles, target-specific refactor impact
 data, proposal-only validation command descriptors, a summary-only review
 packet, approval decision metadata, application request metadata, and
-application result metadata plus refactor handoff metadata and refactor
-checklist metadata for editor navigation and reviewed refactoring planning.
+application result metadata plus refactor handoff metadata, refactor checklist
+metadata, and refactor session status metadata for editor navigation and
+reviewed refactoring planning.
 
 It is not a full SystemVerilog parser, not semantic elaboration, not an LSP
 implementation, and not a write-capable refactoring engine.
@@ -60,6 +61,9 @@ python -m pccx_ide_cli refactor-handoff <path> --action move-module --module <na
 python -m pccx_ide_cli refactor-checklist <path> --action rename-module --module <name> --new-name <name> --format json
 python -m pccx_ide_cli refactor-checklist <path> --action extract-port --module <name> --port-name <name> --direction input --format text
 python -m pccx_ide_cli refactor-checklist <path> --action move-module --module <name> --destination rtl/<name>.sv --format json
+python -m pccx_ide_cli refactor-session <path> --action rename-module --module <name> --new-name <name> --format json
+python -m pccx_ide_cli refactor-session <path> --action extract-port --module <name> --port-name <name> --direction input --format text
+python -m pccx_ide_cli refactor-session <path> --action move-module --module <name> --destination rtl/<name>.sv --format json
 ```
 
 `<path>` may be a `.sv` / `.v` file or a directory. Directory scans follow the
@@ -976,6 +980,70 @@ launcher, run vendor tools, call providers, touch hardware, upload telemetry,
 publish public text, create pull requests, write comments, mutate projects,
 accept an application request, apply a refactor, perform rollback, grant
 approval, or perform automatic repository actions.
+
+## Refactor Session Status
+
+`refactor-session` adds summary-only refactor session status metadata over the
+existing `refactor-checklist` summary. It is intended for editor status panes
+and handoff dashboards that need one compact state envelope before any
+write-capable helper exists.
+
+Example shape:
+
+```json
+{
+  "kind": "module-refactor-session-status",
+  "session_state": "ready-for-review",
+  "current_stage": "maintainer-review",
+  "action": "rename-module",
+  "writes_files": false,
+  "session_summary": {
+    "checklist_kind": "module-refactor-checklist-summary",
+    "checklist_state": "ready-for-review",
+    "ready_for_maintainer_review": true,
+    "required_item_count": 6,
+    "complete_required_count": 1,
+    "incomplete_required_count": 5
+  },
+  "result_summary": {
+    "application_result": "not_applied",
+    "write_attempted": false,
+    "patch_generated": false,
+    "file_change_count": 0,
+    "validation_run": false,
+    "rollback_required": false,
+    "command_descriptor_count": 8
+  },
+  "safety": {
+    "read_only": true,
+    "session_status_only": true,
+    "session_persistence": false,
+    "status_writeback": false,
+    "notification_dispatched": false,
+    "approval_granted": false,
+    "request_accepted": false,
+    "writes_files": false,
+    "generates_patch": false,
+    "runs_validation": false,
+    "runs_shell": false,
+    "invokes_pccx_lab": false,
+    "invokes_launcher": false,
+    "hardware_access": false
+  }
+}
+```
+
+The session status intentionally summarizes checklist items and counts only.
+It does not include command argv; consumers that need the fixed-argv descriptor
+list should call `validation-plan` directly.
+
+This boundary does not persist session state, write status files, dispatch
+notifications, write files, apply refactors, move files, generate patches, run
+validation, execute shell commands, invoke `pccx-lab`, invoke the launcher, run
+vendor tools, call providers, touch hardware, upload telemetry, publish public
+text, create pull requests, write comments, mutate projects, accept an
+application request, apply a refactor, perform rollback, grant approval, or
+perform automatic repository actions.
 
 ## Limitations
 

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -703,6 +703,59 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    refactor_session_cmd = sub.add_parser(
+        "refactor-session",
+        help="Emit summary-only session status for refactor review.",
+    )
+    refactor_session_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    refactor_session_cmd.add_argument(
+        "--action",
+        choices=("rename-module", "extract-port", "move-module"),
+        required=True,
+        help="Refactor proposal kind to summarize as session status.",
+    )
+    refactor_session_cmd.add_argument(
+        "--module",
+        required=True,
+        help="Exact module name to use as the session target.",
+    )
+    refactor_session_cmd.add_argument(
+        "--new-name",
+        default=None,
+        help="New module name for rename-module session status.",
+    )
+    refactor_session_cmd.add_argument(
+        "--port-name",
+        default=None,
+        help="Port name for extract-port session status.",
+    )
+    refactor_session_cmd.add_argument(
+        "--direction",
+        choices=("input", "output", "inout"),
+        default=None,
+        help="Port direction for extract-port session status.",
+    )
+    refactor_session_cmd.add_argument(
+        "--width",
+        default=None,
+        help="Optional port width text for extract-port session status.",
+    )
+    refactor_session_cmd.add_argument(
+        "--destination",
+        default=None,
+        help="Relative destination path for move-module session status.",
+    )
+    refactor_session_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     xsim_log = sub.add_parser(
         "xsim-log",
         help="Parse an existing xsim-style log file into diagnostics-like output.",
@@ -1265,6 +1318,34 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_refactor_checklist_summary_text(checklist))
+        return 0
+
+    if args.command == "refactor-session":
+        from .module_organization import (
+            build_refactor_session_status,
+            format_refactor_session_status_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        session = build_refactor_session_status(
+            str(args.path),
+            args.path,
+            args.action,
+            args.module,
+            new_name=args.new_name,
+            port_name=args.port_name,
+            direction=args.direction,
+            width=args.width,
+            destination=args.destination,
+        )
+        if args.format == "json":
+            json.dump(session, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_refactor_session_status_text(session))
         return 0
 
     if args.command == "xsim-log":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -229,6 +229,21 @@ CHECKLIST_SUMMARY_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+REFACTOR_SESSION_LIMITATIONS: tuple[str, ...] = (
+    "summary-only refactor session status metadata",
+    "summarizes the existing refactor checklist for editor status panes",
+    "does not include command argv; use validation-plan for command descriptors",
+    "does not persist session state, write status files, or dispatch notifications",
+    "does not record approval, accept application requests, or apply refactors",
+    "does not execute validation commands or shell commands",
+    "does not apply refactors, write files, move files, generate patches, "
+    "or roll back files",
+    "does not publish public text, create pull requests, write comments, "
+    "or mutate projects",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 _REFACTOR_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
     "rename-module": ("new_name",),
     "extract-port": ("port_name", "direction"),
@@ -515,6 +530,41 @@ def _checklist_summary_safety_flags() -> dict[str, bool]:
         "approval_granted": False,
         "request_accepted": False,
         "write_attempted": False,
+        "summarizes_command_descriptors": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "rollback_required": False,
+        "public_text_published": False,
+        "pull_request_created": False,
+        "comment_written": False,
+        "project_mutation": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _refactor_session_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "session_status_only": True,
+        "checklist_summary_only": True,
+        "approval_granted": False,
+        "request_accepted": False,
+        "write_attempted": False,
+        "session_persistence": False,
+        "status_writeback": False,
+        "notification_dispatched": False,
         "summarizes_command_descriptors": True,
         "emits_command_descriptors": False,
         "writes_files": False,
@@ -2649,6 +2699,107 @@ def build_refactor_checklist_summary(
     }
 
 
+def _refactor_session_items(checklist: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {
+            "complete": item["complete"],
+            "item_id": item["item_id"],
+            "required": item["required"],
+            "status": item["status"],
+            "summary": item["summary"],
+        }
+        for item in checklist["checklist_items"]
+    ]
+
+
+def build_refactor_session_status(
+    source: str,
+    path: Path,
+    action: str,
+    module_name: str,
+    *,
+    new_name: str | None = None,
+    port_name: str | None = None,
+    direction: str | None = None,
+    width: str | None = None,
+    destination: str | None = None,
+) -> dict[str, Any]:
+    checklist = build_refactor_checklist_summary(
+        source,
+        path,
+        action,
+        module_name,
+        new_name=new_name,
+        port_name=port_name,
+        direction=direction,
+        width=width,
+        destination=destination,
+    )
+    items = _refactor_session_items(checklist)
+    required_items = [item for item in items if item["required"]]
+    incomplete_required = [
+        item for item in required_items if not item["complete"]
+    ]
+    preflight_status = checklist["preflight"]["status"]
+    session_state = checklist["checklist_state"]
+    current_stage = (
+        "preflight-blocked"
+        if session_state == "blocked"
+        else "maintainer-review"
+    )
+    next_required_action = (
+        "resolve refactor preflight blockers before session review"
+        if session_state == "blocked"
+        else "review checklist items before approval or application"
+    )
+
+    return {
+        "action": action,
+        "blocked_actions": [
+            *checklist["blocked_actions"],
+            "session-persistence",
+            "status-writeback",
+            "notification-dispatch",
+        ],
+        "current_stage": current_stage,
+        "kind": "module-refactor-session-status",
+        "limitations": list(REFACTOR_SESSION_LIMITATIONS),
+        "module": checklist["module"],
+        "next_required_action": next_required_action,
+        "preflight": {
+            "reasons": list(checklist["preflight"]["reasons"]),
+            "requires_approval_before_write": checklist["preflight"][
+                "requires_approval_before_write"
+            ],
+            "requires_explicit_approval_before_run": True,
+            "status": preflight_status,
+        },
+        "result_summary": dict(checklist["result_summary"]),
+        "safety": _refactor_session_safety_flags(),
+        "scanner": "line-scanner",
+        "session_items": items,
+        "session_state": session_state,
+        "session_summary": {
+            "checklist_kind": checklist["kind"],
+            "checklist_state": checklist["checklist_state"],
+            "complete_required_count": (
+                len(required_items) - len(incomplete_required)
+            ),
+            "incomplete_required_count": len(incomplete_required),
+            "item_count": len(items),
+            "ready_for_maintainer_review": checklist["handoff_summary"][
+                "ready_for_maintainer_review"
+            ],
+            "required_item_count": len(required_items),
+            "result_state": checklist["handoff_summary"]["result_state"],
+        },
+        "source": source,
+        "target": module_name,
+        "tool": "pccx-ide-cli",
+        "writes_files": False,
+    }
+
+
 def format_refactor_proposal_text(proposal: dict[str, Any]) -> str:
     lines = [
         f"source: {proposal['source']}",
@@ -2931,6 +3082,50 @@ def format_refactor_checklist_summary_text(checklist: dict[str, Any]) -> str:
         "application accept, validation, shell, refactor, patch, file write, "
         "rollback, public text, pull request, comment, project mutation, lab, "
         "launcher, vendor tool, provider, or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_refactor_session_status_text(session: dict[str, Any]) -> str:
+    summary = session["session_summary"]
+    result = session["result_summary"]
+    ready = "yes" if summary["ready_for_maintainer_review"] else "no"
+    lines = [
+        f"source: {session['source']}",
+        f"target: {session['target']}",
+        f"action: {session['action']}",
+        f"refactor session: {session['session_state']}",
+        f"current stage: {session['current_stage']}",
+        f"checklist: {summary['checklist_state']}",
+        f"ready for maintainer review: {ready}",
+        f"required complete: {summary['complete_required_count']}/"
+        f"{summary['required_item_count']}",
+        "write attempted: no",
+        "patch generated: no",
+        "files changed: 0",
+        "validation run: no",
+        "rollback required: no",
+        f"approval decision: {result['approval_decision_state']}",
+        f"application result: {result['application_result']}",
+        f"preflight: {session['preflight']['status']}",
+        "writes files: no",
+        "runs validation: no",
+        f"validation descriptors: {result['command_descriptor_count']}",
+    ]
+    for item in session["session_items"]:
+        lines.append(
+            f"session item: {item['item_id']} ({item['status']}): "
+            f"{item['summary']}"
+        )
+    for reason in session["preflight"]["reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"next step: {session['next_required_action']}")
+    lines.append(
+        "summary-only session status: no command argv, approval grant, "
+        "application accept, validation, shell, refactor, patch, file write, "
+        "rollback, status writeback, notification dispatch, public text, "
+        "pull request, comment, project mutation, lab, launcher, vendor tool, "
+        "provider, or hardware execution"
     )
     return "\n".join(lines) + "\n"
 

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -32,12 +32,14 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_refactor_impact_view,
     build_refactor_proposal,
     build_refactor_review_packet,
+    build_refactor_session_status,
     build_refactor_validation_plan,
     format_refactor_approval_decision_text,
     format_refactor_application_result_text,
     format_refactor_application_request_text,
     format_refactor_checklist_summary_text,
     format_refactor_handoff_summary_text,
+    format_refactor_session_status_text,
     format_module_dependency_text,
     format_module_context_text,
     format_module_hierarchy_text,
@@ -923,6 +925,87 @@ def test_build_refactor_checklist_summary_reports_blocked_preflight():
     assert items["validation-plan-review"]["status"] == "blocked-by-preflight"
 
 
+def test_build_refactor_session_status_summarizes_checklist_only():
+    session = build_refactor_session_status(
+        str(FIXTURE),
+        FIXTURE,
+        "rename-module",
+        "leaf_mod",
+        new_name="leaf_mod_next",
+    )
+
+    assert session["kind"] == "module-refactor-session-status"
+    assert session["session_state"] == "ready-for-review"
+    assert session["current_stage"] == "maintainer-review"
+    assert session["next_required_action"] == (
+        "review checklist items before approval or application"
+    )
+    assert session["session_summary"]["checklist_kind"] == (
+        "module-refactor-checklist-summary"
+    )
+    assert session["session_summary"]["ready_for_maintainer_review"] is True
+    assert session["session_summary"]["required_item_count"] == 6
+    assert session["session_summary"]["complete_required_count"] == 1
+    assert session["session_summary"]["incomplete_required_count"] == 5
+    assert session["result_summary"]["application_result"] == "not_applied"
+    assert session["result_summary"]["write_attempted"] is False
+    assert session["result_summary"]["patch_generated"] is False
+    assert session["result_summary"]["validation_run"] is False
+    assert [item["item_id"] for item in session["session_items"]] == [
+        "preflight",
+        "context-review",
+        "validation-plan-review",
+        "approval-gate",
+        "application-gate",
+        "handoff-review",
+    ]
+    assert "session-persistence" in session["blocked_actions"]
+    assert "status-writeback" in session["blocked_actions"]
+    assert "notification-dispatch" in session["blocked_actions"]
+    assert session["safety"]["read_only"] is True
+    assert session["safety"]["session_status_only"] is True
+    assert session["safety"]["session_persistence"] is False
+    assert session["safety"]["status_writeback"] is False
+    assert session["safety"]["notification_dispatched"] is False
+    assert session["safety"]["approval_granted"] is False
+    assert session["safety"]["request_accepted"] is False
+    assert session["safety"]["writes_files"] is False
+    assert session["safety"]["generates_patch"] is False
+    assert session["safety"]["runs_validation"] is False
+    assert session["safety"]["runs_shell"] is False
+    assert session["safety"]["public_text_published"] is False
+    assert session["safety"]["pull_request_created"] is False
+    assert session["safety"]["comment_written"] is False
+    assert session["safety"]["project_mutation"] is False
+    assert session["safety"]["invokes_pccx_lab"] is False
+    assert session["safety"]["invokes_launcher"] is False
+    assert session["safety"]["hardware_access"] is False
+    assert '"argv"' not in json.dumps(session)
+
+
+def test_build_refactor_session_status_reports_blocked_preflight():
+    session = build_refactor_session_status(
+        str(FIXTURE),
+        FIXTURE,
+        "extract-port",
+        "top_mod",
+        port_name="valid_i",
+    )
+
+    assert session["session_state"] == "blocked"
+    assert session["current_stage"] == "preflight-blocked"
+    assert session["next_required_action"] == (
+        "resolve refactor preflight blockers before session review"
+    )
+    assert session["session_summary"]["ready_for_maintainer_review"] is False
+    assert "missing required direction" in session["preflight"]["reasons"]
+    items = {item["item_id"]: item for item in session["session_items"]}
+    assert items["preflight"]["status"] == "blocked"
+    assert items["preflight"]["complete"] is False
+    assert items["context-review"]["status"] == "blocked-by-preflight"
+    assert items["validation-plan-review"]["status"] == "blocked-by-preflight"
+
+
 def test_format_module_organization_text_mentions_boundary_and_hierarchy():
     export = build_module_organization_export(str(FIXTURE), FIXTURE)
     text = format_module_organization_text(export)
@@ -1729,6 +1812,66 @@ def test_cli_refactor_checklist_text():
     assert "summary-only checklist: no command argv" in result.stdout
 
 
+def test_cli_refactor_session_json():
+    result = _run_cli(
+        "refactor-session",
+        str(FIXTURE),
+        "--action",
+        "rename-module",
+        "--module",
+        "leaf_mod",
+        "--new-name",
+        "leaf_mod_next",
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-refactor-session-status"
+    assert payload["session_state"] == "ready-for-review"
+    assert payload["current_stage"] == "maintainer-review"
+    assert payload["session_summary"]["ready_for_maintainer_review"] is True
+    assert payload["session_summary"]["incomplete_required_count"] == 5
+    assert payload["result_summary"]["application_result"] == "not_applied"
+    assert payload["result_summary"]["write_attempted"] is False
+    assert payload["result_summary"]["patch_generated"] is False
+    assert payload["result_summary"]["validation_run"] is False
+    assert payload["safety"]["session_status_only"] is True
+    assert payload["safety"]["session_persistence"] is False
+    assert payload["safety"]["status_writeback"] is False
+    assert payload["safety"]["notification_dispatched"] is False
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["generates_patch"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert payload["safety"]["runs_shell"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_refactor_session_text():
+    result = _run_cli(
+        "refactor-session",
+        str(FIXTURE),
+        "--action",
+        "extract-port",
+        "--module",
+        "top_mod",
+        "--port-name",
+        "valid_i",
+        "--format",
+        "text",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "refactor session: blocked" in result.stdout
+    assert "current stage: preflight-blocked" in result.stdout
+    assert "ready for maintainer review: no" in result.stdout
+    assert "validation run: no" in result.stdout
+    assert "approval decision: blocked" in result.stdout
+    assert "application result: not_applied" in result.stdout
+    assert "session item: preflight (blocked)" in result.stdout
+    assert "blocked: missing required direction" in result.stdout
+    assert "summary-only session status: no command argv" in result.stdout
+
+
 def test_cli_organization_missing_path_exits_nonzero():
     result = _run_cli("organization", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
@@ -1891,6 +2034,21 @@ def test_cli_refactor_checklist_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_refactor_session_missing_path_exits_nonzero():
+    result = _run_cli(
+        "refactor-session",
+        str(FIXTURE.parent / "missing.sv"),
+        "--action",
+        "rename-module",
+        "--module",
+        "leaf_mod",
+        "--new-name",
+        "leaf_mod_next",
+    )
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_docs_cover_organization_flow_and_limits():
     contract = CONTRACT_DOC.read_text(encoding="utf-8")
     workflow = WORKFLOW_DOC.read_text(encoding="utf-8")
@@ -1908,6 +2066,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "refactor-result <path>" in contract
     assert "refactor-handoff <path>" in contract
     assert "refactor-checklist <path>" in contract
+    assert "refactor-session <path>" in contract
     assert "MODULE_ORGANIZATION_WORKFLOW.md" in contract
     assert "proposal-only" in workflow
     assert "module-hierarchy-view" in workflow
@@ -1923,6 +2082,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-refactor-application-result" in workflow
     assert "module-refactor-handoff-summary" in workflow
     assert "module-refactor-checklist-summary" in workflow
+    assert "module-refactor-session-status" in workflow
     assert "proposed-not-run" in workflow
     assert "summary-only review packet" in workflow
     assert "approval decision metadata" in workflow
@@ -1930,5 +2090,6 @@ def test_docs_cover_organization_flow_and_limits():
     assert "application result metadata" in workflow
     assert "refactor handoff metadata" in workflow
     assert "refactor checklist metadata" in workflow
+    assert "refactor session status metadata" in workflow
     assert "does not write files" in workflow
     assert "not a full SystemVerilog parser" in workflow


### PR DESCRIPTION
Summary:
- Add summary-only refactor-session status over the existing refactor checklist boundary.
- Wire CLI JSON/text output for current stage, checklist counts, incomplete required items, and next required action.
- Document the new surface in README, editor bridge contract, and module organization workflow docs with test coverage.

Validation:
- python3 -m py_compile src/pccx_ide_cli/module_organization.py src/pccx_ide_cli/cli.py tests/test_module_organization.py
- PYTHONPATH=src python3 -m pccx_ide_cli refactor-session fixtures/organization/hierarchy_top.sv --action rename-module --module leaf_mod --new-name leaf_mod_next --format json
- PYTHONPATH=src python3 -m pccx_ide_cli refactor-session fixtures/organization/hierarchy_top.sv --action extract-port --module top_mod --port-name valid_i --format text
- PYTHONPATH=src python3 -m pytest tests/test_module_organization.py -q
- PYTHONPATH=src python3 -m pytest -q
- bash -n scripts/check-editor-bridge-examples.sh scripts/editor-bridge-smoke.sh scripts/vscode-adapter-smoke.sh scripts/vscode-extension-host-smoke.sh
- python3 scripts/check-source-headers.py
- bash scripts/check-editor-bridge-examples.sh
- bash scripts/editor-bridge-smoke.sh
- bash scripts/vscode-adapter-smoke.sh
- local claim scan clean
- git diff --check
- git diff --cached --check

Refs #8