### PR TITLE
Add module boundary audit surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,13 @@ jobs:
               fixtures/organization/hierarchy_top.sv \
               | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-summary-view'; assert d['safety']['writes_files'] is False"
           echo "module summary smoke ok"
+      - name: cli smoke (boundary audit exits zero)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli boundary-audit \
+              fixtures/organization/hierarchy_top.sv \
+              | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-boundary-audit'; assert d['safety']['writes_files'] is False"
+          echo "boundary audit smoke ok"
       - name: cli smoke (module context exits zero)
         run: |
           set -e

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -45,6 +45,7 @@ python -m pccx_ide_cli locate <path> <name> --kind any --format json
 
 # Module organization for editor project trees
 python -m pccx_ide_cli organization <path> --format json
+python -m pccx_ide_cli boundary-audit <path> --format json
 python -m pccx_ide_cli hierarchy <path> --format json
 python -m pccx_ide_cli dependencies <path> --format json
 python -m pccx_ide_cli module-summary <path> --format json
@@ -197,11 +198,16 @@ declaration records.  `declarations` exports those records directly, and
 `locate` resolves exact declaration names by requested kind. `organization`
 adds scanner-based module boundary spans, hierarchy edges, root candidates,
 and proposal-only refactoring metadata for project tree and reviewed
-refactoring workflows. `hierarchy`, `dependencies`, `module-summary`,
-`port-usage`, `module-context`, and `refactor-impact` render focused
-read-only views from the same scanner data, including conservative module
-header/port summaries, target port usage summaries, target module context
-bundles, and target-specific refactor impact review data. The
+refactoring workflows. `boundary-audit` emits read-only module boundary
+completeness and refactor-readiness audit data from the same scanner output;
+it does not write files, apply refactors, generate patches, run validation,
+invoke pccx-lab or the launcher, run vendor tools, call providers, touch
+hardware, or perform automatic repository actions. `hierarchy`,
+`dependencies`, `module-summary`, `port-usage`, `module-context`, and
+`refactor-impact` render focused read-only views from the same scanner data,
+including conservative module header/port summaries, target port usage
+summaries, target module context bundles, and target-specific refactor impact
+review data. The
 organization surface is documented in
 [`MODULE_ORGANIZATION_WORKFLOW.md`](./MODULE_ORGANIZATION_WORKFLOW.md).
 `refactor-plan` extends the same boundary with proposal-only
@@ -279,9 +285,9 @@ xsim path, and text surface sketches is documented in
 ## Limitations
 
 - Scanner-based scaffolds, not full SystemVerilog parsing.
-- Module organization, header/port summaries, port usage summaries,
-  refactor impact review, refactor planning, and validation planning are
-  scanner-based; refactor review packets, approval decisions, application
+- Module organization, boundary audits, header/port summaries, port usage
+  summaries, refactor impact review, refactor planning, and validation planning
+  are scanner-based; refactor review packets, approval decisions, application
   requests, application results, handoff summaries, and checklists are summary-only
   metadata over those
   surfaces. They are not semantic elaboration and do not apply refactors or

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -4,18 +4,18 @@
 
 This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
-`module-summary`, `port-usage`, `module-context`, `refactor-impact`,
-`validation-plan`, `refactor-review`, `refactor-approval`,
+`module-summary`, `boundary-audit`, `port-usage`, `module-context`,
+`refactor-impact`, `validation-plan`, `refactor-review`, `refactor-approval`,
 `refactor-application`, `refactor-result`, `refactor-handoff`,
 `refactor-checklist`, and `refactor-session` CLI surfaces
 that report module boundary spans, scanner-based hierarchy data, direct
 dependency impact data, conservative module header/port summaries, target port
 usage summaries, target module context bundles, target-specific refactor impact
-data, proposal-only validation command descriptors, a summary-only review
-packet, approval decision metadata, application request metadata, and
-application result metadata plus refactor handoff metadata, refactor checklist
-metadata, and refactor session status metadata for editor navigation and
-reviewed refactoring planning.
+data, boundary audit data, proposal-only validation command descriptors, a
+summary-only review packet, approval decision metadata, application request
+metadata, and application result metadata plus refactor handoff metadata,
+refactor checklist metadata, and refactor session status metadata for editor
+navigation and reviewed refactoring planning.
 
 It is not a full SystemVerilog parser, not semantic elaboration, not an LSP
 implementation, and not a write-capable refactoring engine.
@@ -31,6 +31,8 @@ python -m pccx_ide_cli dependencies <path> --format json
 python -m pccx_ide_cli dependencies <path> --format text
 python -m pccx_ide_cli module-summary <path> --format json
 python -m pccx_ide_cli module-summary <path> --format text
+python -m pccx_ide_cli boundary-audit <path> --format json
+python -m pccx_ide_cli boundary-audit <path> --format text
 python -m pccx_ide_cli port-usage <path> --module <name> --format json
 python -m pccx_ide_cli port-usage <path> --module <name> --format text
 python -m pccx_ide_cli module-context <path> --module <name> --format json
@@ -203,6 +205,39 @@ The module summary view is display data only. It does not write files,
 apply refactors, generate patches, run validation, execute shell
 commands, invoke `pccx-lab`, invoke the launcher, call providers, touch
 hardware, upload telemetry, or perform automatic repository actions.
+
+The boundary audit view reports scanner-detected module boundary
+completeness and whether those boundaries are ready for reviewed
+refactor planning:
+
+```json
+{
+  "kind": "module-boundary-audit",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "audit_state": "available_as_data",
+  "refactor_readiness": "ready-for-review",
+  "module_count": 2,
+  "complete_module_count": 2,
+  "incomplete_module_count": 0,
+  "modules": [],
+  "blocked_reasons": [],
+  "writes_files": false,
+  "safety": {
+    "read_only": true,
+    "boundary_audit_only": true,
+    "writes_files": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The boundary audit is status data only. It does not write files, apply
+refactors, generate patches, run validation, execute shell commands,
+invoke `pccx-lab`, invoke the launcher, run vendor tools, call providers,
+touch hardware, upload telemetry, or perform automatic repository actions.
 
 The port usage view reports a target module's conservative port
 declarations and scanner-detected dependent instantiation usage sites:

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -136,6 +136,25 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    boundary_audit_cmd = sub.add_parser(
+        "boundary-audit",
+        help=(
+            "Emit read-only scanner-based module boundary completeness "
+            "and refactor-readiness audit data."
+        ),
+    )
+    boundary_audit_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    boundary_audit_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     hierarchy_cmd = sub.add_parser(
         "hierarchy",
         help=(
@@ -986,6 +1005,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_organization_text(export))
+        return 0
+
+    if args.command == "boundary-audit":
+        from .module_organization import (
+            build_module_boundary_audit,
+            format_module_boundary_audit_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        audit = build_module_boundary_audit(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(audit, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_boundary_audit_text(audit))
         return 0
 
     if args.command == "hierarchy":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -78,6 +78,15 @@ LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+MODULE_BOUNDARY_AUDIT_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based module boundary audit data only",
+    "uses declaration spans and endmodule matching from the organization scanner",
+    "does not semantically elaborate modules or resolve generate blocks",
+    "does not apply refactors, write files, generate patches, or run validation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 HIERARCHY_VIEW_LIMITATIONS: tuple[str, ...] = (
     "scanner-based hierarchy visualization data only",
     "single-line instantiation candidates only",
@@ -264,6 +273,27 @@ def _refactor_safety_flags() -> dict[str, bool]:
         "runs_shell": False,
         "invokes_pccx_lab": False,
         "invokes_launcher": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _module_boundary_audit_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "boundary_audit_only": True,
+        "writes_files": False,
+        "applies_refactor": False,
+        "moves_files": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
         "provider_calls": False,
         "hardware_access": False,
         "telemetry": False,
@@ -753,6 +783,85 @@ def build_module_organization_export(
         "scanner": "line-scanner",
         "source": source,
         "tool": "pccx-ide-cli",
+    }
+
+
+def _boundary_audit_rows(
+    modules: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for module in modules:
+        reasons = []
+        if not module["complete"]:
+            reasons.append(f"missing endmodule for module: {module['name']}")
+        rows.append({
+            "boundary_state": "complete" if module["complete"] else "incomplete",
+            "complete": module["complete"],
+            "end_column": module["end_column"],
+            "end_line": module["end_line"],
+            "file": module["file"],
+            "name": module["name"],
+            "reasons": reasons,
+            "refactor_preflight_state": (
+                "ready-for-review" if module["complete"] else "blocked"
+            ),
+            "span_lines": module["span_lines"],
+            "start_column": module["start_column"],
+            "start_line": module["start_line"],
+        })
+    return rows
+
+
+def build_module_boundary_audit(source: str, path: Path) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    rows = _boundary_audit_rows(organization["modules"])
+    incomplete_rows = [
+        row
+        for row in rows
+        if not row["complete"]
+    ]
+    blocked_reasons = [
+        reason
+        for row in incomplete_rows
+        for reason in row["reasons"]
+    ]
+    if not rows:
+        blocked_reasons.append("no module declarations detected")
+
+    return {
+        "audit_state": "available_as_data",
+        "blocked_reasons": blocked_reasons,
+        "boundary_state_counts": {
+            "complete": len(rows) - len(incomplete_rows),
+            "incomplete": len(incomplete_rows),
+        },
+        "complete_module_count": len(rows) - len(incomplete_rows),
+        "hierarchy_edge_count": len(organization["hierarchy"]["edges"]),
+        "incomplete_module_count": len(incomplete_rows),
+        "incomplete_modules": [
+            {
+                "file": row["file"],
+                "name": row["name"],
+                "reasons": list(row["reasons"]),
+                "start_line": row["start_line"],
+            }
+            for row in incomplete_rows
+        ],
+        "kind": "module-boundary-audit",
+        "limitations": list(MODULE_BOUNDARY_AUDIT_LIMITATIONS),
+        "module_count": len(rows),
+        "modules": rows,
+        "refactor_readiness": (
+            "ready-for-review"
+            if rows and not incomplete_rows
+            else "blocked"
+        ),
+        "safety": _module_boundary_audit_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "tool": "pccx-ide-cli",
+        "unresolved_dependency_count": len(organization["hierarchy"]["unresolved"]),
+        "writes_files": False,
     }
 
 
@@ -3165,6 +3274,49 @@ def format_module_organization_text(export: dict[str, Any]) -> str:
     if hierarchy["unresolved"]:
         lines.append(f"unresolved: {', '.join(hierarchy['unresolved'])}")
     lines.append("refactoring: proposal-only, no file writes")
+    return "\n".join(lines) + "\n"
+
+
+def format_module_boundary_audit_text(audit: dict[str, Any]) -> str:
+    lines = [
+        f"source: {audit['source']}",
+        f"boundary audit: {audit['audit_state']}",
+        f"refactor readiness: {audit['refactor_readiness']}",
+        "writes files: no",
+        (
+            f"{audit['module_count']} module"
+            f"{'s' if audit['module_count'] != 1 else ''}; "
+            f"{audit['complete_module_count']} complete; "
+            f"{audit['incomplete_module_count']} incomplete"
+        ),
+        (
+            f"{audit['hierarchy_edge_count']} hierarchy edge"
+            f"{'s' if audit['hierarchy_edge_count'] != 1 else ''}; "
+            f"{audit['unresolved_dependency_count']} unresolved"
+        ),
+    ]
+    if not audit["modules"]:
+        lines.append("modules: none")
+    for module in audit["modules"]:
+        end = (
+            f"{module['end_line']}:{module['end_column']}"
+            if module["complete"]
+            else "missing"
+        )
+        lines.append(
+            f"{module['file']}:{module['start_line']}:"
+            f"{module['start_column']}-{end}: module {module['name']} "
+            f"({module['boundary_state']}; "
+            f"{module['refactor_preflight_state']})"
+        )
+        for reason in module["reasons"]:
+            lines.append(f"  blocked: {reason}")
+    for reason in audit["blocked_reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(
+        "read-only: no file writes, refactors, validation, shell, lab, "
+        "launcher, vendor tool, provider, or hardware execution"
+    )
     return "\n".join(lines) + "\n"
 
 

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -12,6 +12,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SRC = REPO_ROOT / "src"
 FIXTURE = REPO_ROOT / "fixtures" / "organization" / "hierarchy_top.sv"
+INCOMPLETE_FIXTURE = REPO_ROOT / "fixtures" / "missing_endmodule.sv"
 CONTRACT_DOC = REPO_ROOT / "docs" / "EDITOR_BRIDGE_CONTRACT.md"
 WORKFLOW_DOC = REPO_ROOT / "docs" / "MODULE_ORGANIZATION_WORKFLOW.md"
 
@@ -19,6 +20,7 @@ sys.path.insert(0, str(SRC))
 
 from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_dependency_view,
+    build_module_boundary_audit,
     build_module_context_bundle,
     build_module_hierarchy_view,
     build_module_organization_export,
@@ -40,6 +42,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_refactor_checklist_summary_text,
     format_refactor_handoff_summary_text,
     format_refactor_session_status_text,
+    format_module_boundary_audit_text,
     format_module_dependency_text,
     format_module_context_text,
     format_module_hierarchy_text,
@@ -99,6 +102,65 @@ def test_build_module_organization_export_hierarchy_seed():
             "resolved": True,
         }
     ]
+
+
+def test_build_module_boundary_audit_reports_complete_boundaries():
+    audit = build_module_boundary_audit(str(FIXTURE), FIXTURE)
+
+    assert audit["kind"] == "module-boundary-audit"
+    assert audit["audit_state"] == "available_as_data"
+    assert audit["refactor_readiness"] == "ready-for-review"
+    assert audit["module_count"] == 2
+    assert audit["complete_module_count"] == 2
+    assert audit["incomplete_module_count"] == 0
+    assert audit["blocked_reasons"] == []
+    assert audit["boundary_state_counts"] == {
+        "complete": 2,
+        "incomplete": 0,
+    }
+    assert [row["name"] for row in audit["modules"]] == ["leaf_mod", "top_mod"]
+    assert all(row["boundary_state"] == "complete" for row in audit["modules"])
+    assert all(
+        row["refactor_preflight_state"] == "ready-for-review"
+        for row in audit["modules"]
+    )
+    assert audit["safety"]["read_only"] is True
+    assert audit["safety"]["boundary_audit_only"] is True
+    assert audit["safety"]["writes_files"] is False
+    assert audit["safety"]["applies_refactor"] is False
+    assert audit["safety"]["generates_patch"] is False
+    assert audit["safety"]["runs_validation"] is False
+    assert audit["safety"]["runs_shell"] is False
+    assert audit["safety"]["invokes_pccx_lab"] is False
+    assert audit["safety"]["invokes_launcher"] is False
+    assert audit["safety"]["invokes_vendor_tools"] is False
+    assert audit["safety"]["provider_calls"] is False
+    assert audit["safety"]["hardware_access"] is False
+    assert audit["writes_files"] is False
+
+
+def test_build_module_boundary_audit_blocks_incomplete_boundaries():
+    audit = build_module_boundary_audit(str(INCOMPLETE_FIXTURE), INCOMPLETE_FIXTURE)
+
+    assert audit["refactor_readiness"] == "blocked"
+    assert audit["module_count"] == 1
+    assert audit["complete_module_count"] == 0
+    assert audit["incomplete_module_count"] == 1
+    assert audit["incomplete_modules"] == [
+        {
+            "file": str(INCOMPLETE_FIXTURE),
+            "name": "bad_module",
+            "reasons": ["missing endmodule for module: bad_module"],
+            "start_line": 1,
+        }
+    ]
+    assert audit["modules"][0]["boundary_state"] == "incomplete"
+    assert audit["modules"][0]["refactor_preflight_state"] == "blocked"
+    assert audit["modules"][0]["end_line"] is None
+    assert audit["blocked_reasons"] == [
+        "missing endmodule for module: bad_module"
+    ]
+    assert audit["writes_files"] is False
 
 
 def test_build_module_hierarchy_view_tree_is_read_only():
@@ -1015,6 +1077,19 @@ def test_format_module_organization_text_mentions_boundary_and_hierarchy():
     assert "refactoring: proposal-only, no file writes" in text
 
 
+def test_format_module_boundary_audit_text_mentions_read_only_gate():
+    audit = build_module_boundary_audit(str(INCOMPLETE_FIXTURE), INCOMPLETE_FIXTURE)
+    text = format_module_boundary_audit_text(audit)
+
+    assert "boundary audit: available_as_data" in text
+    assert "refactor readiness: blocked" in text
+    assert "writes files: no" in text
+    assert "1 module; 0 complete; 1 incomplete" in text
+    assert "module bad_module (incomplete; blocked)" in text
+    assert "blocked: missing endmodule for module: bad_module" in text
+    assert "read-only: no file writes" in text
+
+
 def test_format_module_hierarchy_text_mentions_tree_and_boundary():
     view = build_module_hierarchy_view(str(FIXTURE), FIXTURE)
     text = format_module_hierarchy_text(view)
@@ -1273,6 +1348,33 @@ def test_cli_organization_text():
     assert "source:" in result.stdout
     assert "2 modules" in result.stdout
     assert "1 hierarchy edge" in result.stdout
+
+
+def test_cli_boundary_audit_json():
+    result = _run_cli("boundary-audit", str(FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-boundary-audit"
+    assert payload["refactor_readiness"] == "ready-for-review"
+    assert payload["complete_module_count"] == 2
+    assert payload["incomplete_module_count"] == 0
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["runs_validation"] is False
+
+
+def test_cli_boundary_audit_text():
+    result = _run_cli(
+        "boundary-audit",
+        str(INCOMPLETE_FIXTURE),
+        "--format",
+        "text",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "boundary audit: available_as_data" in result.stdout
+    assert "refactor readiness: blocked" in result.stdout
+    assert "module bad_module (incomplete; blocked)" in result.stdout
+    assert "blocked: missing endmodule for module: bad_module" in result.stdout
+    assert "read-only: no file writes" in result.stdout
 
 
 def test_cli_hierarchy_json():
@@ -1878,6 +1980,12 @@ def test_cli_organization_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_boundary_audit_missing_path_exits_nonzero():
+    result = _run_cli("boundary-audit", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_cli_hierarchy_missing_path_exits_nonzero():
     result = _run_cli("hierarchy", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
@@ -2053,6 +2161,7 @@ def test_docs_cover_organization_flow_and_limits():
     contract = CONTRACT_DOC.read_text(encoding="utf-8")
     workflow = WORKFLOW_DOC.read_text(encoding="utf-8")
     assert "organization <path>" in contract
+    assert "boundary-audit <path>" in contract
     assert "hierarchy <path>" in contract
     assert "dependencies <path>" in contract
     assert "module-summary <path>" in contract
@@ -2069,6 +2178,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "refactor-session <path>" in contract
     assert "MODULE_ORGANIZATION_WORKFLOW.md" in contract
     assert "proposal-only" in workflow
+    assert "module-boundary-audit" in workflow
     assert "module-hierarchy-view" in workflow
     assert "module-dependency-view" in workflow
     assert "module-summary-view" in workflow
@@ -2091,5 +2201,6 @@ def test_docs_cover_organization_flow_and_limits():
     assert "refactor handoff metadata" in workflow
     assert "refactor checklist metadata" in workflow
     assert "refactor session status metadata" in workflow
+    assert "boundary audit data" in workflow
     assert "does not write files" in workflow
     assert "not a full SystemVerilog parser" in workflow


### PR DESCRIPTION
## Summary

Refs #8.

- add a read-only `boundary-audit` CLI surface for scanner-detected module boundary completeness and refactor readiness
- report complete/incomplete boundary counts, incomplete module reasons, and conservative safety flags without write-capable behavior
- document the new surface and add CI smoke plus focused unit/CLI coverage

## Validation

- `python3 -m py_compile src/pccx_ide_cli/module_organization.py src/pccx_ide_cli/cli.py`
- `python3 -m pytest tests/test_module_organization.py -q`
- `python3 -m pytest -q`
- `PYTHONPATH=src python3 -m pccx_ide_cli boundary-audit fixtures/organization/hierarchy_top.sv --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli boundary-audit fixtures/missing_endmodule.sv --format text`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `find scripts -type f -name "*.sh" -print0 | xargs -0 bash -n`
- `git diff --check`
- `git diff --cached --check`
- local forbidden-claim scan equivalent

## Boundary

This remains scanner-based status data only. It does not apply refactors, write files, generate patches, run validation, execute shell commands, invoke pccx-lab or the launcher, run vendor tools, call providers, touch hardware, or perform automatic repository actions.