### PR TITLE
Add refactor candidate list surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,13 @@ jobs:
               fixtures/organization/hierarchy_top.sv \
               | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-boundary-audit'; assert d['safety']['writes_files'] is False"
           echo "boundary audit smoke ok"
+      - name: cli smoke (refactor candidates exits zero)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli refactor-candidates \
+              fixtures/organization/hierarchy_top.sv \
+              | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-refactor-candidate-list'; assert d['safety']['writes_files'] is False; assert d['safety']['emits_command_descriptors'] is False"
+          echo "refactor candidates smoke ok"
       - name: cli smoke (module context exits zero)
         run: |
           set -e

--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ python -m pccx_ide_cli dependencies fixtures/organization/hierarchy_top.sv --for
 python -m pccx_ide_cli module-summary fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli module-summary fixtures/organization/hierarchy_top.sv --format text
 
+# Module boundary audit and refactor candidate list (pre-stable, read-only)
+python -m pccx_ide_cli boundary-audit fixtures/organization/hierarchy_top.sv --format json
+python -m pccx_ide_cli refactor-candidates fixtures/organization/hierarchy_top.sv --format text
+
 # Target port usage view (pre-stable, read-only)
 python -m pccx_ide_cli port-usage fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
 python -m pccx_ide_cli port-usage fixtures/organization/hierarchy_top.sv --module leaf_mod --format text
@@ -214,8 +218,10 @@ for editor sidebars and reviewed refactoring planning. `port-usage`
 renders target port declarations with scanner-detected dependent
 instantiation connection summaries. `module-context` bundles target
 summary, dependency, port-usage, and refactor-impact review data for
-editor context panes. `refactor-impact` renders target-specific
-declaration, dependent, and dependency review data for a named module.
+editor context panes. `refactor-candidates` lists scanner-detected
+modules and proposal-only helper action metadata for editor action
+menus. `refactor-impact` renders target-specific declaration,
+dependent, and dependency review data for a named module.
 These commands do not edit files, apply
 refactors, execute validation, run vendor tools, invoke `pccx-lab` or the
 launcher, or implement semantic elaboration. The output shapes are
@@ -280,8 +286,9 @@ surfaces, external editor planning, and later workflow tracks lives in
 [`docs/ROADMAP.md`](./docs/ROADMAP.md).
 The scanner-based module organization workflow for module boundaries,
 hierarchy views, dependency views, module header/port summaries, and
-target-specific refactor impact review data plus proposal-only
-refactoring planning, including the target module context bundle, is documented in
+target-specific refactor candidate and impact review data plus
+proposal-only refactoring planning, including the target module context
+bundle, is documented in
 [`docs/MODULE_ORGANIZATION_WORKFLOW.md`](./docs/MODULE_ORGANIZATION_WORKFLOW.md).
 The planned SystemVerilog workflow boundary, permission boundary, and
 pccx-lab controlled tool dependency are documented in

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -4,18 +4,19 @@
 
 This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
-`module-summary`, `boundary-audit`, `port-usage`, `module-context`,
-`refactor-impact`, `validation-plan`, `refactor-review`, `refactor-approval`,
-`refactor-application`, `refactor-result`, `refactor-handoff`,
-`refactor-checklist`, and `refactor-session` CLI surfaces
+`module-summary`, `boundary-audit`, `refactor-candidates`, `port-usage`,
+`module-context`, `refactor-impact`, `validation-plan`, `refactor-review`,
+`refactor-approval`, `refactor-application`, `refactor-result`,
+`refactor-handoff`, `refactor-checklist`, and `refactor-session` CLI surfaces
 that report module boundary spans, scanner-based hierarchy data, direct
 dependency impact data, conservative module header/port summaries, target port
 usage summaries, target module context bundles, target-specific refactor impact
-data, boundary audit data, proposal-only validation command descriptors, a
-summary-only review packet, approval decision metadata, application request
-metadata, and application result metadata plus refactor handoff metadata,
-refactor checklist metadata, and refactor session status metadata for editor
-navigation and reviewed refactoring planning.
+data, boundary audit data, refactor candidate metadata for editor action
+menus, proposal-only validation command descriptors, a summary-only review
+packet, approval decision metadata, application request metadata, and
+application result metadata plus refactor handoff metadata, refactor checklist
+metadata, and refactor session status metadata for editor navigation and
+reviewed refactoring planning.
 
 It is not a full SystemVerilog parser, not semantic elaboration, not an LSP
 implementation, and not a write-capable refactoring engine.
@@ -33,6 +34,8 @@ python -m pccx_ide_cli module-summary <path> --format json
 python -m pccx_ide_cli module-summary <path> --format text
 python -m pccx_ide_cli boundary-audit <path> --format json
 python -m pccx_ide_cli boundary-audit <path> --format text
+python -m pccx_ide_cli refactor-candidates <path> --format json
+python -m pccx_ide_cli refactor-candidates <path> --format text
 python -m pccx_ide_cli port-usage <path> --module <name> --format json
 python -m pccx_ide_cli port-usage <path> --module <name> --format text
 python -m pccx_ide_cli module-context <path> --module <name> --format json
@@ -239,6 +242,52 @@ refactors, generate patches, run validation, execute shell commands,
 invoke `pccx-lab`, invoke the launcher, run vendor tools, call providers,
 touch hardware, upload telemetry, or perform automatic repository actions.
 
+The refactor candidate list reports scanner-detected modules and
+proposal-only helper action metadata for editor menus:
+
+```json
+{
+  "kind": "module-refactor-candidate-list",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "candidate_state": "available_as_data",
+  "module_count": 2,
+  "ready_module_count": 2,
+  "blocked_module_count": 0,
+  "actions": [
+    {
+      "action": "rename-module",
+      "proposal_command": "refactor-plan",
+      "required_inputs": ["new_name"],
+      "proposal_only": true,
+      "writes_files": false
+    }
+  ],
+  "candidates": [],
+  "safety": {
+    "read_only": true,
+    "candidate_metadata_only": true,
+    "action_enablement_only": true,
+    "emits_command_descriptors": false,
+    "writes_files": false,
+    "applies_refactor": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The candidate list is action-enablement metadata only. It does not include
+command argv, does not record requested refactor inputs, and does not create a
+proposal. Consumers that need a reviewed proposal envelope should call
+`refactor-plan` with explicit inputs.
+
+This boundary does not write files, apply refactors, move files, generate
+patches, run validation, execute shell commands, invoke `pccx-lab`, invoke the
+launcher, run vendor tools, call providers, touch hardware, upload telemetry,
+or perform automatic repository actions.
+
 The port usage view reports a target module's conservative port
 declarations and scanner-detected dependent instantiation usage sites:
 
@@ -422,6 +471,8 @@ The `port-usage` command renders a target module's conservative port data
 and dependent instantiation connection summaries.
 The `module-context` command bundles target summary, dependency,
 port-usage, and refactor-impact review data for editor context panes.
+The `refactor-candidates` command lists scanner-detected modules and
+proposal-only helper action metadata for editor action menus.
 These commands do not run elaboration, expand macros, interpret generate
 blocks, or replace vendor tooling.
 
@@ -492,6 +543,7 @@ inputs for later helpers:
 - target-specific port usage summaries
 - target-specific module context bundles
 - target-specific refactor impact review data
+- refactor candidate action metadata for editor action menus
 - planned helper names for rename, extract-port, and move-module workflows
 - summary-only checklist metadata for maintainer review
 
@@ -1096,7 +1148,8 @@ This workflow advances
 with read-only module boundary detection, a focused hierarchy view, a
 direct dependency view, conservative module header/port summaries,
 target-specific port usage summaries, target-specific module context
-bundles, target-specific refactor impact review data, and a
+bundles, refactor candidate action metadata, target-specific refactor
+impact review data, and a
 proposal-only refactoring, validation planning, review packet, approval
 decision, application request, application result, handoff summary, and
 checklist summary boundary.

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -33,6 +33,7 @@ run_json locate locate fixtures/modules/simple_module.sv simple_mod --format jso
 run_json module-hierarchy-view hierarchy fixtures/organization/hierarchy_top.sv --format json
 run_json module-dependency-view dependencies fixtures/organization/hierarchy_top.sv --format json
 run_json module-summary-view module-summary fixtures/organization/hierarchy_top.sv --format json
+run_json module-refactor-candidate-list refactor-candidates fixtures/organization/hierarchy_top.sv --format json
 run_json module-port-usage-view port-usage fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
 run_json module-refactor-impact-view refactor-impact fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
 run_json module-refactor-proposal refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -155,6 +155,25 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    refactor_candidates_cmd = sub.add_parser(
+        "refactor-candidates",
+        help=(
+            "Emit read-only scanner-based module refactor candidate "
+            "metadata for editor action menus."
+        ),
+    )
+    refactor_candidates_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    refactor_candidates_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     hierarchy_cmd = sub.add_parser(
         "hierarchy",
         help=(
@@ -1023,6 +1042,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_boundary_audit_text(audit))
+        return 0
+
+    if args.command == "refactor-candidates":
+        from .module_organization import (
+            build_refactor_candidate_list,
+            format_refactor_candidate_list_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        candidates = build_refactor_candidate_list(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(candidates, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_refactor_candidate_list_text(candidates))
         return 0
 
     if args.command == "hierarchy":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -87,6 +87,15 @@ MODULE_BOUNDARY_AUDIT_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+REFACTOR_CANDIDATE_LIST_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based refactor candidate metadata only",
+    "lists scanner-detected modules and proposal-only helper actions for editor menus",
+    "does not include command argv; use refactor-plan for reviewed proposal metadata",
+    "does not apply refactors, write files, move files, generate patches, or run validation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 HIERARCHY_VIEW_LIMITATIONS: tuple[str, ...] = (
     "scanner-based hierarchy visualization data only",
     "single-line instantiation candidates only",
@@ -287,6 +296,29 @@ def _module_boundary_audit_safety_flags() -> dict[str, bool]:
         "writes_files": False,
         "applies_refactor": False,
         "moves_files": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _refactor_candidate_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "candidate_metadata_only": True,
+        "action_enablement_only": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
         "applies_patch": False,
         "generates_patch": False,
         "runs_validation": False,
@@ -861,6 +893,141 @@ def build_module_boundary_audit(source: str, path: Path) -> dict[str, Any]:
         "source": source,
         "tool": "pccx-ide-cli",
         "unresolved_dependency_count": len(organization["hierarchy"]["unresolved"]),
+        "writes_files": False,
+    }
+
+
+def _candidate_module_summary(module: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "complete": module["complete"],
+        "end_column": module["end_column"],
+        "end_line": module["end_line"],
+        "file": module["file"],
+        "name": module["name"],
+        "span_lines": module["span_lines"],
+        "start_column": module["start_column"],
+        "start_line": module["start_line"],
+    }
+
+
+def _candidate_action_required_inputs(action: str) -> list[str]:
+    return list(_REFACTOR_REQUIRED_FIELDS[action])
+
+
+def _candidate_action_optional_inputs(action: str) -> list[str]:
+    if action == "extract-port":
+        return ["width"]
+    return []
+
+
+def _candidate_action_descriptor(
+    action: str,
+    state: str,
+    reasons: list[str],
+) -> dict[str, Any]:
+    return {
+        "action": action,
+        "applies_refactor": False,
+        "optional_inputs": _candidate_action_optional_inputs(action),
+        "proposal_command": "refactor-plan",
+        "proposal_only": True,
+        "required_inputs": _candidate_action_required_inputs(action),
+        "requires_explicit_approval_before_write": True,
+        "state": state,
+        "blocked_reasons": list(reasons),
+        "writes_files": False,
+    }
+
+
+def _candidate_blocked_reasons(
+    module: dict[str, Any],
+    name_counts: dict[str, int],
+) -> list[str]:
+    reasons: list[str] = []
+    if not module["complete"]:
+        reasons.append(f"module boundary is incomplete: {module['name']}")
+    if name_counts.get(module["name"], 0) > 1:
+        reasons.append(f"ambiguous module name: {module['name']}")
+    return reasons
+
+
+def _refactor_candidate_rows(
+    modules: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    name_counts: dict[str, int] = {}
+    for module in modules:
+        name_counts[module["name"]] = name_counts.get(module["name"], 0) + 1
+
+    rows: list[dict[str, Any]] = []
+    for module in modules:
+        reasons = _candidate_blocked_reasons(module, name_counts)
+        state = "blocked" if reasons else "ready-for-request"
+        rows.append({
+            "actions": [
+                _candidate_action_descriptor(action, state, reasons)
+                for action in REFACTOR_ACTIONS
+            ],
+            "blocked_reasons": reasons,
+            "candidate_state": state,
+            "module": _candidate_module_summary(module),
+        })
+    return rows
+
+
+def build_refactor_candidate_list(source: str, path: Path) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    candidates = _refactor_candidate_rows(modules)
+    ready_candidates = [
+        candidate
+        for candidate in candidates
+        if candidate["candidate_state"] == "ready-for-request"
+    ]
+    blocked_candidates = [
+        candidate
+        for candidate in candidates
+        if candidate["candidate_state"] == "blocked"
+    ]
+    blocked_reasons = [
+        reason
+        for candidate in blocked_candidates
+        for reason in candidate["blocked_reasons"]
+    ]
+    blocked_reasons = list(dict.fromkeys(blocked_reasons))
+    if not candidates:
+        blocked_reasons.append("no module declarations detected")
+
+    return {
+        "action_count": len(REFACTOR_ACTIONS),
+        "actions": [
+            {
+                "action": action,
+                "optional_inputs": _candidate_action_optional_inputs(action),
+                "proposal_command": "refactor-plan",
+                "proposal_only": True,
+                "required_inputs": _candidate_action_required_inputs(action),
+                "requires_explicit_approval_before_write": True,
+                "writes_files": False,
+            }
+            for action in REFACTOR_ACTIONS
+        ],
+        "blocked_module_count": len(blocked_candidates),
+        "blocked_reasons": blocked_reasons,
+        "candidate_count": len(candidates),
+        "candidate_state": (
+            "available_as_data"
+            if candidates
+            else "blocked"
+        ),
+        "candidates": candidates,
+        "kind": "module-refactor-candidate-list",
+        "limitations": list(REFACTOR_CANDIDATE_LIST_LIMITATIONS),
+        "module_count": len(modules),
+        "ready_module_count": len(ready_candidates),
+        "safety": _refactor_candidate_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "tool": "pccx-ide-cli",
         "writes_files": False,
     }
 
@@ -3316,6 +3483,56 @@ def format_module_boundary_audit_text(audit: dict[str, Any]) -> str:
     lines.append(
         "read-only: no file writes, refactors, validation, shell, lab, "
         "launcher, vendor tool, provider, or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_refactor_candidate_list_text(candidates: dict[str, Any]) -> str:
+    lines = [
+        f"source: {candidates['source']}",
+        f"refactor candidates: {candidates['candidate_state']}",
+        "writes files: no",
+        (
+            f"{candidates['module_count']} module"
+            f"{'s' if candidates['module_count'] != 1 else ''}; "
+            f"{candidates['ready_module_count']} ready; "
+            f"{candidates['blocked_module_count']} blocked"
+        ),
+        (
+            f"{candidates['action_count']} proposal-only action"
+            f"{'s' if candidates['action_count'] != 1 else ''}"
+        ),
+    ]
+    if not candidates["candidates"]:
+        lines.append("candidates: none")
+    for candidate in candidates["candidates"]:
+        module = candidate["module"]
+        end = (
+            f"{module['end_line']}:{module['end_column']}"
+            if module["complete"]
+            else "missing"
+        )
+        lines.append(
+            f"{module['file']}:{module['start_line']}:"
+            f"{module['start_column']}-{end}: module {module['name']} "
+            f"({candidate['candidate_state']})"
+        )
+        for action in candidate["actions"]:
+            required = ", ".join(action["required_inputs"]) or "none"
+            optional = ", ".join(action["optional_inputs"]) or "none"
+            lines.append(
+                f"  {action['action']}: {action['state']}; "
+                f"required={required}; optional={optional}; "
+                "proposal-only"
+            )
+        for reason in candidate["blocked_reasons"]:
+            lines.append(f"  blocked: {reason}")
+    for reason in candidates["blocked_reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(
+        "read-only candidate metadata: no command argv, file writes, "
+        "refactors, validation, shell, lab, launcher, vendor tool, provider, "
+        "or hardware execution"
     )
     return "\n".join(lines) + "\n"
 

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -26,6 +26,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_organization_export,
     build_module_port_usage_view,
     build_module_summary_view,
+    build_refactor_candidate_list,
     build_refactor_approval_decision,
     build_refactor_application_result,
     build_refactor_application_request,
@@ -49,6 +50,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_module_organization_text,
     format_module_port_usage_text,
     format_module_summary_text,
+    format_refactor_candidate_list_text,
     format_refactor_impact_text,
     format_refactor_proposal_text,
     format_refactor_review_packet_text,
@@ -161,6 +163,77 @@ def test_build_module_boundary_audit_blocks_incomplete_boundaries():
         "missing endmodule for module: bad_module"
     ]
     assert audit["writes_files"] is False
+
+
+def test_build_refactor_candidate_list_reports_action_enablement():
+    candidates = build_refactor_candidate_list(str(FIXTURE), FIXTURE)
+
+    assert candidates["kind"] == "module-refactor-candidate-list"
+    assert candidates["candidate_state"] == "available_as_data"
+    assert candidates["module_count"] == 2
+    assert candidates["ready_module_count"] == 2
+    assert candidates["blocked_module_count"] == 0
+    assert candidates["action_count"] == 3
+    assert candidates["blocked_reasons"] == []
+    assert [action["action"] for action in candidates["actions"]] == [
+        "rename-module",
+        "extract-port",
+        "move-module",
+    ]
+    leaf = candidates["candidates"][0]
+    assert leaf["module"]["name"] == "leaf_mod"
+    assert leaf["candidate_state"] == "ready-for-request"
+    assert leaf["blocked_reasons"] == []
+    actions = {action["action"]: action for action in leaf["actions"]}
+    assert actions["rename-module"]["required_inputs"] == ["new_name"]
+    assert actions["extract-port"]["required_inputs"] == [
+        "port_name",
+        "direction",
+    ]
+    assert actions["extract-port"]["optional_inputs"] == ["width"]
+    assert actions["move-module"]["required_inputs"] == ["destination"]
+    assert all(action["proposal_only"] is True for action in leaf["actions"])
+    assert all(action["writes_files"] is False for action in leaf["actions"])
+    assert all(action["applies_refactor"] is False for action in leaf["actions"])
+    assert candidates["safety"]["read_only"] is True
+    assert candidates["safety"]["candidate_metadata_only"] is True
+    assert candidates["safety"]["action_enablement_only"] is True
+    assert candidates["safety"]["emits_command_descriptors"] is False
+    assert candidates["safety"]["writes_files"] is False
+    assert candidates["safety"]["applies_refactor"] is False
+    assert candidates["safety"]["runs_validation"] is False
+    assert candidates["safety"]["runs_shell"] is False
+    assert candidates["safety"]["invokes_pccx_lab"] is False
+    assert candidates["safety"]["invokes_launcher"] is False
+    assert candidates["safety"]["hardware_access"] is False
+    assert '"argv"' not in json.dumps(candidates)
+
+
+def test_build_refactor_candidate_list_blocks_incomplete_boundaries():
+    candidates = build_refactor_candidate_list(
+        str(INCOMPLETE_FIXTURE),
+        INCOMPLETE_FIXTURE,
+    )
+
+    assert candidates["candidate_state"] == "available_as_data"
+    assert candidates["ready_module_count"] == 0
+    assert candidates["blocked_module_count"] == 1
+    assert candidates["blocked_reasons"] == [
+        "module boundary is incomplete: bad_module"
+    ]
+    candidate = candidates["candidates"][0]
+    assert candidate["candidate_state"] == "blocked"
+    assert candidate["blocked_reasons"] == [
+        "module boundary is incomplete: bad_module"
+    ]
+    assert all(action["state"] == "blocked" for action in candidate["actions"])
+    assert all(
+        action["blocked_reasons"] == [
+            "module boundary is incomplete: bad_module"
+        ]
+        for action in candidate["actions"]
+    )
+    assert candidates["writes_files"] is False
 
 
 def test_build_module_hierarchy_view_tree_is_read_only():
@@ -1090,6 +1163,20 @@ def test_format_module_boundary_audit_text_mentions_read_only_gate():
     assert "read-only: no file writes" in text
 
 
+def test_format_refactor_candidate_list_text_mentions_actions_and_no_execution():
+    candidates = build_refactor_candidate_list(str(FIXTURE), FIXTURE)
+    text = format_refactor_candidate_list_text(candidates)
+
+    assert "refactor candidates: available_as_data" in text
+    assert "2 modules; 2 ready; 0 blocked" in text
+    assert "rename-module: ready-for-request" in text
+    assert "required=new_name" in text
+    assert "extract-port: ready-for-request" in text
+    assert "optional=width" in text
+    assert "writes files: no" in text
+    assert "read-only candidate metadata: no command argv" in text
+
+
 def test_format_module_hierarchy_text_mentions_tree_and_boundary():
     view = build_module_hierarchy_view(str(FIXTURE), FIXTURE)
     text = format_module_hierarchy_text(view)
@@ -1375,6 +1462,28 @@ def test_cli_boundary_audit_text():
     assert "module bad_module (incomplete; blocked)" in result.stdout
     assert "blocked: missing endmodule for module: bad_module" in result.stdout
     assert "read-only: no file writes" in result.stdout
+
+
+def test_cli_refactor_candidates_json():
+    result = _run_cli("refactor-candidates", str(FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-refactor-candidate-list"
+    assert payload["candidate_state"] == "available_as_data"
+    assert payload["ready_module_count"] == 2
+    assert payload["blocked_module_count"] == 0
+    assert payload["candidates"][0]["actions"][0]["action"] == "rename-module"
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["emits_command_descriptors"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_refactor_candidates_text():
+    result = _run_cli("refactor-candidates", str(FIXTURE), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "refactor candidates: available_as_data" in result.stdout
+    assert "rename-module: ready-for-request" in result.stdout
+    assert "read-only candidate metadata: no command argv" in result.stdout
 
 
 def test_cli_hierarchy_json():


### PR DESCRIPTION
## Summary
- add a read-only `refactor-candidates` CLI surface that lists scanner-detected modules and proposal-only helper action metadata for editor menus
- include candidate safety flags showing no command argv, writes, refactor application, validation, shell, lab, launcher, vendor tool, provider, or hardware execution
- document the pre-stable shape and add CLI smoke/test coverage

Closes no issue; continues #8.

## Validation
- `PYTHONPATH=src python3 -m pytest -q` (`274 passed`)
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py`
- `git diff --check`
- `find scripts -type f -name '*.sh' -exec bash -n {} +`
- local forbidden-claim scan matching CI pattern