### PR TITLE
Add refactor readiness summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ python -m pccx_ide_cli module-summary fixtures/organization/hierarchy_top.sv --f
 # Module boundary audit and refactor candidate list (pre-stable, read-only)
 python -m pccx_ide_cli boundary-audit fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli refactor-candidates fixtures/organization/hierarchy_top.sv --format text
+python -m pccx_ide_cli refactor-readiness fixtures/organization/hierarchy_top.sv --format json
 
 # Target port usage view (pre-stable, read-only)
 python -m pccx_ide_cli port-usage fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
@@ -220,7 +221,9 @@ instantiation connection summaries. `module-context` bundles target
 summary, dependency, port-usage, and refactor-impact review data for
 editor context panes. `refactor-candidates` lists scanner-detected
 modules and proposal-only helper action metadata for editor action
-menus. `refactor-impact` renders target-specific declaration,
+menus. `refactor-readiness` summarizes boundary-audit and candidate
+counts for editor status panes without selecting an action or emitting
+command argv. `refactor-impact` renders target-specific declaration,
 dependent, and dependency review data for a named module.
 These commands do not edit files, apply
 refactors, execute validation, run vendor tools, invoke `pccx-lab` or the

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -46,6 +46,7 @@ python -m pccx_ide_cli locate <path> <name> --kind any --format json
 # Module organization for editor project trees
 python -m pccx_ide_cli organization <path> --format json
 python -m pccx_ide_cli boundary-audit <path> --format json
+python -m pccx_ide_cli refactor-readiness <path> --format json
 python -m pccx_ide_cli hierarchy <path> --format json
 python -m pccx_ide_cli dependencies <path> --format json
 python -m pccx_ide_cli module-summary <path> --format json
@@ -200,7 +201,9 @@ adds scanner-based module boundary spans, hierarchy edges, root candidates,
 and proposal-only refactoring metadata for project tree and reviewed
 refactoring workflows. `boundary-audit` emits read-only module boundary
 completeness and refactor-readiness audit data from the same scanner output;
-it does not write files, apply refactors, generate patches, run validation,
+`refactor-readiness` summarizes that audit plus refactor-candidate counts for
+editor status panes without selecting an action or emitting command argv. These
+surfaces do not write files, apply refactors, generate patches, run validation,
 invoke pccx-lab or the launcher, run vendor tools, call providers, touch
 hardware, or perform automatic repository actions. `hierarchy`,
 `dependencies`, `module-summary`, `port-usage`, `module-context`, and

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -36,6 +36,8 @@ python -m pccx_ide_cli boundary-audit <path> --format json
 python -m pccx_ide_cli boundary-audit <path> --format text
 python -m pccx_ide_cli refactor-candidates <path> --format json
 python -m pccx_ide_cli refactor-candidates <path> --format text
+python -m pccx_ide_cli refactor-readiness <path> --format json
+python -m pccx_ide_cli refactor-readiness <path> --format text
 python -m pccx_ide_cli port-usage <path> --module <name> --format json
 python -m pccx_ide_cli port-usage <path> --module <name> --format text
 python -m pccx_ide_cli module-context <path> --module <name> --format json
@@ -473,8 +475,34 @@ The `module-context` command bundles target summary, dependency,
 port-usage, and refactor-impact review data for editor context panes.
 The `refactor-candidates` command lists scanner-detected modules and
 proposal-only helper action metadata for editor action menus.
+The `refactor-readiness` command emits summary-only readiness metadata over
+the boundary audit and candidate list so editor status panes can show whether
+proposal-only refactor requests are ready to review.
 These commands do not run elaboration, expand macros, interpret generate
 blocks, or replace vendor tooling.
+
+The readiness envelope uses:
+
+```json
+{
+  "kind": "module-refactor-readiness-summary",
+  "readiness_state": "ready-for-request",
+  "ready_for_request": true,
+  "writes_files": false,
+  "safety": {
+    "read_only": true,
+    "readiness_summary_only": true,
+    "emits_command_descriptors": false,
+    "writes_files": false,
+    "runs_validation": false
+  }
+}
+```
+
+It is not a proposal, approval, validation runner, or write path. It does not
+capture requested inputs, select an action, emit command argv, run shell
+commands, invoke `pccx-lab`, invoke the launcher, call providers, touch
+hardware, upload telemetry, or perform automatic repository actions.
 
 ## Module Header And Port Summary
 

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -34,6 +34,7 @@ run_json module-hierarchy-view hierarchy fixtures/organization/hierarchy_top.sv 
 run_json module-dependency-view dependencies fixtures/organization/hierarchy_top.sv --format json
 run_json module-summary-view module-summary fixtures/organization/hierarchy_top.sv --format json
 run_json module-refactor-candidate-list refactor-candidates fixtures/organization/hierarchy_top.sv --format json
+run_json module-refactor-readiness-summary refactor-readiness fixtures/organization/hierarchy_top.sv --format json
 run_json module-port-usage-view port-usage fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
 run_json module-refactor-impact-view refactor-impact fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
 run_json module-refactor-proposal refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --format json

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -174,6 +174,25 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    refactor_readiness_cmd = sub.add_parser(
+        "refactor-readiness",
+        help=(
+            "Emit read-only scanner-based refactor readiness summary "
+            "metadata for editor status panes."
+        ),
+    )
+    refactor_readiness_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    refactor_readiness_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     hierarchy_cmd = sub.add_parser(
         "hierarchy",
         help=(
@@ -1060,6 +1079,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_refactor_candidate_list_text(candidates))
+        return 0
+
+    if args.command == "refactor-readiness":
+        from .module_organization import (
+            build_refactor_readiness_summary,
+            format_refactor_readiness_summary_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        summary = build_refactor_readiness_summary(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(summary, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_refactor_readiness_summary_text(summary))
         return 0
 
     if args.command == "hierarchy":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -96,6 +96,15 @@ REFACTOR_CANDIDATE_LIST_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+REFACTOR_READINESS_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based refactor readiness summary only",
+    "combines module boundary audit and refactor candidate counts for editor status panes",
+    "does not include command argv or select a refactor action",
+    "does not apply refactors, write files, move files, generate patches, or run validation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 HIERARCHY_VIEW_LIMITATIONS: tuple[str, ...] = (
     "scanner-based hierarchy visualization data only",
     "single-line instantiation candidates only",
@@ -315,6 +324,36 @@ def _refactor_candidate_safety_flags() -> dict[str, bool]:
         "read_only": True,
         "candidate_metadata_only": True,
         "action_enablement_only": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _refactor_readiness_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "readiness_summary_only": True,
+        "combines_boundary_audit": True,
+        "combines_candidate_list": True,
+        "selects_refactor_action": False,
+        "captures_requested_inputs": False,
+        "proposal_created": False,
+        "approval_granted": False,
+        "request_accepted": False,
+        "write_attempted": False,
         "emits_command_descriptors": False,
         "writes_files": False,
         "moves_files": False,
@@ -1028,6 +1067,78 @@ def build_refactor_candidate_list(source: str, path: Path) -> dict[str, Any]:
         "scanner": "line-scanner",
         "source": source,
         "tool": "pccx-ide-cli",
+        "writes_files": False,
+    }
+
+
+def _readiness_status_cards(
+    audit: dict[str, Any],
+    candidates: dict[str, Any],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "card_id": "boundary-audit",
+            "kind": audit["kind"],
+            "status": audit["refactor_readiness"],
+            "complete_module_count": audit["complete_module_count"],
+            "incomplete_module_count": audit["incomplete_module_count"],
+            "required": True,
+        },
+        {
+            "card_id": "candidate-list",
+            "kind": candidates["kind"],
+            "status": candidates["candidate_state"],
+            "ready_module_count": candidates["ready_module_count"],
+            "blocked_module_count": candidates["blocked_module_count"],
+            "required": True,
+        },
+    ]
+
+
+def _refactor_readiness_next_action(
+    audit: dict[str, Any],
+    candidates: dict[str, Any],
+) -> str:
+    if candidates["candidate_count"] == 0:
+        return "add module declarations before refactor readiness review"
+    if audit["incomplete_module_count"] > 0 or candidates["blocked_module_count"] > 0:
+        return "resolve scanner boundary blockers before requesting refactor plans"
+    return "choose a proposal-only refactor action and create a reviewed refactor-plan"
+
+
+def build_refactor_readiness_summary(source: str, path: Path) -> dict[str, Any]:
+    audit = build_module_boundary_audit(source, path)
+    candidates = build_refactor_candidate_list(source, path)
+    blocked_reasons = list(dict.fromkeys([
+        *audit["blocked_reasons"],
+        *candidates["blocked_reasons"],
+    ]))
+    ready = (
+        candidates["candidate_count"] > 0
+        and audit["incomplete_module_count"] == 0
+        and candidates["blocked_module_count"] == 0
+    )
+
+    return {
+        "blocked_reasons": blocked_reasons,
+        "candidate_count": candidates["candidate_count"],
+        "complete_module_count": audit["complete_module_count"],
+        "hierarchy_edge_count": audit["hierarchy_edge_count"],
+        "incomplete_module_count": audit["incomplete_module_count"],
+        "kind": "module-refactor-readiness-summary",
+        "limitations": list(REFACTOR_READINESS_LIMITATIONS),
+        "module_count": audit["module_count"],
+        "next_required_action": _refactor_readiness_next_action(audit, candidates),
+        "ready_for_request": ready,
+        "ready_module_count": candidates["ready_module_count"],
+        "blocked_module_count": candidates["blocked_module_count"],
+        "readiness_state": "ready-for-request" if ready else "blocked",
+        "safety": _refactor_readiness_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "status_cards": _readiness_status_cards(audit, candidates),
+        "tool": "pccx-ide-cli",
+        "unresolved_dependency_count": audit["unresolved_dependency_count"],
         "writes_files": False,
     }
 
@@ -3533,6 +3644,43 @@ def format_refactor_candidate_list_text(candidates: dict[str, Any]) -> str:
         "read-only candidate metadata: no command argv, file writes, "
         "refactors, validation, shell, lab, launcher, vendor tool, provider, "
         "or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_refactor_readiness_summary_text(summary: dict[str, Any]) -> str:
+    ready = "yes" if summary["ready_for_request"] else "no"
+    lines = [
+        f"source: {summary['source']}",
+        f"refactor readiness: {summary['readiness_state']}",
+        f"ready for request: {ready}",
+        "writes files: no",
+        (
+            f"{summary['module_count']} module"
+            f"{'s' if summary['module_count'] != 1 else ''}; "
+            f"{summary['complete_module_count']} complete; "
+            f"{summary['incomplete_module_count']} incomplete"
+        ),
+        (
+            f"{summary['ready_module_count']} ready candidate"
+            f"{'s' if summary['ready_module_count'] != 1 else ''}; "
+            f"{summary['blocked_module_count']} blocked"
+        ),
+        (
+            f"{summary['hierarchy_edge_count']} hierarchy edge"
+            f"{'s' if summary['hierarchy_edge_count'] != 1 else ''}; "
+            f"{summary['unresolved_dependency_count']} unresolved"
+        ),
+    ]
+    for card in summary["status_cards"]:
+        lines.append(f"status: {card['card_id']} ({card['status']})")
+    for reason in summary["blocked_reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"next step: {summary['next_required_action']}")
+    lines.append(
+        "summary-only readiness: no command argv, requested input capture, "
+        "proposal creation, approval, validation, shell, refactor, patch, "
+        "file write, lab, launcher, vendor tool, provider, or hardware execution"
     )
     return "\n".join(lines) + "\n"
 

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -34,6 +34,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_refactor_handoff_summary,
     build_refactor_impact_view,
     build_refactor_proposal,
+    build_refactor_readiness_summary,
     build_refactor_review_packet,
     build_refactor_session_status,
     build_refactor_validation_plan,
@@ -53,6 +54,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_refactor_candidate_list_text,
     format_refactor_impact_text,
     format_refactor_proposal_text,
+    format_refactor_readiness_summary_text,
     format_refactor_review_packet_text,
     format_refactor_validation_plan_text,
 )
@@ -234,6 +236,65 @@ def test_build_refactor_candidate_list_blocks_incomplete_boundaries():
         for action in candidate["actions"]
     )
     assert candidates["writes_files"] is False
+
+
+def test_build_refactor_readiness_summary_reports_request_readiness():
+    summary = build_refactor_readiness_summary(str(FIXTURE), FIXTURE)
+
+    assert summary["kind"] == "module-refactor-readiness-summary"
+    assert summary["readiness_state"] == "ready-for-request"
+    assert summary["ready_for_request"] is True
+    assert summary["module_count"] == 2
+    assert summary["complete_module_count"] == 2
+    assert summary["incomplete_module_count"] == 0
+    assert summary["ready_module_count"] == 2
+    assert summary["blocked_module_count"] == 0
+    assert summary["blocked_reasons"] == []
+    assert summary["next_required_action"] == (
+        "choose a proposal-only refactor action and create a reviewed refactor-plan"
+    )
+    assert [card["card_id"] for card in summary["status_cards"]] == [
+        "boundary-audit",
+        "candidate-list",
+    ]
+    assert summary["safety"]["read_only"] is True
+    assert summary["safety"]["readiness_summary_only"] is True
+    assert summary["safety"]["combines_boundary_audit"] is True
+    assert summary["safety"]["combines_candidate_list"] is True
+    assert summary["safety"]["selects_refactor_action"] is False
+    assert summary["safety"]["captures_requested_inputs"] is False
+    assert summary["safety"]["emits_command_descriptors"] is False
+    assert summary["safety"]["writes_files"] is False
+    assert summary["safety"]["applies_refactor"] is False
+    assert summary["safety"]["runs_validation"] is False
+    assert summary["safety"]["runs_shell"] is False
+    assert summary["safety"]["invokes_pccx_lab"] is False
+    assert summary["safety"]["invokes_launcher"] is False
+    assert summary["safety"]["hardware_access"] is False
+    assert '"argv"' not in json.dumps(summary)
+
+
+def test_build_refactor_readiness_summary_blocks_incomplete_boundaries():
+    summary = build_refactor_readiness_summary(
+        str(INCOMPLETE_FIXTURE),
+        INCOMPLETE_FIXTURE,
+    )
+
+    assert summary["readiness_state"] == "blocked"
+    assert summary["ready_for_request"] is False
+    assert summary["module_count"] == 1
+    assert summary["complete_module_count"] == 0
+    assert summary["incomplete_module_count"] == 1
+    assert summary["ready_module_count"] == 0
+    assert summary["blocked_module_count"] == 1
+    assert summary["blocked_reasons"] == [
+        "missing endmodule for module: bad_module",
+        "module boundary is incomplete: bad_module",
+    ]
+    assert summary["next_required_action"] == (
+        "resolve scanner boundary blockers before requesting refactor plans"
+    )
+    assert summary["writes_files"] is False
 
 
 def test_build_module_hierarchy_view_tree_is_read_only():
@@ -1486,6 +1547,34 @@ def test_cli_refactor_candidates_text():
     assert "read-only candidate metadata: no command argv" in result.stdout
 
 
+def test_cli_refactor_readiness_json():
+    result = _run_cli("refactor-readiness", str(FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-refactor-readiness-summary"
+    assert payload["readiness_state"] == "ready-for-request"
+    assert payload["ready_for_request"] is True
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["emits_command_descriptors"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_refactor_readiness_text():
+    result = _run_cli(
+        "refactor-readiness",
+        str(INCOMPLETE_FIXTURE),
+        "--format",
+        "text",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "refactor readiness: blocked" in result.stdout
+    assert "ready for request: no" in result.stdout
+    assert "blocked: missing endmodule for module: bad_module" in result.stdout
+    assert "blocked: module boundary is incomplete: bad_module" in result.stdout
+    assert "summary-only readiness: no command argv" in result.stdout
+
+
 def test_cli_hierarchy_json():
     result = _run_cli("hierarchy", str(FIXTURE), "--format", "json")
     assert result.returncode == 0, result.stderr
@@ -2271,6 +2360,7 @@ def test_docs_cover_organization_flow_and_limits():
     workflow = WORKFLOW_DOC.read_text(encoding="utf-8")
     assert "organization <path>" in contract
     assert "boundary-audit <path>" in contract
+    assert "refactor-readiness <path>" in contract
     assert "hierarchy <path>" in contract
     assert "dependencies <path>" in contract
     assert "module-summary <path>" in contract
@@ -2288,6 +2378,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "MODULE_ORGANIZATION_WORKFLOW.md" in contract
     assert "proposal-only" in workflow
     assert "module-boundary-audit" in workflow
+    assert "module-refactor-readiness-summary" in workflow
     assert "module-hierarchy-view" in workflow
     assert "module-dependency-view" in workflow
     assert "module-summary-view" in workflow
@@ -2311,5 +2402,6 @@ def test_docs_cover_organization_flow_and_limits():
     assert "refactor checklist metadata" in workflow
     assert "refactor session status metadata" in workflow
     assert "boundary audit data" in workflow
+    assert "readiness metadata" in workflow
     assert "does not write files" in workflow
     assert "not a full SystemVerilog parser" in workflow


### PR DESCRIPTION
## Summary
- Add a read-only `refactor-readiness` CLI surface that combines module boundary audit and refactor candidate counts for editor status panes.
- Include `module-refactor-readiness-summary` JSON/text output with readiness state, blocked reasons, status cards, next required action, and explicit safety flags.
- Document the pre-stable shape and add focused CLI/test/smoke coverage.

## Boundary
- No command argv emission, requested input capture, refactor action selection, proposal creation, approval grant, request acceptance, validation execution, shell execution, file writes, refactor application, patch generation, move execution, lab/launcher/vendor-tool/provider/hardware execution, LSP claim, marketplace claim, runtime claim, or stable API/ABI claim.
- Refs #8.

## Validation
- `PYTHONPATH=src python3 -m pytest -q tests/test_module_organization.py`
- `bash scripts/editor-bridge-smoke.sh`
- `python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py`
- `git diff --check`
- `PYTHONPATH=src python3 -m pccx_ide_cli refactor-readiness fixtures/organization/hierarchy_top.sv --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli refactor-readiness fixtures/missing_endmodule.sv --format text`
- `PYTHONPATH=src python3 -m pytest -q`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `find scripts -type f -name '*.sh' -exec bash -n {} +`
- local forbidden-claim scan
