### PR TITLE
Add hierarchy cycle report

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ python -m pccx_ide_cli hierarchy fixtures/organization/hierarchy_top.sv --format
 # Module dependency view (pre-stable, read-only)
 python -m pccx_ide_cli dependencies fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli dependencies fixtures/organization/hierarchy_top.sv --format text
+python -m pccx_ide_cli hierarchy-cycles fixtures/organization/cyclic_hierarchy.sv --format json
 
 # Module header/port summary view (pre-stable, read-only)
 python -m pccx_ide_cli module-summary fixtures/organization/hierarchy_top.sv --format json
@@ -214,6 +215,8 @@ hierarchy seed, and proposal-only refactoring metadata. `hierarchy`
 renders the same scanner data as a focused read-only hierarchy view for
 editor tree consumers. `dependencies` renders direct module dependency,
 dependent, and impact summaries from the same scanner data.
+`hierarchy-cycles` reports scanner-detected resolved dependency cycles
+for editor warnings without running validation or emitting command argv.
 `module-summary` renders conservative module header and port summaries
 for editor sidebars and reviewed refactoring planning. `port-usage`
 renders target port declarations with scanner-detected dependent

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -49,6 +49,7 @@ python -m pccx_ide_cli boundary-audit <path> --format json
 python -m pccx_ide_cli refactor-readiness <path> --format json
 python -m pccx_ide_cli hierarchy <path> --format json
 python -m pccx_ide_cli dependencies <path> --format json
+python -m pccx_ide_cli hierarchy-cycles <path> --format json
 python -m pccx_ide_cli module-summary <path> --format json
 python -m pccx_ide_cli port-usage <path> --module <name> --format json
 python -m pccx_ide_cli module-context <path> --module <name> --format json

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -4,19 +4,19 @@
 
 This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
-`module-summary`, `boundary-audit`, `refactor-candidates`, `port-usage`,
-`module-context`, `refactor-impact`, `validation-plan`, `refactor-review`,
-`refactor-approval`, `refactor-application`, `refactor-result`,
+`hierarchy-cycles`, `module-summary`, `boundary-audit`, `refactor-candidates`,
+`port-usage`, `module-context`, `refactor-impact`, `validation-plan`,
+`refactor-review`, `refactor-approval`, `refactor-application`, `refactor-result`,
 `refactor-handoff`, `refactor-checklist`, and `refactor-session` CLI surfaces
 that report module boundary spans, scanner-based hierarchy data, direct
-dependency impact data, conservative module header/port summaries, target port
-usage summaries, target module context bundles, target-specific refactor impact
-data, boundary audit data, refactor candidate metadata for editor action
-menus, proposal-only validation command descriptors, a summary-only review
-packet, approval decision metadata, application request metadata, and
-application result metadata plus refactor handoff metadata, refactor checklist
-metadata, and refactor session status metadata for editor navigation and
-reviewed refactoring planning.
+dependency impact data, hierarchy cycle report metadata, conservative module
+header/port summaries, target port usage summaries, target module context
+bundles, target-specific refactor impact data, boundary audit data, refactor
+candidate metadata for editor action menus, proposal-only validation command
+descriptors, a summary-only review packet, approval decision metadata,
+application request metadata, and application result metadata plus refactor
+handoff metadata, refactor checklist metadata, and refactor session status
+metadata for editor navigation and reviewed refactoring planning.
 
 It is not a full SystemVerilog parser, not semantic elaboration, not an LSP
 implementation, and not a write-capable refactoring engine.
@@ -30,6 +30,8 @@ python -m pccx_ide_cli hierarchy <path> --format json
 python -m pccx_ide_cli hierarchy <path> --format text
 python -m pccx_ide_cli dependencies <path> --format json
 python -m pccx_ide_cli dependencies <path> --format text
+python -m pccx_ide_cli hierarchy-cycles <path> --format json
+python -m pccx_ide_cli hierarchy-cycles <path> --format text
 python -m pccx_ide_cli module-summary <path> --format json
 python -m pccx_ide_cli module-summary <path> --format text
 python -m pccx_ide_cli boundary-audit <path> --format json
@@ -159,6 +161,41 @@ The dependency view is display data only. It does not write files, apply
 refactors, generate patches, run validation, execute shell commands,
 invoke `pccx-lab`, invoke the launcher, call providers, touch hardware,
 upload telemetry, or perform automatic repository actions.
+
+The hierarchy cycle report uses resolved scanner dependency edges and emits
+cycle-warning metadata for editor consumers:
+
+```json
+{
+  "kind": "module-hierarchy-cycle-report",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "cycle_state": "cycles-detected",
+  "has_cycles": true,
+  "cycle_count": 1,
+  "cycles": [
+    {
+      "cycle_id": "cycle-1",
+      "module_path": ["alpha_mod", "beta_mod", "alpha_mod"],
+      "summary": "alpha_mod -> beta_mod -> alpha_mod",
+      "edges": []
+    }
+  ],
+  "safety": {
+    "read_only": true,
+    "writes_files": false,
+    "applies_refactor": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The hierarchy cycle report is display data only. It does not write files,
+apply refactors, generate patches, run validation, execute shell commands,
+emit command argv, invoke `pccx-lab`, invoke the launcher, call providers,
+touch hardware, upload telemetry, or perform automatic repository actions.
 
 The module summary view reports conservative scanner-detected module
 header and port metadata:

--- a/fixtures/organization/cyclic_hierarchy.sv
+++ b/fixtures/organization/cyclic_hierarchy.sv
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
+
+module alpha_mod ();
+    beta_mod u_beta ();
+endmodule
+
+module beta_mod ();
+    alpha_mod u_alpha ();
+endmodule

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -32,6 +32,7 @@ run_json declarations declarations fixtures/modules --format json
 run_json locate locate fixtures/modules/simple_module.sv simple_mod --format json
 run_json module-hierarchy-view hierarchy fixtures/organization/hierarchy_top.sv --format json
 run_json module-dependency-view dependencies fixtures/organization/hierarchy_top.sv --format json
+run_json module-hierarchy-cycle-report hierarchy-cycles fixtures/organization/cyclic_hierarchy.sv --format json
 run_json module-summary-view module-summary fixtures/organization/hierarchy_top.sv --format json
 run_json module-refactor-candidate-list refactor-candidates fixtures/organization/hierarchy_top.sv --format json
 run_json module-refactor-readiness-summary refactor-readiness fixtures/organization/hierarchy_top.sv --format json

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -230,6 +230,24 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    hierarchy_cycles_cmd = sub.add_parser(
+        "hierarchy-cycles",
+        help=(
+            "Render scanner-based read-only hierarchy cycle report data."
+        ),
+    )
+    hierarchy_cycles_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    hierarchy_cycles_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     module_summary_cmd = sub.add_parser(
         "module-summary",
         help=(
@@ -1133,6 +1151,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_dependency_text(view))
+        return 0
+
+    if args.command == "hierarchy-cycles":
+        from .module_organization import (
+            build_module_hierarchy_cycle_report,
+            format_module_hierarchy_cycle_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        report = build_module_hierarchy_cycle_report(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(report, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_hierarchy_cycle_text(report))
         return 0
 
     if args.command == "module-summary":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -124,6 +124,16 @@ DEPENDENCY_VIEW_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+HIERARCHY_CYCLE_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based module hierarchy cycle report only",
+    "single-line instantiation candidates only",
+    "resolved module dependency edges only",
+    "no semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
+    "does not apply refactors, write files, generate patches, or run validation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 MODULE_SUMMARY_LIMITATIONS: tuple[str, ...] = (
     "scanner-based module header and port summary data only",
     "ANSI-style port declarations are detected conservatively",
@@ -397,6 +407,28 @@ def _dependency_safety_flags() -> dict[str, bool]:
         "runs_shell": False,
         "invokes_pccx_lab": False,
         "invokes_launcher": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _hierarchy_cycle_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "cycle_report_only": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
         "provider_calls": False,
         "hardware_access": False,
         "telemetry": False,
@@ -1354,6 +1386,125 @@ def build_module_dependency_view(source: str, path: Path) -> dict[str, Any]:
             for edge in hierarchy["edges"]
             if not edge["resolved"]
         ]),
+    }
+
+
+def _cycle_key(module_path: list[str]) -> tuple[str, ...]:
+    cycle = module_path[:-1]
+    if not cycle:
+        return tuple(module_path)
+
+    rotations = [
+        tuple(cycle[index:] + cycle[:index])
+        for index in range(len(cycle))
+    ]
+    return min(rotations)
+
+
+def _cycle_edge_summary(edge: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "child": edge["child"],
+        "column": edge["column"],
+        "file": edge["file"],
+        "instance": edge["instance"],
+        "line": edge["line"],
+        "parent": edge["parent"],
+    }
+
+
+def _hierarchy_cycle_rows(hierarchy: dict[str, Any]) -> list[dict[str, Any]]:
+    adjacency: dict[str, list[dict[str, Any]]] = {}
+    module_names: set[str] = set()
+    for edge in hierarchy["edges"]:
+        module_names.add(edge["parent"])
+        if not edge["resolved"]:
+            continue
+        module_names.add(edge["child"])
+        adjacency.setdefault(edge["parent"], []).append(edge)
+
+    for edges in adjacency.values():
+        edges.sort(key=lambda e: (e["child"], e["line"], e["column"], e["instance"]))
+
+    seen: set[tuple[str, ...]] = set()
+    cycles: list[dict[str, Any]] = []
+
+    def visit(
+        start: str,
+        current: str,
+        module_path: list[str],
+        edge_path: list[dict[str, Any]],
+    ) -> None:
+        for edge in adjacency.get(current, []):
+            child = edge["child"]
+            if child == start:
+                completed_modules = [*module_path, child]
+                key = _cycle_key(completed_modules)
+                if key in seen:
+                    continue
+                seen.add(key)
+                completed_edges = [*edge_path, edge]
+                cycles.append({
+                    "cycle_state": "detected",
+                    "edge_count": len(completed_edges),
+                    "edges": [
+                        _cycle_edge_summary(cycle_edge)
+                        for cycle_edge in completed_edges
+                    ],
+                    "module_path": completed_modules,
+                    "summary": " -> ".join(completed_modules),
+                })
+                continue
+            if child in module_path:
+                continue
+            visit(start, child, [*module_path, child], [*edge_path, edge])
+
+    for module_name in sorted(module_names):
+        visit(module_name, module_name, [module_name], [])
+
+    cycles.sort(key=lambda row: (row["summary"], row["edge_count"]))
+    for index, cycle in enumerate(cycles, 1):
+        cycle["cycle_id"] = f"cycle-{index}"
+    return cycles
+
+
+def build_module_hierarchy_cycle_report(source: str, path: Path) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    hierarchy = organization["hierarchy"]
+    resolved_edge_count = len([
+        edge
+        for edge in hierarchy["edges"]
+        if edge["resolved"]
+    ])
+    cycles = _hierarchy_cycle_rows(hierarchy)
+    blocked_reasons = [
+        f"scanner-detected hierarchy cycle: {cycle['summary']}"
+        for cycle in cycles
+    ]
+
+    return {
+        "blocked_reasons": blocked_reasons,
+        "cycle_count": len(cycles),
+        "cycle_state": "cycles-detected" if cycles else "no-cycles-detected",
+        "cycles": cycles,
+        "edge_count": len(hierarchy["edges"]),
+        "has_cycles": bool(cycles),
+        "kind": "module-hierarchy-cycle-report",
+        "limitations": list(HIERARCHY_CYCLE_LIMITATIONS),
+        "module_count": len(modules),
+        "next_required_action": (
+            "review scanner-detected hierarchy cycles before refactor planning"
+            if cycles
+            else "continue hierarchy and refactor review"
+        ),
+        "resolved_edge_count": resolved_edge_count,
+        "safety": _hierarchy_cycle_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "tool": "pccx-ide-cli",
+        "unresolved": hierarchy["unresolved"],
+        "unresolved_edge_count": len(hierarchy["edges"]) - resolved_edge_count,
+        "writes_files": False,
     }
 
 
@@ -3751,6 +3902,35 @@ def format_module_dependency_text(view: dict[str, Any]) -> str:
     lines.append(
         "read-only: no file writes, refactors, validation, lab, launcher, "
         "provider, or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_module_hierarchy_cycle_text(report: dict[str, Any]) -> str:
+    lines = [
+        f"source: {report['source']}",
+        f"hierarchy cycles: {report['cycle_state']}",
+        f"{report['module_count']} module"
+        f"{'s' if report['module_count'] != 1 else ''}",
+        f"{report['cycle_count']} cycle"
+        f"{'s' if report['cycle_count'] != 1 else ''}",
+    ]
+    if not report["cycles"]:
+        lines.append("cycles: none")
+    for cycle in report["cycles"]:
+        lines.append(f"{cycle['cycle_id']}: {cycle['summary']}")
+        for edge in cycle["edges"]:
+            lines.append(
+                f"  {edge['parent']} -> {edge['child']} as {edge['instance']} "
+                f"at {edge['file']}:{edge['line']}:{edge['column']}"
+            )
+    for reason in report["blocked_reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"next: {report['next_required_action']}")
+    lines.append(
+        "read-only cycle report: no command argv, validation, shell, "
+        "refactor, patch, file write, lab, launcher, vendor tool, provider, "
+        "or hardware execution"
     )
     return "\n".join(lines) + "\n"
 

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -12,6 +12,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SRC = REPO_ROOT / "src"
 FIXTURE = REPO_ROOT / "fixtures" / "organization" / "hierarchy_top.sv"
+CYCLIC_FIXTURE = REPO_ROOT / "fixtures" / "organization" / "cyclic_hierarchy.sv"
 INCOMPLETE_FIXTURE = REPO_ROOT / "fixtures" / "missing_endmodule.sv"
 CONTRACT_DOC = REPO_ROOT / "docs" / "EDITOR_BRIDGE_CONTRACT.md"
 WORKFLOW_DOC = REPO_ROOT / "docs" / "MODULE_ORGANIZATION_WORKFLOW.md"
@@ -22,6 +23,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_dependency_view,
     build_module_boundary_audit,
     build_module_context_bundle,
+    build_module_hierarchy_cycle_report,
     build_module_hierarchy_view,
     build_module_organization_export,
     build_module_port_usage_view,
@@ -47,6 +49,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_module_boundary_audit_text,
     format_module_dependency_text,
     format_module_context_text,
+    format_module_hierarchy_cycle_text,
     format_module_hierarchy_text,
     format_module_organization_text,
     format_module_port_usage_text,
@@ -358,6 +361,64 @@ def test_build_module_dependency_view_is_read_only():
     assert view["safety"]["invokes_launcher"] is False
     assert view["safety"]["provider_calls"] is False
     assert view["safety"]["hardware_access"] is False
+
+
+def test_build_module_hierarchy_cycle_report_detects_cycles():
+    report = build_module_hierarchy_cycle_report(
+        str(CYCLIC_FIXTURE),
+        CYCLIC_FIXTURE,
+    )
+
+    assert report["kind"] == "module-hierarchy-cycle-report"
+    assert report["cycle_state"] == "cycles-detected"
+    assert report["has_cycles"] is True
+    assert report["module_count"] == 2
+    assert report["edge_count"] == 2
+    assert report["resolved_edge_count"] == 2
+    assert report["cycle_count"] == 1
+    assert report["cycles"][0]["cycle_id"] == "cycle-1"
+    assert report["cycles"][0]["module_path"] == [
+        "alpha_mod",
+        "beta_mod",
+        "alpha_mod",
+    ]
+    assert report["cycles"][0]["summary"] == "alpha_mod -> beta_mod -> alpha_mod"
+    assert [edge["instance"] for edge in report["cycles"][0]["edges"]] == [
+        "u_beta",
+        "u_alpha",
+    ]
+    assert report["blocked_reasons"] == [
+        "scanner-detected hierarchy cycle: alpha_mod -> beta_mod -> alpha_mod"
+    ]
+    assert report["next_required_action"] == (
+        "review scanner-detected hierarchy cycles before refactor planning"
+    )
+    assert report["safety"]["read_only"] is True
+    assert report["safety"]["cycle_report_only"] is True
+    assert report["safety"]["emits_command_descriptors"] is False
+    assert report["safety"]["writes_files"] is False
+    assert report["safety"]["applies_refactor"] is False
+    assert report["safety"]["generates_patch"] is False
+    assert report["safety"]["runs_validation"] is False
+    assert report["safety"]["runs_shell"] is False
+    assert report["safety"]["invokes_pccx_lab"] is False
+    assert report["safety"]["invokes_launcher"] is False
+    assert report["safety"]["invokes_vendor_tools"] is False
+    assert report["safety"]["provider_calls"] is False
+    assert report["safety"]["hardware_access"] is False
+    assert report["writes_files"] is False
+    assert '"argv"' not in json.dumps(report)
+
+
+def test_build_module_hierarchy_cycle_report_allows_acyclic_hierarchy():
+    report = build_module_hierarchy_cycle_report(str(FIXTURE), FIXTURE)
+
+    assert report["cycle_state"] == "no-cycles-detected"
+    assert report["has_cycles"] is False
+    assert report["cycle_count"] == 0
+    assert report["cycles"] == []
+    assert report["blocked_reasons"] == []
+    assert report["next_required_action"] == "continue hierarchy and refactor review"
 
 
 def test_build_module_summary_view_reports_ports_and_safety():
@@ -1259,6 +1320,20 @@ def test_format_module_dependency_text_mentions_impact_and_boundary():
     assert "read-only: no file writes" in text
 
 
+def test_format_module_hierarchy_cycle_text_mentions_cycle_and_boundary():
+    report = build_module_hierarchy_cycle_report(
+        str(CYCLIC_FIXTURE),
+        CYCLIC_FIXTURE,
+    )
+    text = format_module_hierarchy_cycle_text(report)
+
+    assert "hierarchy cycles: cycles-detected" in text
+    assert "cycle-1: alpha_mod -> beta_mod -> alpha_mod" in text
+    assert "alpha_mod -> beta_mod as u_beta" in text
+    assert "blocked: scanner-detected hierarchy cycle" in text
+    assert "read-only cycle report: no command argv" in text
+
+
 def test_format_module_summary_text_mentions_ports_and_boundary():
     view = build_module_summary_view(str(FIXTURE), FIXTURE)
     text = format_module_summary_text(view)
@@ -1606,6 +1681,32 @@ def test_cli_dependencies_text():
     assert result.returncode == 0, result.stderr
     assert "dependency view: available_as_data" in result.stdout
     assert "leaf_mod: dependencies=none; dependents=top_mod" in result.stdout
+
+
+def test_cli_hierarchy_cycles_json():
+    result = _run_cli("hierarchy-cycles", str(CYCLIC_FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-hierarchy-cycle-report"
+    assert payload["cycle_state"] == "cycles-detected"
+    assert payload["cycle_count"] == 1
+    assert payload["cycles"][0]["module_path"] == [
+        "alpha_mod",
+        "beta_mod",
+        "alpha_mod",
+    ]
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["emits_command_descriptors"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_hierarchy_cycles_text():
+    result = _run_cli("hierarchy-cycles", str(CYCLIC_FIXTURE), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "hierarchy cycles: cycles-detected" in result.stdout
+    assert "cycle-1: alpha_mod -> beta_mod -> alpha_mod" in result.stdout
+    assert "read-only cycle report: no command argv" in result.stdout
 
 
 def test_cli_module_summary_json():
@@ -2196,6 +2297,12 @@ def test_cli_dependencies_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_hierarchy_cycles_missing_path_exits_nonzero():
+    result = _run_cli("hierarchy-cycles", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_cli_module_summary_missing_path_exits_nonzero():
     result = _run_cli("module-summary", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
@@ -2363,6 +2470,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "refactor-readiness <path>" in contract
     assert "hierarchy <path>" in contract
     assert "dependencies <path>" in contract
+    assert "hierarchy-cycles <path>" in contract
     assert "module-summary <path>" in contract
     assert "port-usage <path>" in contract
     assert "module-context <path>" in contract
@@ -2381,6 +2489,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-refactor-readiness-summary" in workflow
     assert "module-hierarchy-view" in workflow
     assert "module-dependency-view" in workflow
+    assert "module-hierarchy-cycle-report" in workflow
     assert "module-summary-view" in workflow
     assert "module-port-usage-view" in workflow
     assert "module-context-bundle" in workflow
@@ -2403,5 +2512,6 @@ def test_docs_cover_organization_flow_and_limits():
     assert "refactor session status metadata" in workflow
     assert "boundary audit data" in workflow
     assert "readiness metadata" in workflow
+    assert "hierarchy cycle report" in workflow
     assert "does not write files" in workflow
     assert "not a full SystemVerilog parser" in workflow


### PR DESCRIPTION
## Summary
- Add a read-only `hierarchy-cycles` CLI surface for scanner-detected resolved module dependency cycles.
- Include `module-hierarchy-cycle-report` JSON/text output with cycle state, blocked reasons, next required action, cycle edge details, and explicit safety flags.
- Add a small cyclic hierarchy fixture plus docs, tests, and editor bridge smoke coverage.

## Boundary
- No command argv emission, validation execution, shell execution, file writes, refactor application, patch generation, move execution, lab/launcher/vendor-tool/provider/hardware execution, LSP claim, marketplace claim, runtime claim, or stable API/ABI claim.
- Refs #8.

## Validation
- `PYTHONPATH=src python3 -m pytest -q tests/test_module_organization.py`
- `bash scripts/editor-bridge-smoke.sh`
- `python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py`
- `git diff --check`
- `PYTHONPATH=src python3 -m pytest -q`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `find scripts -type f -name '*.sh' -exec bash -n {} +`
- `PYTHONPATH=src python3 -m pccx_ide_cli hierarchy-cycles fixtures/organization/hierarchy_top.sv --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli hierarchy-cycles fixtures/organization/cyclic_hierarchy.sv --format text`
- local forbidden-claim scan
