### PR TITLE
Add module duplicate report

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ python -m pccx_ide_cli module-summary fixtures/organization/hierarchy_top.sv --f
 
 # Module boundary audit and refactor candidate list (pre-stable, read-only)
 python -m pccx_ide_cli boundary-audit fixtures/organization/hierarchy_top.sv --format json
+python -m pccx_ide_cli module-duplicates fixtures/organization/duplicate_modules.sv --format text
 python -m pccx_ide_cli refactor-candidates fixtures/organization/hierarchy_top.sv --format text
 python -m pccx_ide_cli refactor-readiness fixtures/organization/hierarchy_top.sv --format json
 
@@ -226,7 +227,9 @@ editor context panes. `refactor-candidates` lists scanner-detected
 modules and proposal-only helper action metadata for editor action
 menus. `refactor-readiness` summarizes boundary-audit and candidate
 counts for editor status panes without selecting an action or emitting
-command argv. `refactor-impact` renders target-specific declaration,
+command argv. `module-duplicates` reports scanner-detected duplicate
+module names that would block unambiguous refactor planning.
+`refactor-impact` renders target-specific declaration,
 dependent, and dependency review data for a named module.
 These commands do not edit files, apply
 refactors, execute validation, run vendor tools, invoke `pccx-lab` or the

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -46,6 +46,7 @@ python -m pccx_ide_cli locate <path> <name> --kind any --format json
 # Module organization for editor project trees
 python -m pccx_ide_cli organization <path> --format json
 python -m pccx_ide_cli boundary-audit <path> --format json
+python -m pccx_ide_cli module-duplicates <path> --format json
 python -m pccx_ide_cli refactor-readiness <path> --format json
 python -m pccx_ide_cli hierarchy <path> --format json
 python -m pccx_ide_cli dependencies <path> --format json

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -4,13 +4,13 @@
 
 This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
-`hierarchy-cycles`, `module-summary`, `boundary-audit`, `refactor-candidates`,
-`port-usage`, `module-context`, `refactor-impact`, `validation-plan`,
+`hierarchy-cycles`, `module-summary`, `boundary-audit`, `module-duplicates`,
+`refactor-candidates`, `port-usage`, `module-context`, `refactor-impact`, `validation-plan`,
 `refactor-review`, `refactor-approval`, `refactor-application`, `refactor-result`,
 `refactor-handoff`, `refactor-checklist`, and `refactor-session` CLI surfaces
 that report module boundary spans, scanner-based hierarchy data, direct
 dependency impact data, hierarchy cycle report metadata, conservative module
-header/port summaries, target port usage summaries, target module context
+header/port summaries, duplicate-name report metadata, target port usage summaries, target module context
 bundles, target-specific refactor impact data, boundary audit data, refactor
 candidate metadata for editor action menus, proposal-only validation command
 descriptors, a summary-only review packet, approval decision metadata,
@@ -36,6 +36,8 @@ python -m pccx_ide_cli module-summary <path> --format json
 python -m pccx_ide_cli module-summary <path> --format text
 python -m pccx_ide_cli boundary-audit <path> --format json
 python -m pccx_ide_cli boundary-audit <path> --format text
+python -m pccx_ide_cli module-duplicates <path> --format json
+python -m pccx_ide_cli module-duplicates <path> --format text
 python -m pccx_ide_cli refactor-candidates <path> --format json
 python -m pccx_ide_cli refactor-candidates <path> --format text
 python -m pccx_ide_cli refactor-readiness <path> --format json
@@ -280,6 +282,38 @@ The boundary audit is status data only. It does not write files, apply
 refactors, generate patches, run validation, execute shell commands,
 invoke `pccx-lab`, invoke the launcher, run vendor tools, call providers,
 touch hardware, upload telemetry, or perform automatic repository actions.
+
+The duplicate module report surfaces scanner-detected ambiguous module
+declaration names that would block unambiguous refactor planning:
+
+```json
+{
+  "kind": "module-duplicate-report",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "report_state": "duplicates-detected",
+  "module_count": 3,
+  "duplicate_name_count": 1,
+  "duplicate_names": ["dup_mod"],
+  "duplicates": [],
+  "blocked_reasons": ["ambiguous module name: dup_mod"],
+  "safety": {
+    "read_only": true,
+    "duplicate_report_only": true,
+    "emits_command_descriptors": false,
+    "writes_files": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The duplicate-name report is status data only. It does not write files,
+apply refactors, generate patches, run validation, execute shell commands,
+emit command argv, invoke `pccx-lab`, invoke the launcher, run vendor
+tools, call providers, touch hardware, upload telemetry, or perform
+automatic repository actions.
 
 The refactor candidate list reports scanner-detected modules and
 proposal-only helper action metadata for editor menus:

--- a/fixtures/organization/duplicate_modules.sv
+++ b/fixtures/organization/duplicate_modules.sv
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
+
+module dup_mod ();
+endmodule
+
+module unique_mod ();
+endmodule
+
+module dup_mod ();
+endmodule

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -33,6 +33,7 @@ run_json locate locate fixtures/modules/simple_module.sv simple_mod --format jso
 run_json module-hierarchy-view hierarchy fixtures/organization/hierarchy_top.sv --format json
 run_json module-dependency-view dependencies fixtures/organization/hierarchy_top.sv --format json
 run_json module-hierarchy-cycle-report hierarchy-cycles fixtures/organization/cyclic_hierarchy.sv --format json
+run_json module-duplicate-report module-duplicates fixtures/organization/duplicate_modules.sv --format json
 run_json module-summary-view module-summary fixtures/organization/hierarchy_top.sv --format json
 run_json module-refactor-candidate-list refactor-candidates fixtures/organization/hierarchy_top.sv --format json
 run_json module-refactor-readiness-summary refactor-readiness fixtures/organization/hierarchy_top.sv --format json

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -155,6 +155,24 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    module_duplicates_cmd = sub.add_parser(
+        "module-duplicates",
+        help=(
+            "Emit read-only scanner-based duplicate module declaration report data."
+        ),
+    )
+    module_duplicates_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    module_duplicates_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     refactor_candidates_cmd = sub.add_parser(
         "refactor-candidates",
         help=(
@@ -1079,6 +1097,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_boundary_audit_text(audit))
+        return 0
+
+    if args.command == "module-duplicates":
+        from .module_organization import (
+            build_module_duplicate_report,
+            format_module_duplicate_report_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        report = build_module_duplicate_report(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(report, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_duplicate_report_text(report))
         return 0
 
     if args.command == "refactor-candidates":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -87,6 +87,15 @@ MODULE_BOUNDARY_AUDIT_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+MODULE_DUPLICATE_REPORT_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based module duplicate-name report only",
+    "uses declaration names and locations from the organization scanner",
+    "does not semantically elaborate modules or resolve packages/namespaces",
+    "does not apply refactors, write files, generate patches, or run validation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 REFACTOR_CANDIDATE_LIST_LIMITATIONS: tuple[str, ...] = (
     "scanner-based refactor candidate metadata only",
     "lists scanner-detected modules and proposal-only helper actions for editor menus",
@@ -315,6 +324,28 @@ def _module_boundary_audit_safety_flags() -> dict[str, bool]:
         "writes_files": False,
         "applies_refactor": False,
         "moves_files": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _module_duplicate_report_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "duplicate_report_only": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
         "applies_patch": False,
         "generates_patch": False,
         "runs_validation": False,
@@ -964,6 +995,81 @@ def build_module_boundary_audit(source: str, path: Path) -> dict[str, Any]:
         "source": source,
         "tool": "pccx-ide-cli",
         "unresolved_dependency_count": len(organization["hierarchy"]["unresolved"]),
+        "writes_files": False,
+    }
+
+
+def _module_duplicate_rows(
+    modules: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    modules_by_name: dict[str, list[dict[str, Any]]] = {}
+    for module in modules:
+        modules_by_name.setdefault(module["name"], []).append(module)
+
+    rows: list[dict[str, Any]] = []
+    for name, declarations in sorted(modules_by_name.items()):
+        if len(declarations) <= 1:
+            continue
+        rows.append({
+            "declaration_count": len(declarations),
+            "duplicate_state": "duplicate",
+            "locations": [
+                {
+                    "complete": declaration["complete"],
+                    "end_line": declaration["end_line"],
+                    "file": declaration["file"],
+                    "start_line": declaration["start_line"],
+                    "start_column": declaration["start_column"],
+                }
+                for declaration in sorted(
+                    declarations,
+                    key=lambda row: (row["file"], row["start_line"], row["name"]),
+                )
+            ],
+            "name": name,
+            "refactor_preflight_state": "blocked",
+            "reason": f"ambiguous module name: {name}",
+        })
+    return rows
+
+
+def build_module_duplicate_report(source: str, path: Path) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    duplicates = _module_duplicate_rows(modules)
+    duplicate_declaration_count = sum(
+        row["declaration_count"]
+        for row in duplicates
+    )
+    duplicate_names = [
+        row["name"]
+        for row in duplicates
+    ]
+    blocked_reasons = [
+        row["reason"]
+        for row in duplicates
+    ]
+
+    return {
+        "blocked_reasons": blocked_reasons,
+        "duplicate_declaration_count": duplicate_declaration_count,
+        "duplicate_name_count": len(duplicates),
+        "duplicate_names": duplicate_names,
+        "duplicates": duplicates,
+        "kind": "module-duplicate-report",
+        "limitations": list(MODULE_DUPLICATE_REPORT_LIMITATIONS),
+        "module_count": len(modules),
+        "next_required_action": (
+            "rename or disambiguate duplicate module declarations before refactor planning"
+            if duplicates
+            else "continue module organization and refactor review"
+        ),
+        "report_state": "duplicates-detected" if duplicates else "no-duplicates-detected",
+        "safety": _module_duplicate_report_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "tool": "pccx-ide-cli",
+        "unique_module_name_count": len({module["name"] for module in modules}),
         "writes_files": False,
     }
 
@@ -3745,6 +3851,38 @@ def format_module_boundary_audit_text(audit: dict[str, Any]) -> str:
     lines.append(
         "read-only: no file writes, refactors, validation, shell, lab, "
         "launcher, vendor tool, provider, or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_module_duplicate_report_text(report: dict[str, Any]) -> str:
+    lines = [
+        f"source: {report['source']}",
+        f"module duplicates: {report['report_state']}",
+        f"{report['module_count']} module declaration"
+        f"{'s' if report['module_count'] != 1 else ''}",
+        f"{report['duplicate_name_count']} duplicate name"
+        f"{'s' if report['duplicate_name_count'] != 1 else ''}",
+    ]
+    if not report["duplicates"]:
+        lines.append("duplicates: none")
+    for duplicate in report["duplicates"]:
+        lines.append(
+            f"{duplicate['name']}: {duplicate['declaration_count']} declarations"
+        )
+        for location in duplicate["locations"]:
+            end_line = location["end_line"] or "?"
+            lines.append(
+                f"  {location['file']}:{location['start_line']}:"
+                f"{location['start_column']} end={end_line}"
+            )
+    for reason in report["blocked_reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"next: {report['next_required_action']}")
+    lines.append(
+        "read-only duplicate report: no command argv, validation, shell, "
+        "refactor, patch, file write, lab, launcher, vendor tool, provider, "
+        "or hardware execution"
     )
     return "\n".join(lines) + "\n"
 

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -13,6 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SRC = REPO_ROOT / "src"
 FIXTURE = REPO_ROOT / "fixtures" / "organization" / "hierarchy_top.sv"
 CYCLIC_FIXTURE = REPO_ROOT / "fixtures" / "organization" / "cyclic_hierarchy.sv"
+DUPLICATE_FIXTURE = REPO_ROOT / "fixtures" / "organization" / "duplicate_modules.sv"
 INCOMPLETE_FIXTURE = REPO_ROOT / "fixtures" / "missing_endmodule.sv"
 CONTRACT_DOC = REPO_ROOT / "docs" / "EDITOR_BRIDGE_CONTRACT.md"
 WORKFLOW_DOC = REPO_ROOT / "docs" / "MODULE_ORGANIZATION_WORKFLOW.md"
@@ -23,6 +24,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_dependency_view,
     build_module_boundary_audit,
     build_module_context_bundle,
+    build_module_duplicate_report,
     build_module_hierarchy_cycle_report,
     build_module_hierarchy_view,
     build_module_organization_export,
@@ -49,6 +51,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_module_boundary_audit_text,
     format_module_dependency_text,
     format_module_context_text,
+    format_module_duplicate_report_text,
     format_module_hierarchy_cycle_text,
     format_module_hierarchy_text,
     format_module_organization_text,
@@ -168,6 +171,53 @@ def test_build_module_boundary_audit_blocks_incomplete_boundaries():
         "missing endmodule for module: bad_module"
     ]
     assert audit["writes_files"] is False
+
+
+def test_build_module_duplicate_report_detects_ambiguous_names():
+    report = build_module_duplicate_report(str(DUPLICATE_FIXTURE), DUPLICATE_FIXTURE)
+
+    assert report["kind"] == "module-duplicate-report"
+    assert report["report_state"] == "duplicates-detected"
+    assert report["module_count"] == 3
+    assert report["unique_module_name_count"] == 2
+    assert report["duplicate_name_count"] == 1
+    assert report["duplicate_declaration_count"] == 2
+    assert report["duplicate_names"] == ["dup_mod"]
+    assert report["blocked_reasons"] == ["ambiguous module name: dup_mod"]
+    assert report["next_required_action"] == (
+        "rename or disambiguate duplicate module declarations before refactor planning"
+    )
+    duplicate = report["duplicates"][0]
+    assert duplicate["name"] == "dup_mod"
+    assert duplicate["declaration_count"] == 2
+    assert duplicate["refactor_preflight_state"] == "blocked"
+    assert [location["start_line"] for location in duplicate["locations"]] == [4, 10]
+    assert report["safety"]["read_only"] is True
+    assert report["safety"]["duplicate_report_only"] is True
+    assert report["safety"]["emits_command_descriptors"] is False
+    assert report["safety"]["writes_files"] is False
+    assert report["safety"]["applies_refactor"] is False
+    assert report["safety"]["generates_patch"] is False
+    assert report["safety"]["runs_validation"] is False
+    assert report["safety"]["runs_shell"] is False
+    assert report["safety"]["invokes_pccx_lab"] is False
+    assert report["safety"]["invokes_launcher"] is False
+    assert report["safety"]["invokes_vendor_tools"] is False
+    assert report["safety"]["provider_calls"] is False
+    assert report["safety"]["hardware_access"] is False
+    assert report["writes_files"] is False
+    assert '"argv"' not in json.dumps(report)
+
+
+def test_build_module_duplicate_report_allows_unique_names():
+    report = build_module_duplicate_report(str(FIXTURE), FIXTURE)
+
+    assert report["report_state"] == "no-duplicates-detected"
+    assert report["duplicate_name_count"] == 0
+    assert report["duplicate_declaration_count"] == 0
+    assert report["duplicates"] == []
+    assert report["blocked_reasons"] == []
+    assert report["next_required_action"] == "continue module organization and refactor review"
 
 
 def test_build_refactor_candidate_list_reports_action_enablement():
@@ -1285,6 +1335,16 @@ def test_format_module_boundary_audit_text_mentions_read_only_gate():
     assert "read-only: no file writes" in text
 
 
+def test_format_module_duplicate_report_text_mentions_duplicates_and_boundary():
+    report = build_module_duplicate_report(str(DUPLICATE_FIXTURE), DUPLICATE_FIXTURE)
+    text = format_module_duplicate_report_text(report)
+
+    assert "module duplicates: duplicates-detected" in text
+    assert "dup_mod: 2 declarations" in text
+    assert "blocked: ambiguous module name: dup_mod" in text
+    assert "read-only duplicate report: no command argv" in text
+
+
 def test_format_refactor_candidate_list_text_mentions_actions_and_no_execution():
     candidates = build_refactor_candidate_list(str(FIXTURE), FIXTURE)
     text = format_refactor_candidate_list_text(candidates)
@@ -1598,6 +1658,27 @@ def test_cli_boundary_audit_text():
     assert "module bad_module (incomplete; blocked)" in result.stdout
     assert "blocked: missing endmodule for module: bad_module" in result.stdout
     assert "read-only: no file writes" in result.stdout
+
+
+def test_cli_module_duplicates_json():
+    result = _run_cli("module-duplicates", str(DUPLICATE_FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-duplicate-report"
+    assert payload["report_state"] == "duplicates-detected"
+    assert payload["duplicate_names"] == ["dup_mod"]
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["emits_command_descriptors"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_module_duplicates_text():
+    result = _run_cli("module-duplicates", str(DUPLICATE_FIXTURE), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "module duplicates: duplicates-detected" in result.stdout
+    assert "dup_mod: 2 declarations" in result.stdout
+    assert "read-only duplicate report: no command argv" in result.stdout
 
 
 def test_cli_refactor_candidates_json():
@@ -2285,6 +2366,12 @@ def test_cli_boundary_audit_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_module_duplicates_missing_path_exits_nonzero():
+    result = _run_cli("module-duplicates", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_cli_hierarchy_missing_path_exits_nonzero():
     result = _run_cli("hierarchy", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
@@ -2467,6 +2554,7 @@ def test_docs_cover_organization_flow_and_limits():
     workflow = WORKFLOW_DOC.read_text(encoding="utf-8")
     assert "organization <path>" in contract
     assert "boundary-audit <path>" in contract
+    assert "module-duplicates <path>" in contract
     assert "refactor-readiness <path>" in contract
     assert "hierarchy <path>" in contract
     assert "dependencies <path>" in contract
@@ -2486,6 +2574,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "MODULE_ORGANIZATION_WORKFLOW.md" in contract
     assert "proposal-only" in workflow
     assert "module-boundary-audit" in workflow
+    assert "module-duplicate-report" in workflow
     assert "module-refactor-readiness-summary" in workflow
     assert "module-hierarchy-view" in workflow
     assert "module-dependency-view" in workflow
@@ -2511,6 +2600,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "refactor checklist metadata" in workflow
     assert "refactor session status metadata" in workflow
     assert "boundary audit data" in workflow
+    assert "duplicate-name report" in workflow
     assert "readiness metadata" in workflow
     assert "hierarchy cycle report" in workflow
     assert "does not write files" in workflow


### PR DESCRIPTION
## Summary
- Add a read-only `module-duplicates` CLI surface for scanner-detected duplicate module declaration names.
- Include `module-duplicate-report` JSON/text output with duplicate names, declaration locations, blocked reasons, next required action, and explicit safety flags.
- Add a duplicate module fixture plus docs, tests, and editor bridge smoke coverage.

## Boundary
- No command argv emission, validation execution, shell execution, file writes, refactor application, patch generation, move execution, lab/launcher/vendor-tool/provider/hardware execution, LSP claim, marketplace claim, runtime claim, or stable API/ABI claim.
- Refs #8.

## Validation
- `PYTHONPATH=src python3 -m pytest -q tests/test_module_organization.py`
- `bash scripts/editor-bridge-smoke.sh`
- `python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py`
- `git diff --check`
- `PYTHONPATH=src python3 -m pytest -q`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `find scripts -type f -name '*.sh' -exec bash -n {} +`
- `PYTHONPATH=src python3 -m pccx_ide_cli module-duplicates fixtures/organization/duplicate_modules.sv --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli module-duplicates fixtures/organization/hierarchy_top.sv --format text`
- local forbidden-claim scan
