### PR TITLE
Add unresolved instantiation report

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ python -m pccx_ide_cli hierarchy fixtures/organization/hierarchy_top.sv --format
 python -m pccx_ide_cli dependencies fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli dependencies fixtures/organization/hierarchy_top.sv --format text
 python -m pccx_ide_cli hierarchy-cycles fixtures/organization/cyclic_hierarchy.sv --format json
+python -m pccx_ide_cli unresolved-instances fixtures/organization/unresolved_instances.sv --format text
 
 # Module header/port summary view (pre-stable, read-only)
 python -m pccx_ide_cli module-summary fixtures/organization/hierarchy_top.sv --format json
@@ -218,6 +219,8 @@ editor tree consumers. `dependencies` renders direct module dependency,
 dependent, and impact summaries from the same scanner data.
 `hierarchy-cycles` reports scanner-detected resolved dependency cycles
 for editor warnings without running validation or emitting command argv.
+`unresolved-instances` reports scanner-detected instantiation candidates
+whose target module is not declared in the scanned input.
 `module-summary` renders conservative module header and port summaries
 for editor sidebars and reviewed refactoring planning. `port-usage`
 renders target port declarations with scanner-detected dependent

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -51,6 +51,7 @@ python -m pccx_ide_cli refactor-readiness <path> --format json
 python -m pccx_ide_cli hierarchy <path> --format json
 python -m pccx_ide_cli dependencies <path> --format json
 python -m pccx_ide_cli hierarchy-cycles <path> --format json
+python -m pccx_ide_cli unresolved-instances <path> --format json
 python -m pccx_ide_cli module-summary <path> --format json
 python -m pccx_ide_cli port-usage <path> --module <name> --format json
 python -m pccx_ide_cli module-context <path> --module <name> --format json
@@ -208,11 +209,12 @@ editor status panes without selecting an action or emitting command argv. These
 surfaces do not write files, apply refactors, generate patches, run validation,
 invoke pccx-lab or the launcher, run vendor tools, call providers, touch
 hardware, or perform automatic repository actions. `hierarchy`,
-`dependencies`, `module-summary`, `port-usage`, `module-context`, and
-`refactor-impact` render focused read-only views from the same scanner data,
-including conservative module header/port summaries, target port usage
-summaries, target module context bundles, and target-specific refactor impact
-review data. The
+`dependencies`, `hierarchy-cycles`, `unresolved-instances`, `module-summary`,
+`port-usage`, `module-context`, and `refactor-impact` render focused
+read-only views from the same scanner data, including hierarchy cycle warnings,
+unresolved instantiation warnings, conservative module header/port summaries,
+target port usage summaries, target module context bundles, and
+target-specific refactor impact review data. The
 organization surface is documented in
 [`MODULE_ORGANIZATION_WORKFLOW.md`](./MODULE_ORGANIZATION_WORKFLOW.md).
 `refactor-plan` extends the same boundary with proposal-only

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -4,14 +4,16 @@
 
 This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
-`hierarchy-cycles`, `module-summary`, `boundary-audit`, `module-duplicates`,
-`refactor-candidates`, `port-usage`, `module-context`, `refactor-impact`, `validation-plan`,
-`refactor-review`, `refactor-approval`, `refactor-application`, `refactor-result`,
+`hierarchy-cycles`, `unresolved-instances`, `module-summary`,
+`boundary-audit`, `module-duplicates`, `refactor-candidates`, `port-usage`,
+`module-context`, `refactor-impact`, `validation-plan`, `refactor-review`,
+`refactor-approval`, `refactor-application`, `refactor-result`,
 `refactor-handoff`, `refactor-checklist`, and `refactor-session` CLI surfaces
 that report module boundary spans, scanner-based hierarchy data, direct
-dependency impact data, hierarchy cycle report metadata, conservative module
-header/port summaries, duplicate-name report metadata, target port usage summaries, target module context
-bundles, target-specific refactor impact data, boundary audit data, refactor
+dependency impact data, hierarchy cycle report metadata, unresolved
+instantiation report metadata, conservative module header/port summaries,
+duplicate-name report metadata, target port usage summaries, target module
+context bundles, target-specific refactor impact data, boundary audit data, refactor
 candidate metadata for editor action menus, proposal-only validation command
 descriptors, a summary-only review packet, approval decision metadata,
 application request metadata, and application result metadata plus refactor
@@ -32,6 +34,8 @@ python -m pccx_ide_cli dependencies <path> --format json
 python -m pccx_ide_cli dependencies <path> --format text
 python -m pccx_ide_cli hierarchy-cycles <path> --format json
 python -m pccx_ide_cli hierarchy-cycles <path> --format text
+python -m pccx_ide_cli unresolved-instances <path> --format json
+python -m pccx_ide_cli unresolved-instances <path> --format text
 python -m pccx_ide_cli module-summary <path> --format json
 python -m pccx_ide_cli module-summary <path> --format text
 python -m pccx_ide_cli boundary-audit <path> --format json
@@ -198,6 +202,44 @@ The hierarchy cycle report is display data only. It does not write files,
 apply refactors, generate patches, run validation, execute shell commands,
 emit command argv, invoke `pccx-lab`, invoke the launcher, call providers,
 touch hardware, upload telemetry, or perform automatic repository actions.
+
+The unresolved instantiation report uses scanner dependency edges that did
+not resolve to a module declaration in the scanned input:
+
+```json
+{
+  "kind": "module-unresolved-instance-report",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "report_state": "unresolved-instances-detected",
+  "has_unresolved_instances": true,
+  "unresolved_instance_count": 1,
+  "unresolved_modules": ["missing_child"],
+  "unresolved_instances": [
+    {
+      "unresolved_id": "unresolved-1",
+      "parent": "unresolved_top",
+      "target_module": "missing_child",
+      "instance": "u_missing",
+      "resolution_state": "unresolved"
+    }
+  ],
+  "safety": {
+    "read_only": true,
+    "writes_files": false,
+    "emits_command_descriptors": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The unresolved instantiation report is display data only. It does not write
+files, apply refactors, generate patches, run validation, execute shell
+commands, emit command argv, invoke `pccx-lab`, invoke the launcher, call
+providers, touch hardware, upload telemetry, or perform automatic repository
+actions.
 
 The module summary view reports conservative scanner-detected module
 header and port metadata:

--- a/fixtures/organization/unresolved_instances.sv
+++ b/fixtures/organization/unresolved_instances.sv
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
+
+module unresolved_top(input logic clk);
+    missing_child u_missing (.clk(clk));
+endmodule

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -33,6 +33,7 @@ run_json locate locate fixtures/modules/simple_module.sv simple_mod --format jso
 run_json module-hierarchy-view hierarchy fixtures/organization/hierarchy_top.sv --format json
 run_json module-dependency-view dependencies fixtures/organization/hierarchy_top.sv --format json
 run_json module-hierarchy-cycle-report hierarchy-cycles fixtures/organization/cyclic_hierarchy.sv --format json
+run_json module-unresolved-instance-report unresolved-instances fixtures/organization/unresolved_instances.sv --format json
 run_json module-duplicate-report module-duplicates fixtures/organization/duplicate_modules.sv --format json
 run_json module-summary-view module-summary fixtures/organization/hierarchy_top.sv --format json
 run_json module-refactor-candidate-list refactor-candidates fixtures/organization/hierarchy_top.sv --format json

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -266,6 +266,24 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    unresolved_instances_cmd = sub.add_parser(
+        "unresolved-instances",
+        help=(
+            "Render scanner-based read-only unresolved instantiation report data."
+        ),
+    )
+    unresolved_instances_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    unresolved_instances_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     module_summary_cmd = sub.add_parser(
         "module-summary",
         help=(
@@ -1205,6 +1223,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_hierarchy_cycle_text(report))
+        return 0
+
+    if args.command == "unresolved-instances":
+        from .module_organization import (
+            build_module_unresolved_instance_report,
+            format_module_unresolved_instance_report_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        report = build_module_unresolved_instance_report(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(report, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_unresolved_instance_report_text(report))
         return 0
 
     if args.command == "module-summary":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -143,6 +143,16 @@ HIERARCHY_CYCLE_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+UNRESOLVED_INSTANCE_REPORT_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based unresolved module instantiation report only",
+    "single-line instantiation candidates only",
+    "uses module declaration names from the same scan path",
+    "no semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
+    "does not apply refactors, write files, generate patches, or run validation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 MODULE_SUMMARY_LIMITATIONS: tuple[str, ...] = (
     "scanner-based module header and port summary data only",
     "ANSI-style port declarations are detected conservatively",
@@ -449,6 +459,28 @@ def _hierarchy_cycle_safety_flags() -> dict[str, bool]:
     return {
         "read_only": True,
         "cycle_report_only": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _unresolved_instance_report_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "unresolved_instance_report_only": True,
         "emits_command_descriptors": False,
         "writes_files": False,
         "moves_files": False,
@@ -1610,6 +1642,94 @@ def build_module_hierarchy_cycle_report(source: str, path: Path) -> dict[str, An
         "tool": "pccx-ide-cli",
         "unresolved": hierarchy["unresolved"],
         "unresolved_edge_count": len(hierarchy["edges"]) - resolved_edge_count,
+        "writes_files": False,
+    }
+
+
+def _unresolved_instance_rows(hierarchy: dict[str, Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    unresolved_edges = [
+        edge
+        for edge in hierarchy["edges"]
+        if not edge["resolved"]
+    ]
+    unresolved_edges.sort(
+        key=lambda edge: (
+            edge["file"],
+            edge["line"],
+            edge["column"],
+            edge["parent"],
+            edge["child"],
+            edge["instance"],
+        )
+    )
+
+    for index, edge in enumerate(unresolved_edges, 1):
+        rows.append({
+            "column": edge["column"],
+            "file": edge["file"],
+            "instance": edge["instance"],
+            "line": edge["line"],
+            "parent": edge["parent"],
+            "reason": (
+                f"unresolved module instantiation: {edge['child']} "
+                f"as {edge['instance']} in {edge['parent']}"
+            ),
+            "refactor_preflight_state": "blocked",
+            "resolution_state": "unresolved",
+            "target_module": edge["child"],
+            "unresolved_id": f"unresolved-{index}",
+        })
+    return rows
+
+
+def build_module_unresolved_instance_report(
+    source: str, path: Path
+) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    hierarchy = organization["hierarchy"]
+    resolved_edge_count = len([
+        edge
+        for edge in hierarchy["edges"]
+        if edge["resolved"]
+    ])
+    unresolved_instances = _unresolved_instance_rows(hierarchy)
+    unresolved_modules = sorted({
+        instance["target_module"]
+        for instance in unresolved_instances
+    })
+    blocked_reasons = [
+        instance["reason"]
+        for instance in unresolved_instances
+    ]
+
+    return {
+        "blocked_reasons": blocked_reasons,
+        "edge_count": len(hierarchy["edges"]),
+        "has_unresolved_instances": bool(unresolved_instances),
+        "kind": "module-unresolved-instance-report",
+        "limitations": list(UNRESOLVED_INSTANCE_REPORT_LIMITATIONS),
+        "module_count": len(modules),
+        "next_required_action": (
+            "resolve scanner-detected unresolved instantiations before refactor planning"
+            if unresolved_instances
+            else "continue hierarchy and refactor review"
+        ),
+        "report_state": (
+            "unresolved-instances-detected"
+            if unresolved_instances
+            else "no-unresolved-instances-detected"
+        ),
+        "resolved_edge_count": resolved_edge_count,
+        "safety": _unresolved_instance_report_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "tool": "pccx-ide-cli",
+        "unresolved_instance_count": len(unresolved_instances),
+        "unresolved_instances": unresolved_instances,
+        "unresolved_module_count": len(unresolved_modules),
+        "unresolved_modules": unresolved_modules,
         "writes_files": False,
     }
 
@@ -4067,6 +4187,36 @@ def format_module_hierarchy_cycle_text(report: dict[str, Any]) -> str:
     lines.append(f"next: {report['next_required_action']}")
     lines.append(
         "read-only cycle report: no command argv, validation, shell, "
+        "refactor, patch, file write, lab, launcher, vendor tool, provider, "
+        "or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_module_unresolved_instance_report_text(report: dict[str, Any]) -> str:
+    lines = [
+        f"source: {report['source']}",
+        f"unresolved instances: {report['report_state']}",
+        f"{report['module_count']} module"
+        f"{'s' if report['module_count'] != 1 else ''}",
+        f"{report['unresolved_instance_count']} unresolved instance"
+        f"{'s' if report['unresolved_instance_count'] != 1 else ''}",
+    ]
+    if not report["unresolved_instances"]:
+        lines.append("unresolved instances: none")
+    if report["unresolved_modules"]:
+        lines.append(f"unresolved modules: {', '.join(report['unresolved_modules'])}")
+    for instance in report["unresolved_instances"]:
+        lines.append(
+            f"{instance['unresolved_id']}: {instance['parent']} -> "
+            f"{instance['target_module']} as {instance['instance']} "
+            f"at {instance['file']}:{instance['line']}:{instance['column']}"
+        )
+    for reason in report["blocked_reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"next: {report['next_required_action']}")
+    lines.append(
+        "read-only unresolved report: no command argv, validation, shell, "
         "refactor, patch, file write, lab, launcher, vendor tool, provider, "
         "or hardware execution"
     )

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -14,6 +14,7 @@ SRC = REPO_ROOT / "src"
 FIXTURE = REPO_ROOT / "fixtures" / "organization" / "hierarchy_top.sv"
 CYCLIC_FIXTURE = REPO_ROOT / "fixtures" / "organization" / "cyclic_hierarchy.sv"
 DUPLICATE_FIXTURE = REPO_ROOT / "fixtures" / "organization" / "duplicate_modules.sv"
+UNRESOLVED_FIXTURE = REPO_ROOT / "fixtures" / "organization" / "unresolved_instances.sv"
 INCOMPLETE_FIXTURE = REPO_ROOT / "fixtures" / "missing_endmodule.sv"
 CONTRACT_DOC = REPO_ROOT / "docs" / "EDITOR_BRIDGE_CONTRACT.md"
 WORKFLOW_DOC = REPO_ROOT / "docs" / "MODULE_ORGANIZATION_WORKFLOW.md"
@@ -30,6 +31,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_organization_export,
     build_module_port_usage_view,
     build_module_summary_view,
+    build_module_unresolved_instance_report,
     build_refactor_candidate_list,
     build_refactor_approval_decision,
     build_refactor_application_result,
@@ -57,6 +59,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_module_organization_text,
     format_module_port_usage_text,
     format_module_summary_text,
+    format_module_unresolved_instance_report_text,
     format_refactor_candidate_list_text,
     format_refactor_impact_text,
     format_refactor_proposal_text,
@@ -467,6 +470,67 @@ def test_build_module_hierarchy_cycle_report_allows_acyclic_hierarchy():
     assert report["has_cycles"] is False
     assert report["cycle_count"] == 0
     assert report["cycles"] == []
+    assert report["blocked_reasons"] == []
+    assert report["next_required_action"] == "continue hierarchy and refactor review"
+
+
+def test_build_module_unresolved_instance_report_detects_missing_modules():
+    report = build_module_unresolved_instance_report(
+        str(UNRESOLVED_FIXTURE),
+        UNRESOLVED_FIXTURE,
+    )
+
+    assert report["kind"] == "module-unresolved-instance-report"
+    assert report["report_state"] == "unresolved-instances-detected"
+    assert report["has_unresolved_instances"] is True
+    assert report["module_count"] == 1
+    assert report["edge_count"] == 1
+    assert report["resolved_edge_count"] == 0
+    assert report["unresolved_instance_count"] == 1
+    assert report["unresolved_module_count"] == 1
+    assert report["unresolved_modules"] == ["missing_child"]
+    assert report["blocked_reasons"] == [
+        "unresolved module instantiation: missing_child as u_missing in unresolved_top"
+    ]
+    assert report["next_required_action"] == (
+        "resolve scanner-detected unresolved instantiations before refactor planning"
+    )
+    instance = report["unresolved_instances"][0]
+    assert instance["unresolved_id"] == "unresolved-1"
+    assert instance["target_module"] == "missing_child"
+    assert instance["parent"] == "unresolved_top"
+    assert instance["instance"] == "u_missing"
+    assert instance["file"] == str(UNRESOLVED_FIXTURE)
+    assert instance["line"] == 5
+    assert instance["column"] == 5
+    assert instance["resolution_state"] == "unresolved"
+    assert instance["refactor_preflight_state"] == "blocked"
+    assert report["safety"]["read_only"] is True
+    assert report["safety"]["unresolved_instance_report_only"] is True
+    assert report["safety"]["emits_command_descriptors"] is False
+    assert report["safety"]["writes_files"] is False
+    assert report["safety"]["applies_refactor"] is False
+    assert report["safety"]["generates_patch"] is False
+    assert report["safety"]["runs_validation"] is False
+    assert report["safety"]["runs_shell"] is False
+    assert report["safety"]["invokes_pccx_lab"] is False
+    assert report["safety"]["invokes_launcher"] is False
+    assert report["safety"]["invokes_vendor_tools"] is False
+    assert report["safety"]["provider_calls"] is False
+    assert report["safety"]["hardware_access"] is False
+    assert report["writes_files"] is False
+    assert '"argv"' not in json.dumps(report)
+
+
+def test_build_module_unresolved_instance_report_allows_resolved_hierarchy():
+    report = build_module_unresolved_instance_report(str(FIXTURE), FIXTURE)
+
+    assert report["report_state"] == "no-unresolved-instances-detected"
+    assert report["has_unresolved_instances"] is False
+    assert report["unresolved_instance_count"] == 0
+    assert report["unresolved_module_count"] == 0
+    assert report["unresolved_instances"] == []
+    assert report["unresolved_modules"] == []
     assert report["blocked_reasons"] == []
     assert report["next_required_action"] == "continue hierarchy and refactor review"
 
@@ -1394,6 +1458,20 @@ def test_format_module_hierarchy_cycle_text_mentions_cycle_and_boundary():
     assert "read-only cycle report: no command argv" in text
 
 
+def test_format_module_unresolved_instance_report_text_mentions_boundary():
+    report = build_module_unresolved_instance_report(
+        str(UNRESOLVED_FIXTURE),
+        UNRESOLVED_FIXTURE,
+    )
+    text = format_module_unresolved_instance_report_text(report)
+
+    assert "unresolved instances: unresolved-instances-detected" in text
+    assert "unresolved modules: missing_child" in text
+    assert "unresolved-1: unresolved_top -> missing_child as u_missing" in text
+    assert "blocked: unresolved module instantiation" in text
+    assert "read-only unresolved report: no command argv" in text
+
+
 def test_format_module_summary_text_mentions_ports_and_boundary():
     view = build_module_summary_view(str(FIXTURE), FIXTURE)
     text = format_module_summary_text(view)
@@ -1788,6 +1866,38 @@ def test_cli_hierarchy_cycles_text():
     assert "hierarchy cycles: cycles-detected" in result.stdout
     assert "cycle-1: alpha_mod -> beta_mod -> alpha_mod" in result.stdout
     assert "read-only cycle report: no command argv" in result.stdout
+
+
+def test_cli_unresolved_instances_json():
+    result = _run_cli(
+        "unresolved-instances",
+        str(UNRESOLVED_FIXTURE),
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-unresolved-instance-report"
+    assert payload["report_state"] == "unresolved-instances-detected"
+    assert payload["unresolved_modules"] == ["missing_child"]
+    assert payload["unresolved_instances"][0]["target_module"] == "missing_child"
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["emits_command_descriptors"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_unresolved_instances_text():
+    result = _run_cli(
+        "unresolved-instances",
+        str(UNRESOLVED_FIXTURE),
+        "--format",
+        "text",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "unresolved instances: unresolved-instances-detected" in result.stdout
+    assert "unresolved-1: unresolved_top -> missing_child as u_missing" in result.stdout
+    assert "read-only unresolved report: no command argv" in result.stdout
 
 
 def test_cli_module_summary_json():
@@ -2390,6 +2500,12 @@ def test_cli_hierarchy_cycles_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_unresolved_instances_missing_path_exits_nonzero():
+    result = _run_cli("unresolved-instances", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_cli_module_summary_missing_path_exits_nonzero():
     result = _run_cli("module-summary", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
@@ -2559,6 +2675,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "hierarchy <path>" in contract
     assert "dependencies <path>" in contract
     assert "hierarchy-cycles <path>" in contract
+    assert "unresolved-instances <path>" in contract
     assert "module-summary <path>" in contract
     assert "port-usage <path>" in contract
     assert "module-context <path>" in contract
@@ -2579,6 +2696,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-hierarchy-view" in workflow
     assert "module-dependency-view" in workflow
     assert "module-hierarchy-cycle-report" in workflow
+    assert "module-unresolved-instance-report" in workflow
     assert "module-summary-view" in workflow
     assert "module-port-usage-view" in workflow
     assert "module-context-bundle" in workflow
@@ -2603,5 +2721,6 @@ def test_docs_cover_organization_flow_and_limits():
     assert "duplicate-name report" in workflow
     assert "readiness metadata" in workflow
     assert "hierarchy cycle report" in workflow
+    assert "unresolved instantiation report" in workflow
     assert "does not write files" in workflow
     assert "not a full SystemVerilog parser" in workflow


### PR DESCRIPTION
## Summary
- add a read-only `unresolved-instances` CLI report for scanner-detected unresolved module instantiations
- include JSON/text output with blocked reasons, next action, locations, and explicit no-write/no-execution safety flags
- document the surface and add fixture, CLI, smoke, and pytest coverage

Refs #8

## Validation
- `PYTHONPATH=src python3 -m pytest -q tests/test_module_organization.py`
- `python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py`
- `git diff --check`
- `PYTHONPATH=src python3 -m pccx_ide_cli unresolved-instances fixtures/organization/unresolved_instances.sv --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli unresolved-instances fixtures/organization/hierarchy_top.sv --format text`
- `PYTHONPATH=src python3 -m pytest -q`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `find scripts -type f -name '*.sh' -exec bash -n {} +`