### PR TITLE
Add module root candidate report

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ python -m pccx_ide_cli dependencies fixtures/organization/hierarchy_top.sv --for
 python -m pccx_ide_cli dependencies fixtures/organization/hierarchy_top.sv --format text
 python -m pccx_ide_cli hierarchy-cycles fixtures/organization/cyclic_hierarchy.sv --format json
 python -m pccx_ide_cli unresolved-instances fixtures/organization/unresolved_instances.sv --format text
+python -m pccx_ide_cli module-roots fixtures/organization/hierarchy_top.sv --format json
 
 # Module header/port summary view (pre-stable, read-only)
 python -m pccx_ide_cli module-summary fixtures/organization/hierarchy_top.sv --format json
@@ -221,6 +222,8 @@ dependent, and impact summaries from the same scanner data.
 for editor warnings without running validation or emitting command argv.
 `unresolved-instances` reports scanner-detected instantiation candidates
 whose target module is not declared in the scanned input.
+`module-roots` reports scanner-detected root candidates for top-level
+module entry-point review.
 `module-summary` renders conservative module header and port summaries
 for editor sidebars and reviewed refactoring planning. `port-usage`
 renders target port declarations with scanner-detected dependent

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -52,6 +52,7 @@ python -m pccx_ide_cli hierarchy <path> --format json
 python -m pccx_ide_cli dependencies <path> --format json
 python -m pccx_ide_cli hierarchy-cycles <path> --format json
 python -m pccx_ide_cli unresolved-instances <path> --format json
+python -m pccx_ide_cli module-roots <path> --format json
 python -m pccx_ide_cli module-summary <path> --format json
 python -m pccx_ide_cli port-usage <path> --module <name> --format json
 python -m pccx_ide_cli module-context <path> --module <name> --format json
@@ -209,11 +210,12 @@ editor status panes without selecting an action or emitting command argv. These
 surfaces do not write files, apply refactors, generate patches, run validation,
 invoke pccx-lab or the launcher, run vendor tools, call providers, touch
 hardware, or perform automatic repository actions. `hierarchy`,
-`dependencies`, `hierarchy-cycles`, `unresolved-instances`, `module-summary`,
-`port-usage`, `module-context`, and `refactor-impact` render focused
-read-only views from the same scanner data, including hierarchy cycle warnings,
-unresolved instantiation warnings, conservative module header/port summaries,
-target port usage summaries, target module context bundles, and
+`dependencies`, `hierarchy-cycles`, `unresolved-instances`, `module-roots`,
+`module-summary`, `port-usage`, `module-context`, and `refactor-impact` render
+focused read-only views from the same scanner data, including hierarchy cycle
+warnings, unresolved instantiation warnings, root-candidate summaries,
+conservative module header/port summaries, target port usage summaries,
+target module context bundles, and
 target-specific refactor impact review data. The
 organization surface is documented in
 [`MODULE_ORGANIZATION_WORKFLOW.md`](./MODULE_ORGANIZATION_WORKFLOW.md).

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -4,16 +4,17 @@
 
 This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
-`hierarchy-cycles`, `unresolved-instances`, `module-summary`,
+`hierarchy-cycles`, `unresolved-instances`, `module-roots`, `module-summary`,
 `boundary-audit`, `module-duplicates`, `refactor-candidates`, `port-usage`,
 `module-context`, `refactor-impact`, `validation-plan`, `refactor-review`,
 `refactor-approval`, `refactor-application`, `refactor-result`,
 `refactor-handoff`, `refactor-checklist`, and `refactor-session` CLI surfaces
 that report module boundary spans, scanner-based hierarchy data, direct
 dependency impact data, hierarchy cycle report metadata, unresolved
-instantiation report metadata, conservative module header/port summaries,
-duplicate-name report metadata, target port usage summaries, target module
-context bundles, target-specific refactor impact data, boundary audit data, refactor
+instantiation report metadata, root-candidate report metadata, conservative
+module header/port summaries, duplicate-name report metadata, target port
+usage summaries, target module context bundles, target-specific refactor
+impact data, boundary audit data, refactor
 candidate metadata for editor action menus, proposal-only validation command
 descriptors, a summary-only review packet, approval decision metadata,
 application request metadata, and application result metadata plus refactor
@@ -36,6 +37,8 @@ python -m pccx_ide_cli hierarchy-cycles <path> --format json
 python -m pccx_ide_cli hierarchy-cycles <path> --format text
 python -m pccx_ide_cli unresolved-instances <path> --format json
 python -m pccx_ide_cli unresolved-instances <path> --format text
+python -m pccx_ide_cli module-roots <path> --format json
+python -m pccx_ide_cli module-roots <path> --format text
 python -m pccx_ide_cli module-summary <path> --format json
 python -m pccx_ide_cli module-summary <path> --format text
 python -m pccx_ide_cli boundary-audit <path> --format json
@@ -240,6 +243,42 @@ files, apply refactors, generate patches, run validation, execute shell
 commands, emit command argv, invoke `pccx-lab`, invoke the launcher, call
 providers, touch hardware, upload telemetry, or perform automatic repository
 actions.
+
+The root-candidate report uses scanner hierarchy roots to identify modules
+that are not instantiated by another resolved module in the scanned input:
+
+```json
+{
+  "kind": "module-root-candidate-report",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "report_state": "roots-detected",
+  "root_count": 1,
+  "root_names": ["top_mod"],
+  "roots": [
+    {
+      "name": "top_mod",
+      "root_state": "root-candidate",
+      "direct_dependencies": ["leaf_mod"],
+      "unresolved_dependencies": [],
+      "reason": "not instantiated by another resolved module"
+    }
+  ],
+  "safety": {
+    "read_only": true,
+    "writes_files": false,
+    "emits_command_descriptors": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The root-candidate report is display data only. It does not write files,
+apply refactors, generate patches, run validation, execute shell commands,
+emit command argv, invoke `pccx-lab`, invoke the launcher, call providers,
+touch hardware, upload telemetry, or perform automatic repository actions.
 
 The module summary view reports conservative scanner-detected module
 header and port metadata:

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -34,6 +34,7 @@ run_json module-hierarchy-view hierarchy fixtures/organization/hierarchy_top.sv 
 run_json module-dependency-view dependencies fixtures/organization/hierarchy_top.sv --format json
 run_json module-hierarchy-cycle-report hierarchy-cycles fixtures/organization/cyclic_hierarchy.sv --format json
 run_json module-unresolved-instance-report unresolved-instances fixtures/organization/unresolved_instances.sv --format json
+run_json module-root-candidate-report module-roots fixtures/organization/hierarchy_top.sv --format json
 run_json module-duplicate-report module-duplicates fixtures/organization/duplicate_modules.sv --format json
 run_json module-summary-view module-summary fixtures/organization/hierarchy_top.sv --format json
 run_json module-refactor-candidate-list refactor-candidates fixtures/organization/hierarchy_top.sv --format json

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -284,6 +284,24 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    module_roots_cmd = sub.add_parser(
+        "module-roots",
+        help=(
+            "Render scanner-based read-only module root-candidate report data."
+        ),
+    )
+    module_roots_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    module_roots_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     module_summary_cmd = sub.add_parser(
         "module-summary",
         help=(
@@ -1241,6 +1259,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_unresolved_instance_report_text(report))
+        return 0
+
+    if args.command == "module-roots":
+        from .module_organization import (
+            build_module_root_candidate_report,
+            format_module_root_candidate_report_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        report = build_module_root_candidate_report(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(report, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_root_candidate_report_text(report))
         return 0
 
     if args.command == "module-summary":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -153,6 +153,16 @@ UNRESOLVED_INSTANCE_REPORT_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+MODULE_ROOT_REPORT_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based module root-candidate report only",
+    "uses resolved dependency edges from the organization scanner",
+    "single-line instantiation candidates only",
+    "no semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
+    "does not apply refactors, write files, generate patches, or run validation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 MODULE_SUMMARY_LIMITATIONS: tuple[str, ...] = (
     "scanner-based module header and port summary data only",
     "ANSI-style port declarations are detected conservatively",
@@ -481,6 +491,28 @@ def _unresolved_instance_report_safety_flags() -> dict[str, bool]:
     return {
         "read_only": True,
         "unresolved_instance_report_only": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _module_root_report_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "root_candidate_report_only": True,
         "emits_command_descriptors": False,
         "writes_files": False,
         "moves_files": False,
@@ -1730,6 +1762,103 @@ def build_module_unresolved_instance_report(
         "unresolved_instances": unresolved_instances,
         "unresolved_module_count": len(unresolved_modules),
         "unresolved_modules": unresolved_modules,
+        "writes_files": False,
+    }
+
+
+def _module_root_rows(
+    modules: list[dict[str, Any]],
+    hierarchy: dict[str, Any],
+) -> list[dict[str, Any]]:
+    modules_by_name: dict[str, dict[str, Any]] = {}
+    declaration_counts: dict[str, int] = {}
+    for module in modules:
+        modules_by_name.setdefault(module["name"], module)
+        declaration_counts[module["name"]] = declaration_counts.get(module["name"], 0) + 1
+
+    rows: list[dict[str, Any]] = []
+    for root_name in hierarchy["roots"]:
+        module = modules_by_name[root_name]
+        direct_dependencies = sorted({
+            edge["child"]
+            for edge in hierarchy["edges"]
+            if edge["parent"] == root_name and edge["resolved"]
+        })
+        unresolved_dependencies = sorted({
+            edge["child"]
+            for edge in hierarchy["edges"]
+            if edge["parent"] == root_name and not edge["resolved"]
+        })
+        blocked_reasons: list[str] = []
+        if not module["complete"]:
+            blocked_reasons.append(f"module boundary is incomplete: {root_name}")
+        if declaration_counts[root_name] > 1:
+            blocked_reasons.append(f"ambiguous module name: {root_name}")
+        rows.append({
+            "blocked_reasons": blocked_reasons,
+            "complete": module["complete"],
+            "declaration_count": declaration_counts[root_name],
+            "direct_dependencies": direct_dependencies,
+            "direct_dependency_count": len(direct_dependencies),
+            "file": module["file"],
+            "name": root_name,
+            "reason": "not instantiated by another resolved module",
+            "refactor_preflight_state": (
+                "blocked" if blocked_reasons else "ready-for-review"
+            ),
+            "root_state": "root-candidate",
+            "start_column": module["start_column"],
+            "start_line": module["start_line"],
+            "unresolved_dependencies": unresolved_dependencies,
+            "unresolved_dependency_count": len(unresolved_dependencies),
+        })
+    return rows
+
+
+def build_module_root_candidate_report(source: str, path: Path) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    hierarchy = organization["hierarchy"]
+    resolved_edge_count = len([
+        edge
+        for edge in hierarchy["edges"]
+        if edge["resolved"]
+    ])
+    roots = _module_root_rows(modules, hierarchy)
+    blocked_reasons = list(dict.fromkeys([
+        reason
+        for root in roots
+        for reason in root["blocked_reasons"]
+    ]))
+    if modules and not roots:
+        blocked_reasons.append("no root candidates detected")
+    if not modules:
+        blocked_reasons.append("no module declarations detected")
+
+    return {
+        "blocked_reasons": blocked_reasons,
+        "edge_count": len(hierarchy["edges"]),
+        "kind": "module-root-candidate-report",
+        "limitations": list(MODULE_ROOT_REPORT_LIMITATIONS),
+        "module_count": len(modules),
+        "next_required_action": (
+            "review scanner-detected root candidates for top-level organization"
+            if roots
+            else "resolve hierarchy blockers before root-candidate review"
+        ),
+        "report_state": "roots-detected" if roots else "no-roots-detected",
+        "resolved_edge_count": resolved_edge_count,
+        "root_count": len(roots),
+        "root_names": [
+            root["name"]
+            for root in roots
+        ],
+        "roots": roots,
+        "safety": _module_root_report_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "tool": "pccx-ide-cli",
+        "unresolved_edge_count": len(hierarchy["edges"]) - resolved_edge_count,
         "writes_files": False,
     }
 
@@ -4217,6 +4346,41 @@ def format_module_unresolved_instance_report_text(report: dict[str, Any]) -> str
     lines.append(f"next: {report['next_required_action']}")
     lines.append(
         "read-only unresolved report: no command argv, validation, shell, "
+        "refactor, patch, file write, lab, launcher, vendor tool, provider, "
+        "or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_module_root_candidate_report_text(report: dict[str, Any]) -> str:
+    lines = [
+        f"source: {report['source']}",
+        f"module roots: {report['report_state']}",
+        f"{report['module_count']} module"
+        f"{'s' if report['module_count'] != 1 else ''}",
+        f"{report['root_count']} root candidate"
+        f"{'s' if report['root_count'] != 1 else ''}",
+    ]
+    if not report["roots"]:
+        lines.append("roots: none")
+    for root in report["roots"]:
+        dependencies = ", ".join(root["direct_dependencies"]) or "none"
+        unresolved = ", ".join(root["unresolved_dependencies"]) or "none"
+        lines.append(
+            f"{root['file']}:{root['start_line']}: module {root['name']} "
+            f"({root['refactor_preflight_state']})"
+        )
+        lines.append(
+            f"  dependencies={dependencies}; unresolved={unresolved}; "
+            f"reason={root['reason']}"
+        )
+        for reason in root["blocked_reasons"]:
+            lines.append(f"  blocked: {reason}")
+    for reason in report["blocked_reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"next: {report['next_required_action']}")
+    lines.append(
+        "read-only root report: no command argv, validation, shell, "
         "refactor, patch, file write, lab, launcher, vendor tool, provider, "
         "or hardware execution"
     )

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -30,6 +30,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_hierarchy_view,
     build_module_organization_export,
     build_module_port_usage_view,
+    build_module_root_candidate_report,
     build_module_summary_view,
     build_module_unresolved_instance_report,
     build_refactor_candidate_list,
@@ -58,6 +59,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_module_hierarchy_text,
     format_module_organization_text,
     format_module_port_usage_text,
+    format_module_root_candidate_report_text,
     format_module_summary_text,
     format_module_unresolved_instance_report_text,
     format_refactor_candidate_list_text,
@@ -533,6 +535,64 @@ def test_build_module_unresolved_instance_report_allows_resolved_hierarchy():
     assert report["unresolved_modules"] == []
     assert report["blocked_reasons"] == []
     assert report["next_required_action"] == "continue hierarchy and refactor review"
+
+
+def test_build_module_root_candidate_report_detects_top_modules():
+    report = build_module_root_candidate_report(str(FIXTURE), FIXTURE)
+
+    assert report["kind"] == "module-root-candidate-report"
+    assert report["report_state"] == "roots-detected"
+    assert report["module_count"] == 2
+    assert report["edge_count"] == 1
+    assert report["resolved_edge_count"] == 1
+    assert report["unresolved_edge_count"] == 0
+    assert report["root_count"] == 1
+    assert report["root_names"] == ["top_mod"]
+    assert report["blocked_reasons"] == []
+    assert report["next_required_action"] == (
+        "review scanner-detected root candidates for top-level organization"
+    )
+    root = report["roots"][0]
+    assert root["name"] == "top_mod"
+    assert root["file"] == str(FIXTURE)
+    assert root["start_line"] == 9
+    assert root["start_column"] == 1
+    assert root["complete"] is True
+    assert root["declaration_count"] == 1
+    assert root["direct_dependencies"] == ["leaf_mod"]
+    assert root["direct_dependency_count"] == 1
+    assert root["unresolved_dependencies"] == []
+    assert root["unresolved_dependency_count"] == 0
+    assert root["refactor_preflight_state"] == "ready-for-review"
+    assert root["reason"] == "not instantiated by another resolved module"
+    assert report["safety"]["read_only"] is True
+    assert report["safety"]["root_candidate_report_only"] is True
+    assert report["safety"]["emits_command_descriptors"] is False
+    assert report["safety"]["writes_files"] is False
+    assert report["safety"]["applies_refactor"] is False
+    assert report["safety"]["generates_patch"] is False
+    assert report["safety"]["runs_validation"] is False
+    assert report["safety"]["runs_shell"] is False
+    assert report["safety"]["invokes_pccx_lab"] is False
+    assert report["safety"]["invokes_launcher"] is False
+    assert report["safety"]["invokes_vendor_tools"] is False
+    assert report["safety"]["provider_calls"] is False
+    assert report["safety"]["hardware_access"] is False
+    assert report["writes_files"] is False
+    assert '"argv"' not in json.dumps(report)
+
+
+def test_build_module_root_candidate_report_blocks_when_no_roots_detected():
+    report = build_module_root_candidate_report(str(CYCLIC_FIXTURE), CYCLIC_FIXTURE)
+
+    assert report["report_state"] == "no-roots-detected"
+    assert report["root_count"] == 0
+    assert report["root_names"] == []
+    assert report["roots"] == []
+    assert report["blocked_reasons"] == ["no root candidates detected"]
+    assert report["next_required_action"] == (
+        "resolve hierarchy blockers before root-candidate review"
+    )
 
 
 def test_build_module_summary_view_reports_ports_and_safety():
@@ -1472,6 +1532,17 @@ def test_format_module_unresolved_instance_report_text_mentions_boundary():
     assert "read-only unresolved report: no command argv" in text
 
 
+def test_format_module_root_candidate_report_text_mentions_boundary():
+    report = build_module_root_candidate_report(str(FIXTURE), FIXTURE)
+    text = format_module_root_candidate_report_text(report)
+
+    assert "module roots: roots-detected" in text
+    assert "1 root candidate" in text
+    assert "module top_mod (ready-for-review)" in text
+    assert "dependencies=leaf_mod; unresolved=none" in text
+    assert "read-only root report: no command argv" in text
+
+
 def test_format_module_summary_text_mentions_ports_and_boundary():
     view = build_module_summary_view(str(FIXTURE), FIXTURE)
     text = format_module_summary_text(view)
@@ -1898,6 +1969,28 @@ def test_cli_unresolved_instances_text():
     assert "unresolved instances: unresolved-instances-detected" in result.stdout
     assert "unresolved-1: unresolved_top -> missing_child as u_missing" in result.stdout
     assert "read-only unresolved report: no command argv" in result.stdout
+
+
+def test_cli_module_roots_json():
+    result = _run_cli("module-roots", str(FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-root-candidate-report"
+    assert payload["report_state"] == "roots-detected"
+    assert payload["root_names"] == ["top_mod"]
+    assert payload["roots"][0]["direct_dependencies"] == ["leaf_mod"]
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["emits_command_descriptors"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_module_roots_text():
+    result = _run_cli("module-roots", str(FIXTURE), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "module roots: roots-detected" in result.stdout
+    assert "module top_mod (ready-for-review)" in result.stdout
+    assert "read-only root report: no command argv" in result.stdout
 
 
 def test_cli_module_summary_json():
@@ -2506,6 +2599,12 @@ def test_cli_unresolved_instances_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_module_roots_missing_path_exits_nonzero():
+    result = _run_cli("module-roots", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_cli_module_summary_missing_path_exits_nonzero():
     result = _run_cli("module-summary", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
@@ -2676,6 +2775,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "dependencies <path>" in contract
     assert "hierarchy-cycles <path>" in contract
     assert "unresolved-instances <path>" in contract
+    assert "module-roots <path>" in contract
     assert "module-summary <path>" in contract
     assert "port-usage <path>" in contract
     assert "module-context <path>" in contract
@@ -2697,6 +2797,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-dependency-view" in workflow
     assert "module-hierarchy-cycle-report" in workflow
     assert "module-unresolved-instance-report" in workflow
+    assert "module-root-candidate-report" in workflow
     assert "module-summary-view" in workflow
     assert "module-port-usage-view" in workflow
     assert "module-context-bundle" in workflow
@@ -2722,5 +2823,6 @@ def test_docs_cover_organization_flow_and_limits():
     assert "readiness metadata" in workflow
     assert "hierarchy cycle report" in workflow
     assert "unresolved instantiation report" in workflow
+    assert "root-candidate report" in workflow
     assert "does not write files" in workflow
     assert "not a full SystemVerilog parser" in workflow


### PR DESCRIPTION
## Summary
- add a read-only `module-roots` CLI report for scanner-detected hierarchy root candidates
- include JSON/text output with root names, dependency counts, blocked reasons, next action, and explicit no-write/no-execution safety flags
- document the surface and add CLI, smoke, and pytest coverage

Refs #8

## Validation
- `PYTHONPATH=src python3 -m pytest -q tests/test_module_organization.py`
- `python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py`
- `git diff --check`
- `PYTHONPATH=src python3 -m pccx_ide_cli module-roots fixtures/organization/hierarchy_top.sv --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli module-roots fixtures/organization/cyclic_hierarchy.sv --format text`
- `PYTHONPATH=src python3 -m pytest -q`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `find scripts -type f -name '*.sh' -exec bash -n {} +`\n- local forbidden-claim scan