### PR TITLE
Add module leaf candidate report

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ python -m pccx_ide_cli dependencies fixtures/organization/hierarchy_top.sv --for
 python -m pccx_ide_cli hierarchy-cycles fixtures/organization/cyclic_hierarchy.sv --format json
 python -m pccx_ide_cli unresolved-instances fixtures/organization/unresolved_instances.sv --format text
 python -m pccx_ide_cli module-roots fixtures/organization/hierarchy_top.sv --format json
+python -m pccx_ide_cli module-leaves fixtures/organization/hierarchy_top.sv --format json
 
 # Module header/port summary view (pre-stable, read-only)
 python -m pccx_ide_cli module-summary fixtures/organization/hierarchy_top.sv --format json
@@ -224,6 +225,8 @@ for editor warnings without running validation or emitting command argv.
 whose target module is not declared in the scanned input.
 `module-roots` reports scanner-detected root candidates for top-level
 module entry-point review.
+`module-leaves` reports scanner-detected leaf candidates for dependency-end
+organization review.
 `module-summary` renders conservative module header and port summaries
 for editor sidebars and reviewed refactoring planning. `port-usage`
 renders target port declarations with scanner-detected dependent

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -53,6 +53,7 @@ python -m pccx_ide_cli dependencies <path> --format json
 python -m pccx_ide_cli hierarchy-cycles <path> --format json
 python -m pccx_ide_cli unresolved-instances <path> --format json
 python -m pccx_ide_cli module-roots <path> --format json
+python -m pccx_ide_cli module-leaves <path> --format json
 python -m pccx_ide_cli module-summary <path> --format json
 python -m pccx_ide_cli port-usage <path> --module <name> --format json
 python -m pccx_ide_cli module-context <path> --module <name> --format json
@@ -211,9 +212,10 @@ surfaces do not write files, apply refactors, generate patches, run validation,
 invoke pccx-lab or the launcher, run vendor tools, call providers, touch
 hardware, or perform automatic repository actions. `hierarchy`,
 `dependencies`, `hierarchy-cycles`, `unresolved-instances`, `module-roots`,
-`module-summary`, `port-usage`, `module-context`, and `refactor-impact` render
-focused read-only views from the same scanner data, including hierarchy cycle
-warnings, unresolved instantiation warnings, root-candidate summaries,
+`module-leaves`, `module-summary`, `port-usage`, `module-context`, and
+`refactor-impact` render focused read-only views from the same scanner data,
+including hierarchy cycle warnings, unresolved instantiation warnings,
+root-candidate summaries, leaf-candidate summaries,
 conservative module header/port summaries, target port usage summaries,
 target module context bundles, and
 target-specific refactor impact review data. The

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -4,17 +4,18 @@
 
 This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
-`hierarchy-cycles`, `unresolved-instances`, `module-roots`, `module-summary`,
-`boundary-audit`, `module-duplicates`, `refactor-candidates`, `port-usage`,
-`module-context`, `refactor-impact`, `validation-plan`, `refactor-review`,
-`refactor-approval`, `refactor-application`, `refactor-result`,
-`refactor-handoff`, `refactor-checklist`, and `refactor-session` CLI surfaces
-that report module boundary spans, scanner-based hierarchy data, direct
-dependency impact data, hierarchy cycle report metadata, unresolved
-instantiation report metadata, root-candidate report metadata, conservative
-module header/port summaries, duplicate-name report metadata, target port
-usage summaries, target module context bundles, target-specific refactor
-impact data, boundary audit data, refactor
+`hierarchy-cycles`, `unresolved-instances`, `module-roots`, `module-leaves`,
+`module-summary`, `boundary-audit`, `module-duplicates`, `refactor-candidates`,
+`port-usage`, `module-context`, `refactor-impact`, `validation-plan`,
+`refactor-review`, `refactor-approval`, `refactor-application`,
+`refactor-result`, `refactor-handoff`, `refactor-checklist`, and
+`refactor-session` CLI surfaces that report module boundary spans,
+scanner-based hierarchy data, direct dependency impact data, hierarchy cycle
+report metadata, unresolved instantiation report metadata, root-candidate
+report metadata, leaf-candidate report metadata, conservative module
+header/port summaries, duplicate-name report metadata, target port usage
+summaries, target module context bundles, target-specific refactor impact data,
+boundary audit data, refactor
 candidate metadata for editor action menus, proposal-only validation command
 descriptors, a summary-only review packet, approval decision metadata,
 application request metadata, and application result metadata plus refactor
@@ -39,6 +40,8 @@ python -m pccx_ide_cli unresolved-instances <path> --format json
 python -m pccx_ide_cli unresolved-instances <path> --format text
 python -m pccx_ide_cli module-roots <path> --format json
 python -m pccx_ide_cli module-roots <path> --format text
+python -m pccx_ide_cli module-leaves <path> --format json
+python -m pccx_ide_cli module-leaves <path> --format text
 python -m pccx_ide_cli module-summary <path> --format json
 python -m pccx_ide_cli module-summary <path> --format text
 python -m pccx_ide_cli boundary-audit <path> --format json
@@ -276,6 +279,42 @@ that are not instantiated by another resolved module in the scanned input:
 ```
 
 The root-candidate report is display data only. It does not write files,
+apply refactors, generate patches, run validation, execute shell commands,
+emit command argv, invoke `pccx-lab`, invoke the launcher, call providers,
+touch hardware, upload telemetry, or perform automatic repository actions.
+
+The leaf-candidate report uses scanner hierarchy edges to identify modules
+that do not instantiate another resolved module in the scanned input:
+
+```json
+{
+  "kind": "module-leaf-candidate-report",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "report_state": "leaves-detected",
+  "leaf_count": 1,
+  "leaf_names": ["leaf_mod"],
+  "leaves": [
+    {
+      "name": "leaf_mod",
+      "leaf_state": "leaf-candidate",
+      "direct_dependents": ["top_mod"],
+      "unresolved_dependencies": [],
+      "reason": "does not instantiate another resolved module"
+    }
+  ],
+  "safety": {
+    "read_only": true,
+    "writes_files": false,
+    "emits_command_descriptors": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The leaf-candidate report is display data only. It does not write files,
 apply refactors, generate patches, run validation, execute shell commands,
 emit command argv, invoke `pccx-lab`, invoke the launcher, call providers,
 touch hardware, upload telemetry, or perform automatic repository actions.

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -302,6 +302,24 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    module_leaves_cmd = sub.add_parser(
+        "module-leaves",
+        help=(
+            "Render scanner-based read-only module leaf-candidate report data."
+        ),
+    )
+    module_leaves_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    module_leaves_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     module_summary_cmd = sub.add_parser(
         "module-summary",
         help=(
@@ -1277,6 +1295,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_root_candidate_report_text(report))
+        return 0
+
+    if args.command == "module-leaves":
+        from .module_organization import (
+            build_module_leaf_candidate_report,
+            format_module_leaf_candidate_report_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        report = build_module_leaf_candidate_report(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(report, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_leaf_candidate_report_text(report))
         return 0
 
     if args.command == "module-summary":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -163,6 +163,17 @@ MODULE_ROOT_REPORT_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+MODULE_LEAF_REPORT_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based module leaf-candidate report only",
+    "uses resolved dependency edges from the organization scanner",
+    "single-line instantiation candidates only",
+    "unresolved instantiation candidates block leaf-candidate readiness",
+    "no semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
+    "does not apply refactors, write files, generate patches, or run validation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 MODULE_SUMMARY_LIMITATIONS: tuple[str, ...] = (
     "scanner-based module header and port summary data only",
     "ANSI-style port declarations are detected conservatively",
@@ -513,6 +524,28 @@ def _module_root_report_safety_flags() -> dict[str, bool]:
     return {
         "read_only": True,
         "root_candidate_report_only": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _module_leaf_report_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "leaf_candidate_report_only": True,
         "emits_command_descriptors": False,
         "writes_files": False,
         "moves_files": False,
@@ -1774,7 +1807,9 @@ def _module_root_rows(
     declaration_counts: dict[str, int] = {}
     for module in modules:
         modules_by_name.setdefault(module["name"], module)
-        declaration_counts[module["name"]] = declaration_counts.get(module["name"], 0) + 1
+        declaration_counts[module["name"]] = (
+            declaration_counts.get(module["name"], 0) + 1
+        )
 
     rows: list[dict[str, Any]] = []
     for root_name in hierarchy["roots"]:
@@ -1855,6 +1890,128 @@ def build_module_root_candidate_report(source: str, path: Path) -> dict[str, Any
         ],
         "roots": roots,
         "safety": _module_root_report_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "tool": "pccx-ide-cli",
+        "unresolved_edge_count": len(hierarchy["edges"]) - resolved_edge_count,
+        "writes_files": False,
+    }
+
+
+def _module_leaf_rows(
+    modules: list[dict[str, Any]],
+    hierarchy: dict[str, Any],
+) -> list[dict[str, Any]]:
+    modules_by_name: dict[str, dict[str, Any]] = {}
+    declaration_counts: dict[str, int] = {}
+    for module in modules:
+        modules_by_name.setdefault(module["name"], module)
+        declaration_counts[module["name"]] = declaration_counts.get(module["name"], 0) + 1
+
+    resolved_dependencies_by_module: dict[str, set[str]] = {
+        name: set()
+        for name in modules_by_name
+    }
+    direct_dependents_by_module: dict[str, set[str]] = {
+        name: set()
+        for name in modules_by_name
+    }
+    unresolved_dependencies_by_module: dict[str, set[str]] = {
+        name: set()
+        for name in modules_by_name
+    }
+    for edge in hierarchy["edges"]:
+        parent = edge["parent"]
+        child = edge["child"]
+        if parent not in modules_by_name:
+            continue
+        if edge["resolved"]:
+            resolved_dependencies_by_module.setdefault(parent, set()).add(child)
+            if child in direct_dependents_by_module:
+                direct_dependents_by_module[child].add(parent)
+        else:
+            unresolved_dependencies_by_module.setdefault(parent, set()).add(child)
+
+    rows: list[dict[str, Any]] = []
+    for leaf_name in sorted(modules_by_name):
+        if resolved_dependencies_by_module.get(leaf_name):
+            continue
+        module = modules_by_name[leaf_name]
+        direct_dependents = sorted(direct_dependents_by_module.get(leaf_name, set()))
+        unresolved_dependencies = sorted(
+            unresolved_dependencies_by_module.get(leaf_name, set())
+        )
+        blocked_reasons: list[str] = []
+        if not module["complete"]:
+            blocked_reasons.append(f"module boundary is incomplete: {leaf_name}")
+        if declaration_counts[leaf_name] > 1:
+            blocked_reasons.append(f"ambiguous module name: {leaf_name}")
+        if unresolved_dependencies:
+            blocked_reasons.append(
+                "unresolved dependencies for leaf candidate: "
+                f"{', '.join(unresolved_dependencies)}"
+            )
+        rows.append({
+            "blocked_reasons": blocked_reasons,
+            "complete": module["complete"],
+            "declaration_count": declaration_counts[leaf_name],
+            "direct_dependents": direct_dependents,
+            "direct_dependent_count": len(direct_dependents),
+            "file": module["file"],
+            "leaf_state": "leaf-candidate",
+            "name": leaf_name,
+            "reason": "does not instantiate another resolved module",
+            "refactor_preflight_state": (
+                "blocked" if blocked_reasons else "ready-for-review"
+            ),
+            "start_column": module["start_column"],
+            "start_line": module["start_line"],
+            "unresolved_dependencies": unresolved_dependencies,
+            "unresolved_dependency_count": len(unresolved_dependencies),
+        })
+    return rows
+
+
+def build_module_leaf_candidate_report(source: str, path: Path) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    hierarchy = organization["hierarchy"]
+    resolved_edge_count = len([
+        edge
+        for edge in hierarchy["edges"]
+        if edge["resolved"]
+    ])
+    leaves = _module_leaf_rows(modules, hierarchy)
+    blocked_reasons = list(dict.fromkeys([
+        reason
+        for leaf in leaves
+        for reason in leaf["blocked_reasons"]
+    ]))
+    if modules and not leaves:
+        blocked_reasons.append("no leaf candidates detected")
+    if not modules:
+        blocked_reasons.append("no module declarations detected")
+
+    return {
+        "blocked_reasons": blocked_reasons,
+        "edge_count": len(hierarchy["edges"]),
+        "kind": "module-leaf-candidate-report",
+        "leaf_count": len(leaves),
+        "leaf_names": [
+            leaf["name"]
+            for leaf in leaves
+        ],
+        "leaves": leaves,
+        "limitations": list(MODULE_LEAF_REPORT_LIMITATIONS),
+        "module_count": len(modules),
+        "next_required_action": (
+            "review scanner-detected leaf candidates for dependency-end organization"
+            if leaves
+            else "resolve hierarchy blockers before leaf-candidate review"
+        ),
+        "report_state": "leaves-detected" if leaves else "no-leaves-detected",
+        "resolved_edge_count": resolved_edge_count,
+        "safety": _module_leaf_report_safety_flags(),
         "scanner": "line-scanner",
         "source": source,
         "tool": "pccx-ide-cli",
@@ -4381,6 +4538,41 @@ def format_module_root_candidate_report_text(report: dict[str, Any]) -> str:
     lines.append(f"next: {report['next_required_action']}")
     lines.append(
         "read-only root report: no command argv, validation, shell, "
+        "refactor, patch, file write, lab, launcher, vendor tool, provider, "
+        "or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_module_leaf_candidate_report_text(report: dict[str, Any]) -> str:
+    lines = [
+        f"source: {report['source']}",
+        f"module leaves: {report['report_state']}",
+        f"{report['module_count']} module"
+        f"{'s' if report['module_count'] != 1 else ''}",
+        f"{report['leaf_count']} leaf candidate"
+        f"{'s' if report['leaf_count'] != 1 else ''}",
+    ]
+    if not report["leaves"]:
+        lines.append("leaves: none")
+    for leaf in report["leaves"]:
+        dependents = ", ".join(leaf["direct_dependents"]) or "none"
+        unresolved = ", ".join(leaf["unresolved_dependencies"]) or "none"
+        lines.append(
+            f"{leaf['file']}:{leaf['start_line']}: module {leaf['name']} "
+            f"({leaf['refactor_preflight_state']})"
+        )
+        lines.append(
+            f"  dependents={dependents}; unresolved={unresolved}; "
+            f"reason={leaf['reason']}"
+        )
+        for reason in leaf["blocked_reasons"]:
+            lines.append(f"  blocked: {reason}")
+    for reason in report["blocked_reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"next: {report['next_required_action']}")
+    lines.append(
+        "read-only leaf report: no command argv, validation, shell, "
         "refactor, patch, file write, lab, launcher, vendor tool, provider, "
         "or hardware execution"
     )

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -28,6 +28,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_duplicate_report,
     build_module_hierarchy_cycle_report,
     build_module_hierarchy_view,
+    build_module_leaf_candidate_report,
     build_module_organization_export,
     build_module_port_usage_view,
     build_module_root_candidate_report,
@@ -57,6 +58,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_module_duplicate_report_text,
     format_module_hierarchy_cycle_text,
     format_module_hierarchy_text,
+    format_module_leaf_candidate_report_text,
     format_module_organization_text,
     format_module_port_usage_text,
     format_module_root_candidate_report_text,
@@ -592,6 +594,87 @@ def test_build_module_root_candidate_report_blocks_when_no_roots_detected():
     assert report["blocked_reasons"] == ["no root candidates detected"]
     assert report["next_required_action"] == (
         "resolve hierarchy blockers before root-candidate review"
+    )
+
+
+def test_build_module_leaf_candidate_report_detects_leaf_modules():
+    report = build_module_leaf_candidate_report(str(FIXTURE), FIXTURE)
+
+    assert report["kind"] == "module-leaf-candidate-report"
+    assert report["report_state"] == "leaves-detected"
+    assert report["module_count"] == 2
+    assert report["edge_count"] == 1
+    assert report["resolved_edge_count"] == 1
+    assert report["unresolved_edge_count"] == 0
+    assert report["leaf_count"] == 1
+    assert report["leaf_names"] == ["leaf_mod"]
+    assert report["blocked_reasons"] == []
+    assert report["next_required_action"] == (
+        "review scanner-detected leaf candidates for dependency-end organization"
+    )
+    leaf = report["leaves"][0]
+    assert leaf["name"] == "leaf_mod"
+    assert leaf["file"] == str(FIXTURE)
+    assert leaf["start_line"] == 4
+    assert leaf["start_column"] == 1
+    assert leaf["complete"] is True
+    assert leaf["declaration_count"] == 1
+    assert leaf["direct_dependents"] == ["top_mod"]
+    assert leaf["direct_dependent_count"] == 1
+    assert leaf["unresolved_dependencies"] == []
+    assert leaf["unresolved_dependency_count"] == 0
+    assert leaf["refactor_preflight_state"] == "ready-for-review"
+    assert leaf["reason"] == "does not instantiate another resolved module"
+    assert report["safety"]["read_only"] is True
+    assert report["safety"]["leaf_candidate_report_only"] is True
+    assert report["safety"]["emits_command_descriptors"] is False
+    assert report["safety"]["writes_files"] is False
+    assert report["safety"]["applies_refactor"] is False
+    assert report["safety"]["generates_patch"] is False
+    assert report["safety"]["runs_validation"] is False
+    assert report["safety"]["runs_shell"] is False
+    assert report["safety"]["invokes_pccx_lab"] is False
+    assert report["safety"]["invokes_launcher"] is False
+    assert report["safety"]["invokes_vendor_tools"] is False
+    assert report["safety"]["provider_calls"] is False
+    assert report["safety"]["hardware_access"] is False
+    assert report["writes_files"] is False
+    assert '"argv"' not in json.dumps(report)
+
+
+def test_build_module_leaf_candidate_report_blocks_unresolved_dependencies():
+    report = build_module_leaf_candidate_report(
+        str(UNRESOLVED_FIXTURE),
+        UNRESOLVED_FIXTURE,
+    )
+
+    assert report["report_state"] == "leaves-detected"
+    assert report["leaf_names"] == ["unresolved_top"]
+    assert report["blocked_reasons"] == [
+        "unresolved dependencies for leaf candidate: missing_child"
+    ]
+    leaf = report["leaves"][0]
+    assert leaf["refactor_preflight_state"] == "blocked"
+    assert leaf["unresolved_dependencies"] == ["missing_child"]
+    assert leaf["unresolved_dependency_count"] == 1
+    assert leaf["blocked_reasons"] == [
+        "unresolved dependencies for leaf candidate: missing_child"
+    ]
+
+
+def test_build_module_leaf_candidate_report_blocks_when_no_leaves_detected():
+    report = build_module_leaf_candidate_report(
+        str(CYCLIC_FIXTURE),
+        CYCLIC_FIXTURE,
+    )
+
+    assert report["report_state"] == "no-leaves-detected"
+    assert report["leaf_count"] == 0
+    assert report["leaf_names"] == []
+    assert report["leaves"] == []
+    assert report["blocked_reasons"] == ["no leaf candidates detected"]
+    assert report["next_required_action"] == (
+        "resolve hierarchy blockers before leaf-candidate review"
     )
 
 
@@ -1543,6 +1626,17 @@ def test_format_module_root_candidate_report_text_mentions_boundary():
     assert "read-only root report: no command argv" in text
 
 
+def test_format_module_leaf_candidate_report_text_mentions_boundary():
+    report = build_module_leaf_candidate_report(str(FIXTURE), FIXTURE)
+    text = format_module_leaf_candidate_report_text(report)
+
+    assert "module leaves: leaves-detected" in text
+    assert "1 leaf candidate" in text
+    assert "module leaf_mod (ready-for-review)" in text
+    assert "dependents=top_mod; unresolved=none" in text
+    assert "read-only leaf report: no command argv" in text
+
+
 def test_format_module_summary_text_mentions_ports_and_boundary():
     view = build_module_summary_view(str(FIXTURE), FIXTURE)
     text = format_module_summary_text(view)
@@ -1991,6 +2085,28 @@ def test_cli_module_roots_text():
     assert "module roots: roots-detected" in result.stdout
     assert "module top_mod (ready-for-review)" in result.stdout
     assert "read-only root report: no command argv" in result.stdout
+
+
+def test_cli_module_leaves_json():
+    result = _run_cli("module-leaves", str(FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-leaf-candidate-report"
+    assert payload["report_state"] == "leaves-detected"
+    assert payload["leaf_names"] == ["leaf_mod"]
+    assert payload["leaves"][0]["direct_dependents"] == ["top_mod"]
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["emits_command_descriptors"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_module_leaves_text():
+    result = _run_cli("module-leaves", str(FIXTURE), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "module leaves: leaves-detected" in result.stdout
+    assert "module leaf_mod (ready-for-review)" in result.stdout
+    assert "read-only leaf report: no command argv" in result.stdout
 
 
 def test_cli_module_summary_json():
@@ -2776,6 +2892,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "hierarchy-cycles <path>" in contract
     assert "unresolved-instances <path>" in contract
     assert "module-roots <path>" in contract
+    assert "module-leaves <path>" in contract
     assert "module-summary <path>" in contract
     assert "port-usage <path>" in contract
     assert "module-context <path>" in contract
@@ -2798,6 +2915,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-hierarchy-cycle-report" in workflow
     assert "module-unresolved-instance-report" in workflow
     assert "module-root-candidate-report" in workflow
+    assert "module-leaf-candidate-report" in workflow
     assert "module-summary-view" in workflow
     assert "module-port-usage-view" in workflow
     assert "module-context-bundle" in workflow


### PR DESCRIPTION
Summary:
- add a read-only module-leaves CLI/report for scanner-detected leaf candidates
- mark unresolved instantiations as leaf-candidate blockers while keeping the surface data-only
- document the contract/workflow and cover JSON, text, CLI, docs, and blocker cases

Validation:
- PYTHONPATH=src python3 -m pytest -q tests/test_module_organization.py
- python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py
- git diff --check
- PYTHONPATH=src python3 -m pytest -q
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- bash scripts/vscode-adapter-smoke.sh
- find scripts -type f -name '*.sh' -exec bash -n {} +
- local forbidden-claim scan

Refs #8