### PR TITLE
Add module depth report

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ python -m pccx_ide_cli hierarchy-cycles fixtures/organization/cyclic_hierarchy.s
 python -m pccx_ide_cli unresolved-instances fixtures/organization/unresolved_instances.sv --format text
 python -m pccx_ide_cli module-roots fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli module-leaves fixtures/organization/hierarchy_top.sv --format json
+python -m pccx_ide_cli module-depths fixtures/organization/hierarchy_top.sv --format json
 
 # Module header/port summary view (pre-stable, read-only)
 python -m pccx_ide_cli module-summary fixtures/organization/hierarchy_top.sv --format json
@@ -227,6 +228,8 @@ whose target module is not declared in the scanned input.
 module entry-point review.
 `module-leaves` reports scanner-detected leaf candidates for dependency-end
 organization review.
+`module-depths` groups scanner-detected hierarchy levels from root candidates
+for module organization review.
 `module-summary` renders conservative module header and port summaries
 for editor sidebars and reviewed refactoring planning. `port-usage`
 renders target port declarations with scanner-detected dependent

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -54,6 +54,7 @@ python -m pccx_ide_cli hierarchy-cycles <path> --format json
 python -m pccx_ide_cli unresolved-instances <path> --format json
 python -m pccx_ide_cli module-roots <path> --format json
 python -m pccx_ide_cli module-leaves <path> --format json
+python -m pccx_ide_cli module-depths <path> --format json
 python -m pccx_ide_cli module-summary <path> --format json
 python -m pccx_ide_cli port-usage <path> --module <name> --format json
 python -m pccx_ide_cli module-context <path> --module <name> --format json
@@ -212,10 +213,11 @@ surfaces do not write files, apply refactors, generate patches, run validation,
 invoke pccx-lab or the launcher, run vendor tools, call providers, touch
 hardware, or perform automatic repository actions. `hierarchy`,
 `dependencies`, `hierarchy-cycles`, `unresolved-instances`, `module-roots`,
-`module-leaves`, `module-summary`, `port-usage`, `module-context`, and
-`refactor-impact` render focused read-only views from the same scanner data,
-including hierarchy cycle warnings, unresolved instantiation warnings,
-root-candidate summaries, leaf-candidate summaries,
+`module-leaves`, `module-depths`, `module-summary`, `port-usage`,
+`module-context`, and `refactor-impact` render focused read-only views from
+the same scanner data, including hierarchy cycle warnings, unresolved
+instantiation warnings, root-candidate summaries, leaf-candidate summaries,
+depth-level summaries,
 conservative module header/port summaries, target port usage summaries,
 target module context bundles, and
 target-specific refactor impact review data. The

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -5,17 +5,18 @@
 This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
 `hierarchy-cycles`, `unresolved-instances`, `module-roots`, `module-leaves`,
-`module-summary`, `boundary-audit`, `module-duplicates`, `refactor-candidates`,
-`port-usage`, `module-context`, `refactor-impact`, `validation-plan`,
-`refactor-review`, `refactor-approval`, `refactor-application`,
-`refactor-result`, `refactor-handoff`, `refactor-checklist`, and
+`module-depths`, `module-summary`, `boundary-audit`, `module-duplicates`,
+`refactor-candidates`, `port-usage`, `module-context`, `refactor-impact`,
+`validation-plan`, `refactor-review`, `refactor-approval`,
+`refactor-application`, `refactor-result`, `refactor-handoff`,
+`refactor-checklist`, and
 `refactor-session` CLI surfaces that report module boundary spans,
 scanner-based hierarchy data, direct dependency impact data, hierarchy cycle
 report metadata, unresolved instantiation report metadata, root-candidate
-report metadata, leaf-candidate report metadata, conservative module
-header/port summaries, duplicate-name report metadata, target port usage
-summaries, target module context bundles, target-specific refactor impact data,
-boundary audit data, refactor
+report metadata, leaf-candidate report metadata, depth-level report metadata,
+conservative module header/port summaries, duplicate-name report metadata,
+target port usage summaries, target module context bundles, target-specific
+refactor impact data, boundary audit data, refactor
 candidate metadata for editor action menus, proposal-only validation command
 descriptors, a summary-only review packet, approval decision metadata,
 application request metadata, and application result metadata plus refactor
@@ -42,6 +43,8 @@ python -m pccx_ide_cli module-roots <path> --format json
 python -m pccx_ide_cli module-roots <path> --format text
 python -m pccx_ide_cli module-leaves <path> --format json
 python -m pccx_ide_cli module-leaves <path> --format text
+python -m pccx_ide_cli module-depths <path> --format json
+python -m pccx_ide_cli module-depths <path> --format text
 python -m pccx_ide_cli module-summary <path> --format json
 python -m pccx_ide_cli module-summary <path> --format text
 python -m pccx_ide_cli boundary-audit <path> --format json
@@ -318,6 +321,44 @@ The leaf-candidate report is display data only. It does not write files,
 apply refactors, generate patches, run validation, execute shell commands,
 emit command argv, invoke `pccx-lab`, invoke the launcher, call providers,
 touch hardware, upload telemetry, or perform automatic repository actions.
+
+The depth report groups modules by resolved scanner hierarchy depth from
+root candidates:
+
+```json
+{
+  "kind": "module-depth-report",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "report_state": "depths-detected",
+  "depth_count": 2,
+  "max_depth": 1,
+  "levels": [
+    {
+      "depth": 0,
+      "module_names": ["top_mod"]
+    },
+    {
+      "depth": 1,
+      "module_names": ["leaf_mod"]
+    }
+  ],
+  "unplaced_module_names": [],
+  "safety": {
+    "read_only": true,
+    "writes_files": false,
+    "emits_command_descriptors": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The depth report is display data only. It does not write files, apply
+refactors, generate patches, run validation, execute shell commands, emit
+command argv, invoke `pccx-lab`, invoke the launcher, call providers, touch
+hardware, upload telemetry, or perform automatic repository actions.
 
 The module summary view reports conservative scanner-detected module
 header and port metadata:

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -320,6 +320,24 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    module_depths_cmd = sub.add_parser(
+        "module-depths",
+        help=(
+            "Render scanner-based read-only module hierarchy depth report data."
+        ),
+    )
+    module_depths_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    module_depths_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     module_summary_cmd = sub.add_parser(
         "module-summary",
         help=(
@@ -1313,6 +1331,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_leaf_candidate_report_text(report))
+        return 0
+
+    if args.command == "module-depths":
+        from .module_organization import (
+            build_module_depth_report,
+            format_module_depth_report_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        report = build_module_depth_report(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(report, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_depth_report_text(report))
         return 0
 
     if args.command == "module-summary":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -174,6 +174,17 @@ MODULE_LEAF_REPORT_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+MODULE_DEPTH_REPORT_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based module hierarchy depth report only",
+    "uses root candidates and resolved dependency edges from the organization scanner",
+    "single-line instantiation candidates only",
+    "cycles or disconnected modules can leave modules unplaced",
+    "no semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
+    "does not apply refactors, write files, generate patches, or run validation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 MODULE_SUMMARY_LIMITATIONS: tuple[str, ...] = (
     "scanner-based module header and port summary data only",
     "ANSI-style port declarations are detected conservatively",
@@ -546,6 +557,28 @@ def _module_leaf_report_safety_flags() -> dict[str, bool]:
     return {
         "read_only": True,
         "leaf_candidate_report_only": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _module_depth_report_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "depth_report_only": True,
         "emits_command_descriptors": False,
         "writes_files": False,
         "moves_files": False,
@@ -1906,7 +1939,9 @@ def _module_leaf_rows(
     declaration_counts: dict[str, int] = {}
     for module in modules:
         modules_by_name.setdefault(module["name"], module)
-        declaration_counts[module["name"]] = declaration_counts.get(module["name"], 0) + 1
+        declaration_counts[module["name"]] = (
+            declaration_counts.get(module["name"], 0) + 1
+        )
 
     resolved_dependencies_by_module: dict[str, set[str]] = {
         name: set()
@@ -2015,6 +2050,169 @@ def build_module_leaf_candidate_report(source: str, path: Path) -> dict[str, Any
         "scanner": "line-scanner",
         "source": source,
         "tool": "pccx-ide-cli",
+        "unresolved_edge_count": len(hierarchy["edges"]) - resolved_edge_count,
+        "writes_files": False,
+    }
+
+
+def _module_depth_rows(
+    modules: list[dict[str, Any]],
+    hierarchy: dict[str, Any],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[str]]:
+    modules_by_name: dict[str, dict[str, Any]] = {}
+    declaration_counts: dict[str, int] = {}
+    for module in modules:
+        modules_by_name.setdefault(module["name"], module)
+        declaration_counts[module["name"]] = (
+            declaration_counts.get(module["name"], 0) + 1
+        )
+
+    module_names = sorted(modules_by_name)
+    children_by_parent: dict[str, set[str]] = {
+        name: set()
+        for name in module_names
+    }
+    parents_by_child: dict[str, set[str]] = {
+        name: set()
+        for name in module_names
+    }
+    unresolved_by_parent: dict[str, set[str]] = {
+        name: set()
+        for name in module_names
+    }
+    for edge in hierarchy["edges"]:
+        parent = edge["parent"]
+        child = edge["child"]
+        if parent not in modules_by_name:
+            continue
+        if edge["resolved"]:
+            children_by_parent.setdefault(parent, set()).add(child)
+            if child in parents_by_child:
+                parents_by_child[child].add(parent)
+        else:
+            unresolved_by_parent.setdefault(parent, set()).add(child)
+
+    depths: dict[str, int] = {}
+    queue: list[tuple[str, int]] = [
+        (root, 0)
+        for root in hierarchy["roots"]
+        if root in modules_by_name
+    ]
+    while queue:
+        module_name, depth = queue.pop(0)
+        previous_depth = depths.get(module_name)
+        if previous_depth is not None and previous_depth <= depth:
+            continue
+        depths[module_name] = depth
+        for child in sorted(children_by_parent.get(module_name, set())):
+            if child in modules_by_name:
+                queue.append((child, depth + 1))
+
+    module_rows: list[dict[str, Any]] = []
+    for module_name in sorted(depths, key=lambda name: (depths[name], name)):
+        module = modules_by_name[module_name]
+        direct_dependencies = sorted(children_by_parent.get(module_name, set()))
+        direct_dependents = sorted(parents_by_child.get(module_name, set()))
+        unresolved_dependencies = sorted(unresolved_by_parent.get(module_name, set()))
+        blocked_reasons: list[str] = []
+        if not module["complete"]:
+            blocked_reasons.append(f"module boundary is incomplete: {module_name}")
+        if declaration_counts[module_name] > 1:
+            blocked_reasons.append(f"ambiguous module name: {module_name}")
+        if unresolved_dependencies:
+            blocked_reasons.append(
+                "unresolved dependencies for depth report: "
+                f"{', '.join(unresolved_dependencies)}"
+            )
+        module_rows.append({
+            "blocked_reasons": blocked_reasons,
+            "complete": module["complete"],
+            "declaration_count": declaration_counts[module_name],
+            "depth": depths[module_name],
+            "depth_state": "depth-detected",
+            "direct_dependencies": direct_dependencies,
+            "direct_dependency_count": len(direct_dependencies),
+            "direct_dependents": direct_dependents,
+            "direct_dependent_count": len(direct_dependents),
+            "file": module["file"],
+            "name": module_name,
+            "reason": "reachable from scanner root candidates by resolved edges",
+            "refactor_preflight_state": (
+                "blocked" if blocked_reasons else "ready-for-review"
+            ),
+            "start_column": module["start_column"],
+            "start_line": module["start_line"],
+            "unresolved_dependencies": unresolved_dependencies,
+            "unresolved_dependency_count": len(unresolved_dependencies),
+        })
+
+    levels: list[dict[str, Any]] = []
+    for depth in sorted(set(depths.values())):
+        names = sorted([
+            name
+            for name, module_depth in depths.items()
+            if module_depth == depth
+        ])
+        levels.append({
+            "depth": depth,
+            "module_count": len(names),
+            "module_names": names,
+        })
+
+    unplaced_names = sorted(set(module_names) - set(depths))
+    return levels, module_rows, unplaced_names
+
+
+def build_module_depth_report(source: str, path: Path) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    hierarchy = organization["hierarchy"]
+    resolved_edge_count = len([
+        edge
+        for edge in hierarchy["edges"]
+        if edge["resolved"]
+    ])
+    levels, module_rows, unplaced_names = _module_depth_rows(modules, hierarchy)
+    blocked_reasons = list(dict.fromkeys([
+        reason
+        for module in module_rows
+        for reason in module["blocked_reasons"]
+    ]))
+    if modules and not hierarchy["roots"]:
+        blocked_reasons.append("no root candidates detected")
+    if unplaced_names:
+        blocked_reasons.append(f"unplaced modules: {', '.join(unplaced_names)}")
+    if not modules:
+        blocked_reasons.append("no module declarations detected")
+
+    return {
+        "blocked_reasons": blocked_reasons,
+        "depth_count": len(levels),
+        "edge_count": len(hierarchy["edges"]),
+        "kind": "module-depth-report",
+        "levels": levels,
+        "limitations": list(MODULE_DEPTH_REPORT_LIMITATIONS),
+        "max_depth": max((level["depth"] for level in levels), default=None),
+        "module_count": len(modules),
+        "modules": module_rows,
+        "next_required_action": (
+            "review scanner-detected hierarchy depth levels for module organization"
+            if levels
+            else "resolve hierarchy blockers before depth-level review"
+        ),
+        "report_state": "depths-detected" if levels else "no-depths-detected",
+        "resolved_edge_count": resolved_edge_count,
+        "root_names": [
+            root
+            for root in hierarchy["roots"]
+            if any(module["name"] == root for module in modules)
+        ],
+        "safety": _module_depth_report_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "tool": "pccx-ide-cli",
+        "unplaced_module_count": len(unplaced_names),
+        "unplaced_module_names": unplaced_names,
         "unresolved_edge_count": len(hierarchy["edges"]) - resolved_edge_count,
         "writes_files": False,
     }
@@ -4573,6 +4771,50 @@ def format_module_leaf_candidate_report_text(report: dict[str, Any]) -> str:
     lines.append(f"next: {report['next_required_action']}")
     lines.append(
         "read-only leaf report: no command argv, validation, shell, "
+        "refactor, patch, file write, lab, launcher, vendor tool, provider, "
+        "or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_module_depth_report_text(report: dict[str, Any]) -> str:
+    max_depth = report["max_depth"] if report["max_depth"] is not None else "none"
+    lines = [
+        f"source: {report['source']}",
+        f"module depths: {report['report_state']}",
+        f"{report['module_count']} module"
+        f"{'s' if report['module_count'] != 1 else ''}",
+        f"{report['depth_count']} depth level"
+        f"{'s' if report['depth_count'] != 1 else ''}",
+        f"max depth: {max_depth}",
+    ]
+    if not report["levels"]:
+        lines.append("depth levels: none")
+    for level in report["levels"]:
+        module_names = ", ".join(level["module_names"]) or "none"
+        lines.append(f"depth {level['depth']}: {module_names}")
+    for module in report["modules"]:
+        dependencies = ", ".join(module["direct_dependencies"]) or "none"
+        dependents = ", ".join(module["direct_dependents"]) or "none"
+        unresolved = ", ".join(module["unresolved_dependencies"]) or "none"
+        lines.append(
+            f"{module['file']}:{module['start_line']}: module {module['name']} "
+            f"depth={module['depth']} ({module['refactor_preflight_state']})"
+        )
+        lines.append(
+            f"  dependencies={dependencies}; dependents={dependents}; "
+            f"unresolved={unresolved}; reason={module['reason']}"
+        )
+        for reason in module["blocked_reasons"]:
+            lines.append(f"  blocked: {reason}")
+    if report["unplaced_module_names"]:
+        unplaced_names = ", ".join(report["unplaced_module_names"])
+        lines.append(f"unplaced modules: {unplaced_names}")
+    for reason in report["blocked_reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"next: {report['next_required_action']}")
+    lines.append(
+        "read-only depth report: no command argv, validation, shell, "
         "refactor, patch, file write, lab, launcher, vendor tool, provider, "
         "or hardware execution"
     )

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -25,6 +25,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_dependency_view,
     build_module_boundary_audit,
     build_module_context_bundle,
+    build_module_depth_report,
     build_module_duplicate_report,
     build_module_hierarchy_cycle_report,
     build_module_hierarchy_view,
@@ -55,6 +56,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_module_boundary_audit_text,
     format_module_dependency_text,
     format_module_context_text,
+    format_module_depth_report_text,
     format_module_duplicate_report_text,
     format_module_hierarchy_cycle_text,
     format_module_hierarchy_text,
@@ -676,6 +678,109 @@ def test_build_module_leaf_candidate_report_blocks_when_no_leaves_detected():
     assert report["next_required_action"] == (
         "resolve hierarchy blockers before leaf-candidate review"
     )
+
+
+def test_build_module_depth_report_groups_hierarchy_levels():
+    report = build_module_depth_report(str(FIXTURE), FIXTURE)
+
+    assert report["kind"] == "module-depth-report"
+    assert report["report_state"] == "depths-detected"
+    assert report["module_count"] == 2
+    assert report["edge_count"] == 1
+    assert report["resolved_edge_count"] == 1
+    assert report["unresolved_edge_count"] == 0
+    assert report["depth_count"] == 2
+    assert report["max_depth"] == 1
+    assert report["root_names"] == ["top_mod"]
+    assert report["levels"] == [
+        {
+            "depth": 0,
+            "module_count": 1,
+            "module_names": ["top_mod"],
+        },
+        {
+            "depth": 1,
+            "module_count": 1,
+            "module_names": ["leaf_mod"],
+        },
+    ]
+    assert report["unplaced_module_count"] == 0
+    assert report["unplaced_module_names"] == []
+    assert report["blocked_reasons"] == []
+    assert report["next_required_action"] == (
+        "review scanner-detected hierarchy depth levels for module organization"
+    )
+    modules = {module["name"]: module for module in report["modules"]}
+    assert set(modules) == {"top_mod", "leaf_mod"}
+    assert modules["top_mod"]["depth"] == 0
+    assert modules["top_mod"]["direct_dependencies"] == ["leaf_mod"]
+    assert modules["top_mod"]["direct_dependents"] == []
+    assert modules["top_mod"]["unresolved_dependencies"] == []
+    assert modules["top_mod"]["refactor_preflight_state"] == "ready-for-review"
+    assert modules["leaf_mod"]["depth"] == 1
+    assert modules["leaf_mod"]["direct_dependencies"] == []
+    assert modules["leaf_mod"]["direct_dependents"] == ["top_mod"]
+    assert modules["leaf_mod"]["unresolved_dependencies"] == []
+    assert modules["leaf_mod"]["reason"] == (
+        "reachable from scanner root candidates by resolved edges"
+    )
+    assert report["safety"]["read_only"] is True
+    assert report["safety"]["depth_report_only"] is True
+    assert report["safety"]["emits_command_descriptors"] is False
+    assert report["safety"]["writes_files"] is False
+    assert report["safety"]["applies_refactor"] is False
+    assert report["safety"]["generates_patch"] is False
+    assert report["safety"]["runs_validation"] is False
+    assert report["safety"]["runs_shell"] is False
+    assert report["safety"]["invokes_pccx_lab"] is False
+    assert report["safety"]["invokes_launcher"] is False
+    assert report["safety"]["invokes_vendor_tools"] is False
+    assert report["safety"]["provider_calls"] is False
+    assert report["safety"]["hardware_access"] is False
+    assert report["writes_files"] is False
+    assert '"argv"' not in json.dumps(report)
+
+
+def test_build_module_depth_report_blocks_when_no_roots_detected():
+    report = build_module_depth_report(str(CYCLIC_FIXTURE), CYCLIC_FIXTURE)
+
+    assert report["report_state"] == "no-depths-detected"
+    assert report["depth_count"] == 0
+    assert report["max_depth"] is None
+    assert report["levels"] == []
+    assert report["modules"] == []
+    assert report["root_names"] == []
+    assert report["unplaced_module_count"] == 2
+    assert report["unplaced_module_names"] == ["alpha_mod", "beta_mod"]
+    assert report["blocked_reasons"] == [
+        "no root candidates detected",
+        "unplaced modules: alpha_mod, beta_mod",
+    ]
+    assert report["next_required_action"] == (
+        "resolve hierarchy blockers before depth-level review"
+    )
+
+
+def test_build_module_depth_report_blocks_unresolved_dependencies():
+    report = build_module_depth_report(
+        str(UNRESOLVED_FIXTURE),
+        UNRESOLVED_FIXTURE,
+    )
+
+    assert report["report_state"] == "depths-detected"
+    assert report["depth_count"] == 1
+    assert report["root_names"] == ["unresolved_top"]
+    assert report["blocked_reasons"] == [
+        "unresolved dependencies for depth report: missing_child"
+    ]
+    module = report["modules"][0]
+    assert module["name"] == "unresolved_top"
+    assert module["depth"] == 0
+    assert module["refactor_preflight_state"] == "blocked"
+    assert module["unresolved_dependencies"] == ["missing_child"]
+    assert module["blocked_reasons"] == [
+        "unresolved dependencies for depth report: missing_child"
+    ]
 
 
 def test_build_module_summary_view_reports_ports_and_safety():
@@ -1637,6 +1742,20 @@ def test_format_module_leaf_candidate_report_text_mentions_boundary():
     assert "read-only leaf report: no command argv" in text
 
 
+def test_format_module_depth_report_text_mentions_boundary():
+    report = build_module_depth_report(str(FIXTURE), FIXTURE)
+    text = format_module_depth_report_text(report)
+
+    assert "module depths: depths-detected" in text
+    assert "2 depth levels" in text
+    assert "max depth: 1" in text
+    assert "depth 0: top_mod" in text
+    assert "depth 1: leaf_mod" in text
+    assert "module top_mod depth=0 (ready-for-review)" in text
+    assert "dependencies=leaf_mod; dependents=none; unresolved=none" in text
+    assert "read-only depth report: no command argv" in text
+
+
 def test_format_module_summary_text_mentions_ports_and_boundary():
     view = build_module_summary_view(str(FIXTURE), FIXTURE)
     text = format_module_summary_text(view)
@@ -2107,6 +2226,31 @@ def test_cli_module_leaves_text():
     assert "module leaves: leaves-detected" in result.stdout
     assert "module leaf_mod (ready-for-review)" in result.stdout
     assert "read-only leaf report: no command argv" in result.stdout
+
+
+def test_cli_module_depths_json():
+    result = _run_cli("module-depths", str(FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-depth-report"
+    assert payload["report_state"] == "depths-detected"
+    assert payload["depth_count"] == 2
+    assert payload["max_depth"] == 1
+    assert payload["levels"][0]["module_names"] == ["top_mod"]
+    assert payload["levels"][1]["module_names"] == ["leaf_mod"]
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["emits_command_descriptors"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_module_depths_text():
+    result = _run_cli("module-depths", str(FIXTURE), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "module depths: depths-detected" in result.stdout
+    assert "depth 0: top_mod" in result.stdout
+    assert "depth 1: leaf_mod" in result.stdout
+    assert "read-only depth report: no command argv" in result.stdout
 
 
 def test_cli_module_summary_json():
@@ -2893,6 +3037,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "unresolved-instances <path>" in contract
     assert "module-roots <path>" in contract
     assert "module-leaves <path>" in contract
+    assert "module-depths <path>" in contract
     assert "module-summary <path>" in contract
     assert "port-usage <path>" in contract
     assert "module-context <path>" in contract
@@ -2916,6 +3061,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-unresolved-instance-report" in workflow
     assert "module-root-candidate-report" in workflow
     assert "module-leaf-candidate-report" in workflow
+    assert "module-depth-report" in workflow
     assert "module-summary-view" in workflow
     assert "module-port-usage-view" in workflow
     assert "module-context-bundle" in workflow


### PR DESCRIPTION
Summary:
- add a read-only module-depths CLI/report for scanner-detected hierarchy depth levels
- report root-derived depth groups, per-module dependency/dependent context, and unplaced/cycle blockers
- document the contract/workflow and cover JSON, text, CLI, docs, cyclic, and unresolved blocker cases

Validation:
- PYTHONPATH=src python3 -m pytest -q tests/test_module_organization.py
- python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py
- git diff --check
- PYTHONPATH=src python3 -m pccx_ide_cli module-depths fixtures/organization/hierarchy_top.sv --format json
- PYTHONPATH=src python3 -m pccx_ide_cli module-depths fixtures/organization/cyclic_hierarchy.sv --format text
- PYTHONPATH=src python3 -m pytest -q
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- bash scripts/vscode-adapter-smoke.sh
- find scripts -type f -name '*.sh' -exec bash -n {} +
- local forbidden-claim scan

Refs #8