### PR TITLE
Add module graph health summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ python -m pccx_ide_cli unresolved-instances fixtures/organization/unresolved_ins
 python -m pccx_ide_cli module-roots fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli module-leaves fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli module-depths fixtures/organization/hierarchy_top.sv --format json
+python -m pccx_ide_cli module-health fixtures/organization/hierarchy_top.sv --format json
 
 # Module header/port summary view (pre-stable, read-only)
 python -m pccx_ide_cli module-summary fixtures/organization/hierarchy_top.sv --format json
@@ -230,6 +231,9 @@ module entry-point review.
 organization review.
 `module-depths` groups scanner-detected hierarchy levels from root candidates
 for module organization review.
+`module-health` combines scanner-detected root, leaf, depth, cycle,
+unresolved-instance, and duplicate-name signals into a read-only module graph
+health summary for editor status panes.
 `module-summary` renders conservative module header and port summaries
 for editor sidebars and reviewed refactoring planning. `port-usage`
 renders target port declarations with scanner-detected dependent

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -55,6 +55,7 @@ python -m pccx_ide_cli unresolved-instances <path> --format json
 python -m pccx_ide_cli module-roots <path> --format json
 python -m pccx_ide_cli module-leaves <path> --format json
 python -m pccx_ide_cli module-depths <path> --format json
+python -m pccx_ide_cli module-health <path> --format json
 python -m pccx_ide_cli module-summary <path> --format json
 python -m pccx_ide_cli port-usage <path> --module <name> --format json
 python -m pccx_ide_cli module-context <path> --module <name> --format json
@@ -213,11 +214,12 @@ surfaces do not write files, apply refactors, generate patches, run validation,
 invoke pccx-lab or the launcher, run vendor tools, call providers, touch
 hardware, or perform automatic repository actions. `hierarchy`,
 `dependencies`, `hierarchy-cycles`, `unresolved-instances`, `module-roots`,
-`module-leaves`, `module-depths`, `module-summary`, `port-usage`,
+`module-leaves`, `module-depths`, `module-health`, `module-summary`, `port-usage`,
 `module-context`, and `refactor-impact` render focused read-only views from
 the same scanner data, including hierarchy cycle warnings, unresolved
 instantiation warnings, root-candidate summaries, leaf-candidate summaries,
 depth-level summaries,
+module graph health summaries,
 conservative module header/port summaries, target port usage summaries,
 target module context bundles, and
 target-specific refactor impact review data. The

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -5,7 +5,7 @@
 This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
 `hierarchy-cycles`, `unresolved-instances`, `module-roots`, `module-leaves`,
-`module-depths`, `module-summary`, `boundary-audit`, `module-duplicates`,
+`module-depths`, `module-health`, `module-summary`, `boundary-audit`, `module-duplicates`,
 `refactor-candidates`, `port-usage`, `module-context`, `refactor-impact`,
 `validation-plan`, `refactor-review`, `refactor-approval`,
 `refactor-application`, `refactor-result`, `refactor-handoff`,
@@ -14,6 +14,7 @@ projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
 scanner-based hierarchy data, direct dependency impact data, hierarchy cycle
 report metadata, unresolved instantiation report metadata, root-candidate
 report metadata, leaf-candidate report metadata, depth-level report metadata,
+module graph health summary metadata,
 conservative module header/port summaries, duplicate-name report metadata,
 target port usage summaries, target module context bundles, target-specific
 refactor impact data, boundary audit data, refactor
@@ -45,6 +46,8 @@ python -m pccx_ide_cli module-leaves <path> --format json
 python -m pccx_ide_cli module-leaves <path> --format text
 python -m pccx_ide_cli module-depths <path> --format json
 python -m pccx_ide_cli module-depths <path> --format text
+python -m pccx_ide_cli module-health <path> --format json
+python -m pccx_ide_cli module-health <path> --format text
 python -m pccx_ide_cli module-summary <path> --format json
 python -m pccx_ide_cli module-summary <path> --format text
 python -m pccx_ide_cli boundary-audit <path> --format json
@@ -358,6 +361,47 @@ root candidates:
 The depth report is display data only. It does not write files, apply
 refactors, generate patches, run validation, execute shell commands, emit
 command argv, invoke `pccx-lab`, invoke the launcher, call providers, touch
+hardware, upload telemetry, or perform automatic repository actions.
+
+The module graph health summary combines scanner-detected root, leaf, depth,
+cycle, unresolved-instantiation, and duplicate-name signals for editor status
+panes:
+
+```json
+{
+  "kind": "module-graph-health-summary",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "health_state": "ready-for-review",
+  "ready_for_review": true,
+  "root_names": ["top_mod"],
+  "leaf_names": ["leaf_mod"],
+  "max_depth": 1,
+  "health_cards": [
+    {
+      "card_id": "root-candidates",
+      "status": "roots-detected"
+    },
+    {
+      "card_id": "hierarchy-cycles",
+      "status": "no-cycles-detected"
+    }
+  ],
+  "safety": {
+    "read_only": true,
+    "graph_health_summary_only": true,
+    "writes_files": false,
+    "emits_command_descriptors": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The module graph health summary is display data only. It does not write files,
+apply refactors, generate patches, run validation, execute shell commands,
+emit command argv, invoke `pccx-lab`, invoke the launcher, call providers, touch
 hardware, upload telemetry, or perform automatic repository actions.
 
 The module summary view reports conservative scanner-detected module

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -338,6 +338,24 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    module_health_cmd = sub.add_parser(
+        "module-health",
+        help=(
+            "Render a scanner-based read-only module graph health summary."
+        ),
+    )
+    module_health_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    module_health_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     module_summary_cmd = sub.add_parser(
         "module-summary",
         help=(
@@ -1349,6 +1367,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_depth_report_text(report))
+        return 0
+
+    if args.command == "module-health":
+        from .module_organization import (
+            build_module_graph_health_summary,
+            format_module_graph_health_summary_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        summary = build_module_graph_health_summary(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(summary, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_graph_health_summary_text(summary))
         return 0
 
     if args.command == "module-summary":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -185,6 +185,16 @@ MODULE_DEPTH_REPORT_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+MODULE_GRAPH_HEALTH_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based module graph health summary only",
+    "combines root, leaf, depth, cycle, unresolved-instance, and duplicate-name signals",
+    "single-line instantiation candidates only",
+    "no semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
+    "does not apply refactors, write files, generate patches, or run validation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 MODULE_SUMMARY_LIMITATIONS: tuple[str, ...] = (
     "scanner-based module header and port summary data only",
     "ANSI-style port declarations are detected conservatively",
@@ -579,6 +589,34 @@ def _module_depth_report_safety_flags() -> dict[str, bool]:
     return {
         "read_only": True,
         "depth_report_only": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _module_graph_health_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "graph_health_summary_only": True,
+        "combines_root_candidate_report": True,
+        "combines_leaf_candidate_report": True,
+        "combines_depth_report": True,
+        "combines_cycle_report": True,
+        "combines_unresolved_instance_report": True,
+        "combines_duplicate_report": True,
         "emits_command_descriptors": False,
         "writes_files": False,
         "moves_files": False,
@@ -2214,6 +2252,177 @@ def build_module_depth_report(source: str, path: Path) -> dict[str, Any]:
         "unplaced_module_count": len(unplaced_names),
         "unplaced_module_names": unplaced_names,
         "unresolved_edge_count": len(hierarchy["edges"]) - resolved_edge_count,
+        "writes_files": False,
+    }
+
+
+def _module_graph_health_cards(
+    *,
+    complete_module_count: int,
+    incomplete_module_count: int,
+    roots: list[dict[str, Any]],
+    leaves: list[dict[str, Any]],
+    levels: list[dict[str, Any]],
+    cycles: list[dict[str, Any]],
+    unresolved_instances: list[dict[str, Any]],
+    duplicates: list[dict[str, Any]],
+    unplaced_names: list[str],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "card_id": "boundary-completeness",
+            "complete_module_count": complete_module_count,
+            "incomplete_module_count": incomplete_module_count,
+            "required": True,
+            "status": (
+                "complete" if incomplete_module_count == 0 else "blocked"
+            ),
+        },
+        {
+            "card_id": "root-candidates",
+            "root_count": len(roots),
+            "required": True,
+            "status": "roots-detected" if roots else "no-roots-detected",
+        },
+        {
+            "card_id": "leaf-candidates",
+            "leaf_count": len(leaves),
+            "required": True,
+            "status": "leaves-detected" if leaves else "no-leaves-detected",
+        },
+        {
+            "card_id": "depth-levels",
+            "depth_count": len(levels),
+            "required": True,
+            "status": "depths-detected" if levels else "no-depths-detected",
+            "unplaced_module_count": len(unplaced_names),
+        },
+        {
+            "card_id": "hierarchy-cycles",
+            "cycle_count": len(cycles),
+            "required": True,
+            "status": "cycles-detected" if cycles else "no-cycles-detected",
+        },
+        {
+            "card_id": "unresolved-instances",
+            "required": True,
+            "status": (
+                "unresolved-instances-detected"
+                if unresolved_instances
+                else "no-unresolved-instances-detected"
+            ),
+            "unresolved_instance_count": len(unresolved_instances),
+        },
+        {
+            "card_id": "duplicate-modules",
+            "duplicate_name_count": len(duplicates),
+            "required": True,
+            "status": (
+                "duplicates-detected"
+                if duplicates
+                else "no-duplicates-detected"
+            ),
+        },
+    ]
+
+
+def _module_graph_health_next_action(
+    modules: list[dict[str, Any]],
+    blocked_reasons: list[str],
+) -> str:
+    if not modules:
+        return "add module declarations before module graph health review"
+    if blocked_reasons:
+        return "resolve scanner-detected module graph blockers before refactor planning"
+    return "continue module organization and refactor readiness review"
+
+
+def build_module_graph_health_summary(source: str, path: Path) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    hierarchy = organization["hierarchy"]
+    resolved_edge_count = len([
+        edge
+        for edge in hierarchy["edges"]
+        if edge["resolved"]
+    ])
+    roots = _module_root_rows(modules, hierarchy)
+    leaves = _module_leaf_rows(modules, hierarchy)
+    levels, depth_modules, unplaced_names = _module_depth_rows(modules, hierarchy)
+    cycles = _hierarchy_cycle_rows(hierarchy)
+    unresolved_instances = _unresolved_instance_rows(hierarchy)
+    duplicates = _module_duplicate_rows(modules)
+    incomplete_modules = [
+        module
+        for module in modules
+        if not module["complete"]
+    ]
+
+    blocked_reasons: list[str] = []
+    if not modules:
+        blocked_reasons.append("no module declarations detected")
+    for module in incomplete_modules:
+        blocked_reasons.append(f"module boundary is incomplete: {module['name']}")
+    for duplicate in duplicates:
+        blocked_reasons.append(duplicate["reason"])
+    for cycle in cycles:
+        blocked_reasons.append(f"scanner-detected hierarchy cycle: {cycle['summary']}")
+    for instance in unresolved_instances:
+        blocked_reasons.append(instance["reason"])
+    if modules and not roots:
+        blocked_reasons.append("no root candidates detected")
+    if modules and not leaves:
+        blocked_reasons.append("no leaf candidates detected")
+    if unplaced_names:
+        blocked_reasons.append(f"unplaced modules: {', '.join(unplaced_names)}")
+    for module in depth_modules:
+        blocked_reasons.extend(module["blocked_reasons"])
+    blocked_reasons = list(dict.fromkeys(blocked_reasons))
+
+    ready = bool(modules) and not blocked_reasons
+    complete_module_count = len(modules) - len(incomplete_modules)
+
+    return {
+        "blocked_reasons": blocked_reasons,
+        "complete_module_count": complete_module_count,
+        "duplicate_name_count": len(duplicates),
+        "duplicate_names": [duplicate["name"] for duplicate in duplicates],
+        "edge_count": len(hierarchy["edges"]),
+        "health_cards": _module_graph_health_cards(
+            complete_module_count=complete_module_count,
+            incomplete_module_count=len(incomplete_modules),
+            roots=roots,
+            leaves=leaves,
+            levels=levels,
+            cycles=cycles,
+            unresolved_instances=unresolved_instances,
+            duplicates=duplicates,
+            unplaced_names=unplaced_names,
+        ),
+        "health_state": "ready-for-review" if ready else "blocked",
+        "incomplete_module_count": len(incomplete_modules),
+        "kind": "module-graph-health-summary",
+        "leaf_count": len(leaves),
+        "leaf_names": [leaf["name"] for leaf in leaves],
+        "limitations": list(MODULE_GRAPH_HEALTH_LIMITATIONS),
+        "max_depth": max((level["depth"] for level in levels), default=None),
+        "module_count": len(modules),
+        "next_required_action": _module_graph_health_next_action(
+            modules,
+            blocked_reasons,
+        ),
+        "ready_for_review": ready,
+        "resolved_edge_count": resolved_edge_count,
+        "root_count": len(roots),
+        "root_names": [root["name"] for root in roots],
+        "safety": _module_graph_health_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "tool": "pccx-ide-cli",
+        "unplaced_module_count": len(unplaced_names),
+        "unplaced_module_names": unplaced_names,
+        "unresolved_edge_count": len(hierarchy["edges"]) - resolved_edge_count,
+        "unresolved_instance_count": len(unresolved_instances),
         "writes_files": False,
     }
 
@@ -4815,6 +5024,54 @@ def format_module_depth_report_text(report: dict[str, Any]) -> str:
     lines.append(f"next: {report['next_required_action']}")
     lines.append(
         "read-only depth report: no command argv, validation, shell, "
+        "refactor, patch, file write, lab, launcher, vendor tool, provider, "
+        "or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_module_graph_health_summary_text(report: dict[str, Any]) -> str:
+    max_depth = report["max_depth"] if report["max_depth"] is not None else "none"
+    ready = "yes" if report["ready_for_review"] else "no"
+    root_label = "root" if report["root_count"] == 1 else "roots"
+    leaf_label = "leaf" if report["leaf_count"] == 1 else "leaves"
+    lines = [
+        f"source: {report['source']}",
+        f"module graph health: {report['health_state']}",
+        f"ready for review: {ready}",
+        f"{report['module_count']} module"
+        f"{'s' if report['module_count'] != 1 else ''}",
+        (
+            f"{report['root_count']} {root_label}; "
+            f"{report['leaf_count']} {leaf_label}; "
+            f"max depth: {max_depth}"
+        ),
+        (
+            f"{report['resolved_edge_count']} resolved edge"
+            f"{'s' if report['resolved_edge_count'] != 1 else ''}; "
+            f"{report['unresolved_edge_count']} unresolved"
+        ),
+        (
+            f"{report['duplicate_name_count']} duplicate name"
+            f"{'s' if report['duplicate_name_count'] != 1 else ''}; "
+            f"{report['unresolved_instance_count']} unresolved instance"
+            f"{'s' if report['unresolved_instance_count'] != 1 else ''}; "
+            f"{report['unplaced_module_count']} unplaced"
+        ),
+    ]
+    for card in report["health_cards"]:
+        lines.append(f"status: {card['card_id']} ({card['status']})")
+    if report["root_names"]:
+        lines.append(f"roots: {', '.join(report['root_names'])}")
+    if report["leaf_names"]:
+        lines.append(f"leaves: {', '.join(report['leaf_names'])}")
+    if report["unplaced_module_names"]:
+        lines.append(f"unplaced modules: {', '.join(report['unplaced_module_names'])}")
+    for reason in report["blocked_reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"next: {report['next_required_action']}")
+    lines.append(
+        "read-only graph health summary: no command argv, validation, shell, "
         "refactor, patch, file write, lab, launcher, vendor tool, provider, "
         "or hardware execution"
     )

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -27,6 +27,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_context_bundle,
     build_module_depth_report,
     build_module_duplicate_report,
+    build_module_graph_health_summary,
     build_module_hierarchy_cycle_report,
     build_module_hierarchy_view,
     build_module_leaf_candidate_report,
@@ -58,6 +59,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_module_context_text,
     format_module_depth_report_text,
     format_module_duplicate_report_text,
+    format_module_graph_health_summary_text,
     format_module_hierarchy_cycle_text,
     format_module_hierarchy_text,
     format_module_leaf_candidate_report_text,
@@ -781,6 +783,98 @@ def test_build_module_depth_report_blocks_unresolved_dependencies():
     assert module["blocked_reasons"] == [
         "unresolved dependencies for depth report: missing_child"
     ]
+
+
+def test_build_module_graph_health_summary_combines_graph_signals():
+    report = build_module_graph_health_summary(str(FIXTURE), FIXTURE)
+
+    assert report["kind"] == "module-graph-health-summary"
+    assert report["health_state"] == "ready-for-review"
+    assert report["ready_for_review"] is True
+    assert report["module_count"] == 2
+    assert report["complete_module_count"] == 2
+    assert report["incomplete_module_count"] == 0
+    assert report["root_count"] == 1
+    assert report["root_names"] == ["top_mod"]
+    assert report["leaf_count"] == 1
+    assert report["leaf_names"] == ["leaf_mod"]
+    assert report["max_depth"] == 1
+    assert report["resolved_edge_count"] == 1
+    assert report["unresolved_edge_count"] == 0
+    assert report["unresolved_instance_count"] == 0
+    assert report["duplicate_name_count"] == 0
+    assert report["unplaced_module_count"] == 0
+    assert report["blocked_reasons"] == []
+    assert report["next_required_action"] == (
+        "continue module organization and refactor readiness review"
+    )
+    cards = {card["card_id"]: card for card in report["health_cards"]}
+    assert cards["root-candidates"]["status"] == "roots-detected"
+    assert cards["leaf-candidates"]["status"] == "leaves-detected"
+    assert cards["depth-levels"]["status"] == "depths-detected"
+    assert cards["hierarchy-cycles"]["status"] == "no-cycles-detected"
+    assert cards["unresolved-instances"]["status"] == (
+        "no-unresolved-instances-detected"
+    )
+    assert cards["duplicate-modules"]["status"] == "no-duplicates-detected"
+    assert report["safety"]["read_only"] is True
+    assert report["safety"]["graph_health_summary_only"] is True
+    assert report["safety"]["combines_root_candidate_report"] is True
+    assert report["safety"]["combines_leaf_candidate_report"] is True
+    assert report["safety"]["combines_depth_report"] is True
+    assert report["safety"]["combines_cycle_report"] is True
+    assert report["safety"]["combines_unresolved_instance_report"] is True
+    assert report["safety"]["combines_duplicate_report"] is True
+    assert report["safety"]["writes_files"] is False
+    assert report["safety"]["emits_command_descriptors"] is False
+    assert report["safety"]["runs_validation"] is False
+    assert report["safety"]["runs_shell"] is False
+    assert report["safety"]["invokes_pccx_lab"] is False
+    assert report["safety"]["invokes_launcher"] is False
+    assert report["safety"]["hardware_access"] is False
+    assert report["writes_files"] is False
+    assert '"argv"' not in json.dumps(report)
+
+
+def test_build_module_graph_health_summary_blocks_graph_issues():
+    report = build_module_graph_health_summary(str(CYCLIC_FIXTURE), CYCLIC_FIXTURE)
+
+    assert report["health_state"] == "blocked"
+    assert report["ready_for_review"] is False
+    assert report["root_count"] == 0
+    assert report["leaf_count"] == 0
+    assert report["unplaced_module_count"] == 2
+    assert report["blocked_reasons"] == [
+        "scanner-detected hierarchy cycle: alpha_mod -> beta_mod -> alpha_mod",
+        "no root candidates detected",
+        "no leaf candidates detected",
+        "unplaced modules: alpha_mod, beta_mod",
+    ]
+    assert report["next_required_action"] == (
+        "resolve scanner-detected module graph blockers before refactor planning"
+    )
+
+
+def test_build_module_graph_health_summary_blocks_unresolved_and_duplicates():
+    unresolved = build_module_graph_health_summary(
+        str(UNRESOLVED_FIXTURE),
+        UNRESOLVED_FIXTURE,
+    )
+    duplicates = build_module_graph_health_summary(
+        str(DUPLICATE_FIXTURE),
+        DUPLICATE_FIXTURE,
+    )
+
+    assert unresolved["health_state"] == "blocked"
+    assert unresolved["unresolved_instance_count"] == 1
+    assert unresolved["blocked_reasons"] == [
+        "unresolved module instantiation: missing_child as u_missing in unresolved_top",
+        "unresolved dependencies for depth report: missing_child",
+    ]
+    assert duplicates["health_state"] == "blocked"
+    assert duplicates["duplicate_name_count"] == 1
+    assert duplicates["duplicate_names"] == ["dup_mod"]
+    assert "ambiguous module name: dup_mod" in duplicates["blocked_reasons"]
 
 
 def test_build_module_summary_view_reports_ports_and_safety():
@@ -1756,6 +1850,19 @@ def test_format_module_depth_report_text_mentions_boundary():
     assert "read-only depth report: no command argv" in text
 
 
+def test_format_module_graph_health_summary_text_mentions_boundary():
+    report = build_module_graph_health_summary(str(FIXTURE), FIXTURE)
+    text = format_module_graph_health_summary_text(report)
+
+    assert "module graph health: ready-for-review" in text
+    assert "ready for review: yes" in text
+    assert "1 root; 1 leaf; max depth: 1" in text
+    assert "status: hierarchy-cycles (no-cycles-detected)" in text
+    assert "roots: top_mod" in text
+    assert "leaves: leaf_mod" in text
+    assert "read-only graph health summary: no command argv" in text
+
+
 def test_format_module_summary_text_mentions_ports_and_boundary():
     view = build_module_summary_view(str(FIXTURE), FIXTURE)
     text = format_module_summary_text(view)
@@ -2251,6 +2358,29 @@ def test_cli_module_depths_text():
     assert "depth 0: top_mod" in result.stdout
     assert "depth 1: leaf_mod" in result.stdout
     assert "read-only depth report: no command argv" in result.stdout
+
+
+def test_cli_module_health_json():
+    result = _run_cli("module-health", str(FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-graph-health-summary"
+    assert payload["health_state"] == "ready-for-review"
+    assert payload["ready_for_review"] is True
+    assert payload["root_names"] == ["top_mod"]
+    assert payload["leaf_names"] == ["leaf_mod"]
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["emits_command_descriptors"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_module_health_text():
+    result = _run_cli("module-health", str(FIXTURE), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "module graph health: ready-for-review" in result.stdout
+    assert "status: duplicate-modules (no-duplicates-detected)" in result.stdout
+    assert "read-only graph health summary: no command argv" in result.stdout
 
 
 def test_cli_module_summary_json():
@@ -3038,6 +3168,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-roots <path>" in contract
     assert "module-leaves <path>" in contract
     assert "module-depths <path>" in contract
+    assert "module-health <path>" in contract
     assert "module-summary <path>" in contract
     assert "port-usage <path>" in contract
     assert "module-context <path>" in contract
@@ -3062,6 +3193,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-root-candidate-report" in workflow
     assert "module-leaf-candidate-report" in workflow
     assert "module-depth-report" in workflow
+    assert "module-graph-health-summary" in workflow
     assert "module-summary-view" in workflow
     assert "module-port-usage-view" in workflow
     assert "module-context-bundle" in workflow
@@ -3088,5 +3220,6 @@ def test_docs_cover_organization_flow_and_limits():
     assert "hierarchy cycle report" in workflow
     assert "unresolved instantiation report" in workflow
     assert "root-candidate report" in workflow
+    assert "module graph health summary" in workflow
     assert "does not write files" in workflow
     assert "not a full SystemVerilog parser" in workflow


### PR DESCRIPTION
## Summary
- Add a read-only module-health CLI surface that emits a module-graph-health-summary over root, leaf, depth, cycle, unresolved-instance, and duplicate-name scanner signals.
- Add JSON/text coverage for ready and blocked graph states.
- Document the pre-stable editor bridge and module organization boundary.

Refs #8

## Validation
- PYTHONPATH=src python3 -m pytest -q tests/test_module_organization.py
- python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py
- PYTHONPATH=src python3 -m pccx_ide_cli module-health fixtures/organization/hierarchy_top.sv --format json
- PYTHONPATH=src python3 -m pccx_ide_cli module-health fixtures/organization/cyclic_hierarchy.sv --format text
- PYTHONPATH=src python3 -m pytest -q
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- bash scripts/vscode-adapter-smoke.sh
- find scripts -type f -name '*.sh' -exec bash -n {} +
- git diff --check
- local claim-scan matching CI pattern

## Safety
- Report data only: no command argv emission, validation execution, shell execution, refactor application, patch generation, file write, lab or launcher invocation, vendor-tool invocation, provider call, hardware access, telemetry, or automatic repository action.
