### PR TITLE
Add module orphan candidate report

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ python -m pccx_ide_cli hierarchy-cycles fixtures/organization/cyclic_hierarchy.s
 python -m pccx_ide_cli unresolved-instances fixtures/organization/unresolved_instances.sv --format text
 python -m pccx_ide_cli module-roots fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli module-leaves fixtures/organization/hierarchy_top.sv --format json
+python -m pccx_ide_cli module-orphans fixtures/organization/orphan_modules.sv --format json
 python -m pccx_ide_cli module-depths fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli module-health fixtures/organization/hierarchy_top.sv --format json
 
@@ -229,6 +230,8 @@ whose target module is not declared in the scanned input.
 module entry-point review.
 `module-leaves` reports scanner-detected leaf candidates for dependency-end
 organization review.
+`module-orphans` reports scanner-detected isolated module candidates with no
+resolved dependencies or dependents.
 `module-depths` groups scanner-detected hierarchy levels from root candidates
 for module organization review.
 `module-health` combines scanner-detected root, leaf, depth, cycle,

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -54,6 +54,7 @@ python -m pccx_ide_cli hierarchy-cycles <path> --format json
 python -m pccx_ide_cli unresolved-instances <path> --format json
 python -m pccx_ide_cli module-roots <path> --format json
 python -m pccx_ide_cli module-leaves <path> --format json
+python -m pccx_ide_cli module-orphans <path> --format json
 python -m pccx_ide_cli module-depths <path> --format json
 python -m pccx_ide_cli module-health <path> --format json
 python -m pccx_ide_cli module-summary <path> --format json
@@ -214,10 +215,11 @@ surfaces do not write files, apply refactors, generate patches, run validation,
 invoke pccx-lab or the launcher, run vendor tools, call providers, touch
 hardware, or perform automatic repository actions. `hierarchy`,
 `dependencies`, `hierarchy-cycles`, `unresolved-instances`, `module-roots`,
-`module-leaves`, `module-depths`, `module-health`, `module-summary`, `port-usage`,
-`module-context`, and `refactor-impact` render focused read-only views from
-the same scanner data, including hierarchy cycle warnings, unresolved
-instantiation warnings, root-candidate summaries, leaf-candidate summaries,
+`module-leaves`, `module-orphans`, `module-depths`, `module-health`,
+`module-summary`, `port-usage`, `module-context`, and `refactor-impact`
+render focused read-only views from the same scanner data, including
+hierarchy cycle warnings, unresolved instantiation warnings, root-candidate
+summaries, leaf-candidate summaries, orphan-candidate summaries,
 depth-level summaries,
 module graph health summaries,
 conservative module header/port summaries, target port usage summaries,

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -5,15 +5,17 @@
 This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
 `hierarchy-cycles`, `unresolved-instances`, `module-roots`, `module-leaves`,
-`module-depths`, `module-health`, `module-summary`, `boundary-audit`, `module-duplicates`,
-`refactor-candidates`, `port-usage`, `module-context`, `refactor-impact`,
+`module-orphans`, `module-depths`, `module-health`, `module-summary`,
+`boundary-audit`, `module-duplicates`, `refactor-candidates`, `port-usage`,
+`module-context`, `refactor-impact`,
 `validation-plan`, `refactor-review`, `refactor-approval`,
 `refactor-application`, `refactor-result`, `refactor-handoff`,
 `refactor-checklist`, and
 `refactor-session` CLI surfaces that report module boundary spans,
 scanner-based hierarchy data, direct dependency impact data, hierarchy cycle
 report metadata, unresolved instantiation report metadata, root-candidate
-report metadata, leaf-candidate report metadata, depth-level report metadata,
+report metadata, leaf-candidate report metadata, orphan-candidate report
+metadata, depth-level report metadata,
 module graph health summary metadata,
 conservative module header/port summaries, duplicate-name report metadata,
 target port usage summaries, target module context bundles, target-specific
@@ -44,6 +46,8 @@ python -m pccx_ide_cli module-roots <path> --format json
 python -m pccx_ide_cli module-roots <path> --format text
 python -m pccx_ide_cli module-leaves <path> --format json
 python -m pccx_ide_cli module-leaves <path> --format text
+python -m pccx_ide_cli module-orphans <path> --format json
+python -m pccx_ide_cli module-orphans <path> --format text
 python -m pccx_ide_cli module-depths <path> --format json
 python -m pccx_ide_cli module-depths <path> --format text
 python -m pccx_ide_cli module-health <path> --format json
@@ -321,6 +325,43 @@ that do not instantiate another resolved module in the scanned input:
 ```
 
 The leaf-candidate report is display data only. It does not write files,
+apply refactors, generate patches, run validation, execute shell commands,
+emit command argv, invoke `pccx-lab`, invoke the launcher, call providers,
+touch hardware, upload telemetry, or perform automatic repository actions.
+
+The orphan-candidate report uses scanner hierarchy edges to identify modules
+with no resolved dependencies and no resolved dependents in the scanned input:
+
+```json
+{
+  "kind": "module-orphan-candidate-report",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "report_state": "orphans-detected",
+  "orphan_count": 1,
+  "orphan_names": ["orphan_mod"],
+  "orphans": [
+    {
+      "name": "orphan_mod",
+      "orphan_state": "orphan-candidate",
+      "direct_dependencies": [],
+      "direct_dependents": [],
+      "unresolved_dependencies": [],
+      "reason": "no resolved dependencies or dependents detected by scanner"
+    }
+  ],
+  "safety": {
+    "read_only": true,
+    "writes_files": false,
+    "emits_command_descriptors": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The orphan-candidate report is display data only. It does not write files,
 apply refactors, generate patches, run validation, execute shell commands,
 emit command argv, invoke `pccx-lab`, invoke the launcher, call providers,
 touch hardware, upload telemetry, or perform automatic repository actions.

--- a/fixtures/organization/orphan_modules.sv
+++ b/fixtures/organization/orphan_modules.sv
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
+
+module shared_leaf (
+    input logic clk
+);
+endmodule
+
+module connected_top (
+    input logic clk
+);
+    shared_leaf u_leaf (
+        .clk(clk)
+    );
+endmodule
+
+module orphan_mod (
+    input logic clk
+);
+endmodule

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -35,6 +35,7 @@ run_json module-dependency-view dependencies fixtures/organization/hierarchy_top
 run_json module-hierarchy-cycle-report hierarchy-cycles fixtures/organization/cyclic_hierarchy.sv --format json
 run_json module-unresolved-instance-report unresolved-instances fixtures/organization/unresolved_instances.sv --format json
 run_json module-root-candidate-report module-roots fixtures/organization/hierarchy_top.sv --format json
+run_json module-orphan-candidate-report module-orphans fixtures/organization/orphan_modules.sv --format json
 run_json module-duplicate-report module-duplicates fixtures/organization/duplicate_modules.sv --format json
 run_json module-summary-view module-summary fixtures/organization/hierarchy_top.sv --format json
 run_json module-refactor-candidate-list refactor-candidates fixtures/organization/hierarchy_top.sv --format json

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -320,6 +320,24 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    module_orphans_cmd = sub.add_parser(
+        "module-orphans",
+        help=(
+            "Render scanner-based read-only module orphan-candidate report data."
+        ),
+    )
+    module_orphans_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    module_orphans_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     module_depths_cmd = sub.add_parser(
         "module-depths",
         help=(
@@ -1349,6 +1367,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_leaf_candidate_report_text(report))
+        return 0
+
+    if args.command == "module-orphans":
+        from .module_organization import (
+            build_module_orphan_candidate_report,
+            format_module_orphan_candidate_report_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        report = build_module_orphan_candidate_report(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(report, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_orphan_candidate_report_text(report))
         return 0
 
     if args.command == "module-depths":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -174,6 +174,17 @@ MODULE_LEAF_REPORT_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+MODULE_ORPHAN_REPORT_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based module orphan-candidate report only",
+    "uses resolved dependency and dependent edges from the organization scanner",
+    "single-line instantiation candidates only",
+    "unresolved instantiation candidates block orphan-candidate readiness",
+    "no semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
+    "does not apply refactors, write files, generate patches, or run validation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 MODULE_DEPTH_REPORT_LIMITATIONS: tuple[str, ...] = (
     "scanner-based module hierarchy depth report only",
     "uses root candidates and resolved dependency edges from the organization scanner",
@@ -567,6 +578,28 @@ def _module_leaf_report_safety_flags() -> dict[str, bool]:
     return {
         "read_only": True,
         "leaf_candidate_report_only": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _module_orphan_report_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "orphan_candidate_report_only": True,
         "emits_command_descriptors": False,
         "writes_files": False,
         "moves_files": False,
@@ -2085,6 +2118,138 @@ def build_module_leaf_candidate_report(source: str, path: Path) -> dict[str, Any
         "report_state": "leaves-detected" if leaves else "no-leaves-detected",
         "resolved_edge_count": resolved_edge_count,
         "safety": _module_leaf_report_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "tool": "pccx-ide-cli",
+        "unresolved_edge_count": len(hierarchy["edges"]) - resolved_edge_count,
+        "writes_files": False,
+    }
+
+
+def _module_orphan_rows(
+    modules: list[dict[str, Any]],
+    hierarchy: dict[str, Any],
+) -> list[dict[str, Any]]:
+    modules_by_name: dict[str, dict[str, Any]] = {}
+    declaration_counts: dict[str, int] = {}
+    for module in modules:
+        modules_by_name.setdefault(module["name"], module)
+        declaration_counts[module["name"]] = (
+            declaration_counts.get(module["name"], 0) + 1
+        )
+
+    resolved_dependencies_by_module: dict[str, set[str]] = {
+        name: set()
+        for name in modules_by_name
+    }
+    direct_dependents_by_module: dict[str, set[str]] = {
+        name: set()
+        for name in modules_by_name
+    }
+    unresolved_dependencies_by_module: dict[str, set[str]] = {
+        name: set()
+        for name in modules_by_name
+    }
+    for edge in hierarchy["edges"]:
+        parent = edge["parent"]
+        child = edge["child"]
+        if parent not in modules_by_name:
+            continue
+        if edge["resolved"]:
+            resolved_dependencies_by_module.setdefault(parent, set()).add(child)
+            if child in direct_dependents_by_module:
+                direct_dependents_by_module[child].add(parent)
+        else:
+            unresolved_dependencies_by_module.setdefault(parent, set()).add(child)
+
+    rows: list[dict[str, Any]] = []
+    for orphan_name in sorted(modules_by_name):
+        direct_dependencies = sorted(
+            resolved_dependencies_by_module.get(orphan_name, set())
+        )
+        direct_dependents = sorted(
+            direct_dependents_by_module.get(orphan_name, set())
+        )
+        if direct_dependencies or direct_dependents:
+            continue
+
+        module = modules_by_name[orphan_name]
+        unresolved_dependencies = sorted(
+            unresolved_dependencies_by_module.get(orphan_name, set())
+        )
+        blocked_reasons: list[str] = []
+        if not module["complete"]:
+            blocked_reasons.append(f"module boundary is incomplete: {orphan_name}")
+        if declaration_counts[orphan_name] > 1:
+            blocked_reasons.append(f"ambiguous module name: {orphan_name}")
+        if unresolved_dependencies:
+            blocked_reasons.append(
+                "unresolved dependencies for orphan candidate: "
+                f"{', '.join(unresolved_dependencies)}"
+            )
+        rows.append({
+            "blocked_reasons": blocked_reasons,
+            "complete": module["complete"],
+            "declaration_count": declaration_counts[orphan_name],
+            "direct_dependencies": direct_dependencies,
+            "direct_dependency_count": len(direct_dependencies),
+            "direct_dependents": direct_dependents,
+            "direct_dependent_count": len(direct_dependents),
+            "file": module["file"],
+            "name": orphan_name,
+            "orphan_state": "orphan-candidate",
+            "reason": "no resolved dependencies or dependents detected by scanner",
+            "refactor_preflight_state": (
+                "blocked" if blocked_reasons else "ready-for-review"
+            ),
+            "start_column": module["start_column"],
+            "start_line": module["start_line"],
+            "unresolved_dependencies": unresolved_dependencies,
+            "unresolved_dependency_count": len(unresolved_dependencies),
+        })
+    return rows
+
+
+def build_module_orphan_candidate_report(source: str, path: Path) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    hierarchy = organization["hierarchy"]
+    resolved_edge_count = len([
+        edge
+        for edge in hierarchy["edges"]
+        if edge["resolved"]
+    ])
+    orphans = _module_orphan_rows(modules, hierarchy)
+    blocked_reasons = list(dict.fromkeys([
+        reason
+        for orphan in orphans
+        for reason in orphan["blocked_reasons"]
+    ]))
+    if modules and not orphans:
+        blocked_reasons.append("no orphan candidates detected")
+    if not modules:
+        blocked_reasons.append("no module declarations detected")
+
+    return {
+        "blocked_reasons": blocked_reasons,
+        "edge_count": len(hierarchy["edges"]),
+        "kind": "module-orphan-candidate-report",
+        "limitations": list(MODULE_ORPHAN_REPORT_LIMITATIONS),
+        "module_count": len(modules),
+        "next_required_action": (
+            "review scanner-detected orphan candidates for isolation or cleanup"
+            if orphans
+            else "continue module organization review"
+        ),
+        "orphan_count": len(orphans),
+        "orphan_names": [
+            orphan["name"]
+            for orphan in orphans
+        ],
+        "orphans": orphans,
+        "report_state": "orphans-detected" if orphans else "no-orphans-detected",
+        "resolved_edge_count": resolved_edge_count,
+        "safety": _module_orphan_report_safety_flags(),
         "scanner": "line-scanner",
         "source": source,
         "tool": "pccx-ide-cli",
@@ -4980,6 +5145,40 @@ def format_module_leaf_candidate_report_text(report: dict[str, Any]) -> str:
     lines.append(f"next: {report['next_required_action']}")
     lines.append(
         "read-only leaf report: no command argv, validation, shell, "
+        "refactor, patch, file write, lab, launcher, vendor tool, provider, "
+        "or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_module_orphan_candidate_report_text(report: dict[str, Any]) -> str:
+    lines = [
+        f"source: {report['source']}",
+        f"module orphans: {report['report_state']}",
+        f"{report['module_count']} module"
+        f"{'s' if report['module_count'] != 1 else ''}",
+        f"{report['orphan_count']} orphan candidate"
+        f"{'s' if report['orphan_count'] != 1 else ''}",
+    ]
+    if not report["orphans"]:
+        lines.append("orphans: none")
+    for orphan in report["orphans"]:
+        unresolved = ", ".join(orphan["unresolved_dependencies"]) or "none"
+        lines.append(
+            f"{orphan['file']}:{orphan['start_line']}: module {orphan['name']} "
+            f"({orphan['refactor_preflight_state']})"
+        )
+        lines.append(
+            "  dependencies=none; dependents=none; "
+            f"unresolved={unresolved}; reason={orphan['reason']}"
+        )
+        for reason in orphan["blocked_reasons"]:
+            lines.append(f"  blocked: {reason}")
+    for reason in report["blocked_reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"next: {report['next_required_action']}")
+    lines.append(
+        "read-only orphan report: no command argv, validation, shell, "
         "refactor, patch, file write, lab, launcher, vendor tool, provider, "
         "or hardware execution"
     )

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -15,6 +15,7 @@ FIXTURE = REPO_ROOT / "fixtures" / "organization" / "hierarchy_top.sv"
 CYCLIC_FIXTURE = REPO_ROOT / "fixtures" / "organization" / "cyclic_hierarchy.sv"
 DUPLICATE_FIXTURE = REPO_ROOT / "fixtures" / "organization" / "duplicate_modules.sv"
 UNRESOLVED_FIXTURE = REPO_ROOT / "fixtures" / "organization" / "unresolved_instances.sv"
+ORPHAN_FIXTURE = REPO_ROOT / "fixtures" / "organization" / "orphan_modules.sv"
 INCOMPLETE_FIXTURE = REPO_ROOT / "fixtures" / "missing_endmodule.sv"
 CONTRACT_DOC = REPO_ROOT / "docs" / "EDITOR_BRIDGE_CONTRACT.md"
 WORKFLOW_DOC = REPO_ROOT / "docs" / "MODULE_ORGANIZATION_WORKFLOW.md"
@@ -31,6 +32,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_hierarchy_cycle_report,
     build_module_hierarchy_view,
     build_module_leaf_candidate_report,
+    build_module_orphan_candidate_report,
     build_module_organization_export,
     build_module_port_usage_view,
     build_module_root_candidate_report,
@@ -63,6 +65,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_module_hierarchy_cycle_text,
     format_module_hierarchy_text,
     format_module_leaf_candidate_report_text,
+    format_module_orphan_candidate_report_text,
     format_module_organization_text,
     format_module_port_usage_text,
     format_module_root_candidate_report_text,
@@ -680,6 +683,83 @@ def test_build_module_leaf_candidate_report_blocks_when_no_leaves_detected():
     assert report["next_required_action"] == (
         "resolve hierarchy blockers before leaf-candidate review"
     )
+
+
+def test_build_module_orphan_candidate_report_detects_isolated_modules():
+    report = build_module_orphan_candidate_report(str(ORPHAN_FIXTURE), ORPHAN_FIXTURE)
+
+    assert report["kind"] == "module-orphan-candidate-report"
+    assert report["report_state"] == "orphans-detected"
+    assert report["module_count"] == 3
+    assert report["edge_count"] == 1
+    assert report["resolved_edge_count"] == 1
+    assert report["unresolved_edge_count"] == 0
+    assert report["orphan_count"] == 1
+    assert report["orphan_names"] == ["orphan_mod"]
+    assert report["blocked_reasons"] == []
+    assert report["next_required_action"] == (
+        "review scanner-detected orphan candidates for isolation or cleanup"
+    )
+    orphan = report["orphans"][0]
+    assert orphan["name"] == "orphan_mod"
+    assert orphan["file"] == str(ORPHAN_FIXTURE)
+    assert orphan["start_line"] == 17
+    assert orphan["start_column"] == 1
+    assert orphan["complete"] is True
+    assert orphan["declaration_count"] == 1
+    assert orphan["direct_dependencies"] == []
+    assert orphan["direct_dependency_count"] == 0
+    assert orphan["direct_dependents"] == []
+    assert orphan["direct_dependent_count"] == 0
+    assert orphan["unresolved_dependencies"] == []
+    assert orphan["unresolved_dependency_count"] == 0
+    assert orphan["refactor_preflight_state"] == "ready-for-review"
+    assert orphan["reason"] == "no resolved dependencies or dependents detected by scanner"
+    assert report["safety"]["read_only"] is True
+    assert report["safety"]["orphan_candidate_report_only"] is True
+    assert report["safety"]["emits_command_descriptors"] is False
+    assert report["safety"]["writes_files"] is False
+    assert report["safety"]["applies_refactor"] is False
+    assert report["safety"]["generates_patch"] is False
+    assert report["safety"]["runs_validation"] is False
+    assert report["safety"]["runs_shell"] is False
+    assert report["safety"]["invokes_pccx_lab"] is False
+    assert report["safety"]["invokes_launcher"] is False
+    assert report["safety"]["invokes_vendor_tools"] is False
+    assert report["safety"]["provider_calls"] is False
+    assert report["safety"]["hardware_access"] is False
+    assert report["writes_files"] is False
+    assert '"argv"' not in json.dumps(report)
+
+
+def test_build_module_orphan_candidate_report_blocks_when_no_orphans_detected():
+    report = build_module_orphan_candidate_report(str(FIXTURE), FIXTURE)
+
+    assert report["report_state"] == "no-orphans-detected"
+    assert report["orphan_count"] == 0
+    assert report["orphan_names"] == []
+    assert report["orphans"] == []
+    assert report["blocked_reasons"] == ["no orphan candidates detected"]
+    assert report["next_required_action"] == "continue module organization review"
+
+
+def test_build_module_orphan_candidate_report_blocks_unresolved_dependencies():
+    report = build_module_orphan_candidate_report(
+        str(UNRESOLVED_FIXTURE),
+        UNRESOLVED_FIXTURE,
+    )
+
+    assert report["report_state"] == "orphans-detected"
+    assert report["orphan_names"] == ["unresolved_top"]
+    assert report["blocked_reasons"] == [
+        "unresolved dependencies for orphan candidate: missing_child"
+    ]
+    orphan = report["orphans"][0]
+    assert orphan["refactor_preflight_state"] == "blocked"
+    assert orphan["unresolved_dependencies"] == ["missing_child"]
+    assert orphan["blocked_reasons"] == [
+        "unresolved dependencies for orphan candidate: missing_child"
+    ]
 
 
 def test_build_module_depth_report_groups_hierarchy_levels():
@@ -1836,6 +1916,17 @@ def test_format_module_leaf_candidate_report_text_mentions_boundary():
     assert "read-only leaf report: no command argv" in text
 
 
+def test_format_module_orphan_candidate_report_text_mentions_boundary():
+    report = build_module_orphan_candidate_report(str(ORPHAN_FIXTURE), ORPHAN_FIXTURE)
+    text = format_module_orphan_candidate_report_text(report)
+
+    assert "module orphans: orphans-detected" in text
+    assert "1 orphan candidate" in text
+    assert "module orphan_mod (ready-for-review)" in text
+    assert "dependencies=none; dependents=none; unresolved=none" in text
+    assert "read-only orphan report: no command argv" in text
+
+
 def test_format_module_depth_report_text_mentions_boundary():
     report = build_module_depth_report(str(FIXTURE), FIXTURE)
     text = format_module_depth_report_text(report)
@@ -2333,6 +2424,29 @@ def test_cli_module_leaves_text():
     assert "module leaves: leaves-detected" in result.stdout
     assert "module leaf_mod (ready-for-review)" in result.stdout
     assert "read-only leaf report: no command argv" in result.stdout
+
+
+def test_cli_module_orphans_json():
+    result = _run_cli("module-orphans", str(ORPHAN_FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-orphan-candidate-report"
+    assert payload["report_state"] == "orphans-detected"
+    assert payload["orphan_names"] == ["orphan_mod"]
+    assert payload["orphans"][0]["direct_dependencies"] == []
+    assert payload["orphans"][0]["direct_dependents"] == []
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["emits_command_descriptors"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_module_orphans_text():
+    result = _run_cli("module-orphans", str(ORPHAN_FIXTURE), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "module orphans: orphans-detected" in result.stdout
+    assert "module orphan_mod (ready-for-review)" in result.stdout
+    assert "read-only orphan report: no command argv" in result.stdout
 
 
 def test_cli_module_depths_json():
@@ -2995,6 +3109,12 @@ def test_cli_module_roots_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_module_orphans_missing_path_exits_nonzero():
+    result = _run_cli("module-orphans", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_cli_module_summary_missing_path_exits_nonzero():
     result = _run_cli("module-summary", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
@@ -3167,6 +3287,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "unresolved-instances <path>" in contract
     assert "module-roots <path>" in contract
     assert "module-leaves <path>" in contract
+    assert "module-orphans <path>" in contract
     assert "module-depths <path>" in contract
     assert "module-health <path>" in contract
     assert "module-summary <path>" in contract
@@ -3192,6 +3313,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-unresolved-instance-report" in workflow
     assert "module-root-candidate-report" in workflow
     assert "module-leaf-candidate-report" in workflow
+    assert "module-orphan-candidate-report" in workflow
     assert "module-depth-report" in workflow
     assert "module-graph-health-summary" in workflow
     assert "module-summary-view" in workflow


### PR DESCRIPTION
## Summary
- Add read-only `module-orphans` CLI output for scanner-detected module orphan candidates with no resolved dependencies or resolved dependents.
- Add an isolated-module fixture, builder/formatter coverage, CLI tests, docs, and editor bridge smoke coverage.
- Keep the report scanner-only and display-only: no command argv emission, validation execution, shell execution, file writes, refactor application, patch generation, move execution, lab/launcher/vendor-tool/provider/hardware execution, LSP claim, marketplace claim, runtime claim, or stable API/ABI claim.

Refs #8

## Validation
- `PYTHONPATH=src python3 -m pytest -q tests/test_module_organization.py`
- `PYTHONPATH=src python3 -m pccx_ide_cli module-orphans fixtures/organization/orphan_modules.sv --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli module-orphans fixtures/organization/hierarchy_top.sv --format text`
- `python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py`
- `PYTHONPATH=src python3 -m pytest -q`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `find scripts -type f -name '*.sh' -exec bash -n {} +`
- `python3 scripts/check-source-headers.py`
- `git diff --check`
- local forbidden-claim scan matching CI pattern
- `git diff --cached --check`

## Safety
No command argv emission, validation execution, shell execution, file writes, refactor application, patch generation, move execution, lab/launcher/vendor-tool/provider/hardware execution, LSP claim, marketplace claim, runtime claim, or stable API/ABI claim.
