### PR TITLE
Add module fanout report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,13 @@ jobs:
               fixtures/organization/hierarchy_top.sv \
               | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-dependency-view'; assert d['safety']['writes_files'] is False"
           echo "dependency view smoke ok"
+      - name: cli smoke (module fanout exits zero)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli module-fanout \
+              fixtures/organization/fanout_hierarchy.sv \
+              | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-fanout-report'; assert d['safety']['writes_files'] is False; assert d['safety']['emits_command_descriptors'] is False"
+          echo "module fanout smoke ok"
       - name: cli smoke (module summary exits zero)
         run: |
           set -e

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ python -m pccx_ide_cli module-roots fixtures/organization/hierarchy_top.sv --for
 python -m pccx_ide_cli module-leaves fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli module-orphans fixtures/organization/orphan_modules.sv --format json
 python -m pccx_ide_cli module-depths fixtures/organization/hierarchy_top.sv --format json
+python -m pccx_ide_cli module-fanout fixtures/organization/fanout_hierarchy.sv --format json
 python -m pccx_ide_cli module-health fixtures/organization/hierarchy_top.sv --format json
 
 # Module header/port summary view (pre-stable, read-only)
@@ -234,6 +235,8 @@ organization review.
 resolved dependencies or dependents.
 `module-depths` groups scanner-detected hierarchy levels from root candidates
 for module organization review.
+`module-fanout` ranks scanner-detected modules by resolved direct dependency
+count for fanout review.
 `module-health` combines scanner-detected root, leaf, depth, cycle,
 unresolved-instance, and duplicate-name signals into a read-only module graph
 health summary for editor status panes.

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -56,6 +56,7 @@ python -m pccx_ide_cli module-roots <path> --format json
 python -m pccx_ide_cli module-leaves <path> --format json
 python -m pccx_ide_cli module-orphans <path> --format json
 python -m pccx_ide_cli module-depths <path> --format json
+python -m pccx_ide_cli module-fanout <path> --format json
 python -m pccx_ide_cli module-health <path> --format json
 python -m pccx_ide_cli module-summary <path> --format json
 python -m pccx_ide_cli port-usage <path> --module <name> --format json
@@ -215,12 +216,14 @@ surfaces do not write files, apply refactors, generate patches, run validation,
 invoke pccx-lab or the launcher, run vendor tools, call providers, touch
 hardware, or perform automatic repository actions. `hierarchy`,
 `dependencies`, `hierarchy-cycles`, `unresolved-instances`, `module-roots`,
-`module-leaves`, `module-orphans`, `module-depths`, `module-health`,
+`module-leaves`, `module-orphans`, `module-depths`, `module-fanout`,
+`module-health`,
 `module-summary`, `port-usage`, `module-context`, and `refactor-impact`
 render focused read-only views from the same scanner data, including
 hierarchy cycle warnings, unresolved instantiation warnings, root-candidate
 summaries, leaf-candidate summaries, orphan-candidate summaries,
 depth-level summaries,
+fanout rankings,
 module graph health summaries,
 conservative module header/port summaries, target port usage summaries,
 target module context bundles, and

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -5,7 +5,8 @@
 This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
 `hierarchy-cycles`, `unresolved-instances`, `module-roots`, `module-leaves`,
-`module-orphans`, `module-depths`, `module-health`, `module-summary`,
+`module-orphans`, `module-depths`, `module-fanout`, `module-health`,
+`module-summary`,
 `boundary-audit`, `module-duplicates`, `refactor-candidates`, `port-usage`,
 `module-context`, `refactor-impact`,
 `validation-plan`, `refactor-review`, `refactor-approval`,
@@ -16,6 +17,7 @@ scanner-based hierarchy data, direct dependency impact data, hierarchy cycle
 report metadata, unresolved instantiation report metadata, root-candidate
 report metadata, leaf-candidate report metadata, orphan-candidate report
 metadata, depth-level report metadata,
+`module-fanout-report` metadata,
 module graph health summary metadata,
 conservative module header/port summaries, duplicate-name report metadata,
 target port usage summaries, target module context bundles, target-specific
@@ -50,6 +52,8 @@ python -m pccx_ide_cli module-orphans <path> --format json
 python -m pccx_ide_cli module-orphans <path> --format text
 python -m pccx_ide_cli module-depths <path> --format json
 python -m pccx_ide_cli module-depths <path> --format text
+python -m pccx_ide_cli module-fanout <path> --format json
+python -m pccx_ide_cli module-fanout <path> --format text
 python -m pccx_ide_cli module-health <path> --format json
 python -m pccx_ide_cli module-health <path> --format text
 python -m pccx_ide_cli module-summary <path> --format json

--- a/fixtures/organization/fanout_hierarchy.sv
+++ b/fixtures/organization/fanout_hierarchy.sv
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
+
+module fanout_leaf (
+    input logic clk
+);
+endmodule
+
+module fanout_child_a (
+    input logic clk
+);
+    fanout_leaf u_leaf (
+        .clk(clk)
+    );
+endmodule
+
+module fanout_child_b (
+    input logic clk
+);
+endmodule
+
+module fanout_top (
+    input logic clk
+);
+    fanout_child_a u_child_a (
+        .clk(clk)
+    );
+    fanout_child_b u_child_b (
+        .clk(clk)
+    );
+endmodule

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -36,6 +36,7 @@ run_json module-hierarchy-cycle-report hierarchy-cycles fixtures/organization/cy
 run_json module-unresolved-instance-report unresolved-instances fixtures/organization/unresolved_instances.sv --format json
 run_json module-root-candidate-report module-roots fixtures/organization/hierarchy_top.sv --format json
 run_json module-orphan-candidate-report module-orphans fixtures/organization/orphan_modules.sv --format json
+run_json module-fanout-report module-fanout fixtures/organization/fanout_hierarchy.sv --format json
 run_json module-duplicate-report module-duplicates fixtures/organization/duplicate_modules.sv --format json
 run_json module-summary-view module-summary fixtures/organization/hierarchy_top.sv --format json
 run_json module-refactor-candidate-list refactor-candidates fixtures/organization/hierarchy_top.sv --format json

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -356,6 +356,24 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    module_fanout_cmd = sub.add_parser(
+        "module-fanout",
+        help=(
+            "Render scanner-based read-only module fanout report data."
+        ),
+    )
+    module_fanout_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    module_fanout_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     module_health_cmd = sub.add_parser(
         "module-health",
         help=(
@@ -1403,6 +1421,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_depth_report_text(report))
+        return 0
+
+    if args.command == "module-fanout":
+        from .module_organization import (
+            build_module_fanout_report,
+            format_module_fanout_report_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        report = build_module_fanout_report(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(report, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_fanout_report_text(report))
         return 0
 
     if args.command == "module-health":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -196,6 +196,17 @@ MODULE_DEPTH_REPORT_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+MODULE_FANOUT_REPORT_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based module fanout report only",
+    "uses resolved direct dependency edges from the organization scanner",
+    "single-line instantiation candidates only",
+    "unresolved instantiation candidates block fanout review readiness",
+    "no semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
+    "does not apply refactors, write files, generate patches, or run validation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 MODULE_GRAPH_HEALTH_LIMITATIONS: tuple[str, ...] = (
     "scanner-based module graph health summary only",
     "combines root, leaf, depth, cycle, unresolved-instance, and duplicate-name signals",
@@ -622,6 +633,28 @@ def _module_depth_report_safety_flags() -> dict[str, bool]:
     return {
         "read_only": True,
         "depth_report_only": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _module_fanout_report_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "fanout_report_only": True,
         "emits_command_descriptors": False,
         "writes_files": False,
         "moves_files": False,
@@ -2416,6 +2449,154 @@ def build_module_depth_report(source: str, path: Path) -> dict[str, Any]:
         "tool": "pccx-ide-cli",
         "unplaced_module_count": len(unplaced_names),
         "unplaced_module_names": unplaced_names,
+        "unresolved_edge_count": len(hierarchy["edges"]) - resolved_edge_count,
+        "writes_files": False,
+    }
+
+
+def _module_fanout_rows(
+    modules: list[dict[str, Any]],
+    hierarchy: dict[str, Any],
+) -> list[dict[str, Any]]:
+    modules_by_name: dict[str, dict[str, Any]] = {}
+    declaration_counts: dict[str, int] = {}
+    for module in modules:
+        modules_by_name.setdefault(module["name"], module)
+        declaration_counts[module["name"]] = (
+            declaration_counts.get(module["name"], 0) + 1
+        )
+
+    module_names = sorted(modules_by_name)
+    dependencies_by_module: dict[str, set[str]] = {
+        name: set()
+        for name in module_names
+    }
+    dependents_by_module: dict[str, set[str]] = {
+        name: set()
+        for name in module_names
+    }
+    unresolved_by_module: dict[str, set[str]] = {
+        name: set()
+        for name in module_names
+    }
+
+    for edge in hierarchy["edges"]:
+        parent = edge["parent"]
+        child = edge["child"]
+        if parent not in modules_by_name:
+            continue
+        if edge["resolved"]:
+            dependencies_by_module.setdefault(parent, set()).add(child)
+            if child in dependents_by_module:
+                dependents_by_module[child].add(parent)
+        else:
+            unresolved_by_module.setdefault(parent, set()).add(child)
+
+    rows: list[dict[str, Any]] = []
+    for module_name in module_names:
+        module = modules_by_name[module_name]
+        direct_dependencies = sorted(dependencies_by_module.get(module_name, set()))
+        direct_dependents = sorted(dependents_by_module.get(module_name, set()))
+        unresolved_dependencies = sorted(unresolved_by_module.get(module_name, set()))
+        blocked_reasons: list[str] = []
+        if not module["complete"]:
+            blocked_reasons.append(f"module boundary is incomplete: {module_name}")
+        if declaration_counts[module_name] > 1:
+            blocked_reasons.append(f"ambiguous module name: {module_name}")
+        if unresolved_dependencies:
+            blocked_reasons.append(
+                "unresolved dependencies for fanout report: "
+                f"{', '.join(unresolved_dependencies)}"
+            )
+        rows.append({
+            "blocked_reasons": blocked_reasons,
+            "complete": module["complete"],
+            "declaration_count": declaration_counts[module_name],
+            "direct_dependencies": direct_dependencies,
+            "direct_dependency_count": len(direct_dependencies),
+            "direct_dependents": direct_dependents,
+            "direct_dependent_count": len(direct_dependents),
+            "fanout_state": (
+                "has-resolved-fanout"
+                if direct_dependencies
+                else "no-resolved-fanout"
+            ),
+            "file": module["file"],
+            "name": module_name,
+            "reason": "ranked by scanner-detected resolved direct dependencies",
+            "refactor_preflight_state": (
+                "blocked" if blocked_reasons else "ready-for-review"
+            ),
+            "start_column": module["start_column"],
+            "start_line": module["start_line"],
+            "unresolved_dependencies": unresolved_dependencies,
+            "unresolved_dependency_count": len(unresolved_dependencies),
+        })
+
+    rows.sort(
+        key=lambda row: (
+            -row["direct_dependency_count"],
+            -row["unresolved_dependency_count"],
+            row["name"],
+        )
+    )
+    for index, row in enumerate(rows, 1):
+        row["rank"] = index
+    return rows
+
+
+def build_module_fanout_report(source: str, path: Path) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    hierarchy = organization["hierarchy"]
+    resolved_edge_count = len([
+        edge
+        for edge in hierarchy["edges"]
+        if edge["resolved"]
+    ])
+    rows = _module_fanout_rows(modules, hierarchy)
+    fanout_rows = [
+        row
+        for row in rows
+        if row["direct_dependency_count"] > 0
+    ]
+    blocked_reasons = list(dict.fromkeys([
+        reason
+        for row in rows
+        for reason in row["blocked_reasons"]
+    ]))
+    if modules and not fanout_rows:
+        blocked_reasons.append("no resolved fanout detected")
+    if not modules:
+        blocked_reasons.append("no module declarations detected")
+
+    return {
+        "blocked_reasons": blocked_reasons,
+        "edge_count": len(hierarchy["edges"]),
+        "fanout_count": len(fanout_rows),
+        "fanout_names": [
+            row["name"]
+            for row in fanout_rows
+        ],
+        "kind": "module-fanout-report",
+        "limitations": list(MODULE_FANOUT_REPORT_LIMITATIONS),
+        "max_direct_dependency_count": max(
+            (row["direct_dependency_count"] for row in rows),
+            default=0,
+        ),
+        "module_count": len(modules),
+        "modules": rows,
+        "next_required_action": (
+            "review scanner-detected fanout before refactor planning"
+            if fanout_rows
+            else "continue module organization review"
+        ),
+        "report_state": "fanout-detected" if fanout_rows else "no-fanout-detected",
+        "resolved_edge_count": resolved_edge_count,
+        "safety": _module_fanout_report_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "tool": "pccx-ide-cli",
         "unresolved_edge_count": len(hierarchy["edges"]) - resolved_edge_count,
         "writes_files": False,
     }
@@ -5223,6 +5404,43 @@ def format_module_depth_report_text(report: dict[str, Any]) -> str:
     lines.append(f"next: {report['next_required_action']}")
     lines.append(
         "read-only depth report: no command argv, validation, shell, "
+        "refactor, patch, file write, lab, launcher, vendor tool, provider, "
+        "or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_module_fanout_report_text(report: dict[str, Any]) -> str:
+    lines = [
+        f"source: {report['source']}",
+        f"module fanout: {report['report_state']}",
+        f"{report['module_count']} module"
+        f"{'s' if report['module_count'] != 1 else ''}",
+        f"{report['fanout_count']} fanout module"
+        f"{'s' if report['fanout_count'] != 1 else ''}",
+        f"max direct dependencies: {report['max_direct_dependency_count']}",
+    ]
+    if not report["modules"]:
+        lines.append("modules: none")
+    for module in report["modules"]:
+        dependencies = ", ".join(module["direct_dependencies"]) or "none"
+        dependents = ", ".join(module["direct_dependents"]) or "none"
+        unresolved = ", ".join(module["unresolved_dependencies"]) or "none"
+        lines.append(
+            f"rank {module['rank']}: {module['file']}:{module['start_line']}: "
+            f"module {module['name']} ({module['refactor_preflight_state']})"
+        )
+        lines.append(
+            f"  dependencies={dependencies}; dependents={dependents}; "
+            f"unresolved={unresolved}; reason={module['reason']}"
+        )
+        for reason in module["blocked_reasons"]:
+            lines.append(f"  blocked: {reason}")
+    for reason in report["blocked_reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"next: {report['next_required_action']}")
+    lines.append(
+        "read-only fanout report: no command argv, validation, shell, "
         "refactor, patch, file write, lab, launcher, vendor tool, provider, "
         "or hardware execution"
     )

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -16,6 +16,7 @@ CYCLIC_FIXTURE = REPO_ROOT / "fixtures" / "organization" / "cyclic_hierarchy.sv"
 DUPLICATE_FIXTURE = REPO_ROOT / "fixtures" / "organization" / "duplicate_modules.sv"
 UNRESOLVED_FIXTURE = REPO_ROOT / "fixtures" / "organization" / "unresolved_instances.sv"
 ORPHAN_FIXTURE = REPO_ROOT / "fixtures" / "organization" / "orphan_modules.sv"
+FANOUT_FIXTURE = REPO_ROOT / "fixtures" / "organization" / "fanout_hierarchy.sv"
 INCOMPLETE_FIXTURE = REPO_ROOT / "fixtures" / "missing_endmodule.sv"
 CONTRACT_DOC = REPO_ROOT / "docs" / "EDITOR_BRIDGE_CONTRACT.md"
 WORKFLOW_DOC = REPO_ROOT / "docs" / "MODULE_ORGANIZATION_WORKFLOW.md"
@@ -28,6 +29,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_context_bundle,
     build_module_depth_report,
     build_module_duplicate_report,
+    build_module_fanout_report,
     build_module_graph_health_summary,
     build_module_hierarchy_cycle_report,
     build_module_hierarchy_view,
@@ -61,6 +63,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_module_context_text,
     format_module_depth_report_text,
     format_module_duplicate_report_text,
+    format_module_fanout_report_text,
     format_module_graph_health_summary_text,
     format_module_hierarchy_cycle_text,
     format_module_hierarchy_text,
@@ -863,6 +866,94 @@ def test_build_module_depth_report_blocks_unresolved_dependencies():
     assert module["blocked_reasons"] == [
         "unresolved dependencies for depth report: missing_child"
     ]
+
+
+def test_build_module_fanout_report_ranks_direct_dependencies():
+    report = build_module_fanout_report(str(FANOUT_FIXTURE), FANOUT_FIXTURE)
+
+    assert report["kind"] == "module-fanout-report"
+    assert report["report_state"] == "fanout-detected"
+    assert report["module_count"] == 4
+    assert report["edge_count"] == 3
+    assert report["resolved_edge_count"] == 3
+    assert report["unresolved_edge_count"] == 0
+    assert report["fanout_count"] == 2
+    assert report["fanout_names"] == ["fanout_top", "fanout_child_a"]
+    assert report["max_direct_dependency_count"] == 2
+    assert report["blocked_reasons"] == []
+    assert report["next_required_action"] == (
+        "review scanner-detected fanout before refactor planning"
+    )
+    modules = {module["name"]: module for module in report["modules"]}
+    assert list(modules) == [
+        "fanout_top",
+        "fanout_child_a",
+        "fanout_child_b",
+        "fanout_leaf",
+    ]
+    top = modules["fanout_top"]
+    assert top["rank"] == 1
+    assert top["direct_dependencies"] == ["fanout_child_a", "fanout_child_b"]
+    assert top["direct_dependency_count"] == 2
+    assert top["direct_dependents"] == []
+    assert top["unresolved_dependencies"] == []
+    assert top["fanout_state"] == "has-resolved-fanout"
+    assert top["refactor_preflight_state"] == "ready-for-review"
+    child_a = modules["fanout_child_a"]
+    assert child_a["rank"] == 2
+    assert child_a["direct_dependencies"] == ["fanout_leaf"]
+    assert child_a["direct_dependents"] == ["fanout_top"]
+    assert child_a["fanout_state"] == "has-resolved-fanout"
+    leaf = modules["fanout_leaf"]
+    assert leaf["fanout_state"] == "no-resolved-fanout"
+    assert report["safety"]["read_only"] is True
+    assert report["safety"]["fanout_report_only"] is True
+    assert report["safety"]["emits_command_descriptors"] is False
+    assert report["safety"]["writes_files"] is False
+    assert report["safety"]["applies_refactor"] is False
+    assert report["safety"]["generates_patch"] is False
+    assert report["safety"]["runs_validation"] is False
+    assert report["safety"]["runs_shell"] is False
+    assert report["safety"]["invokes_pccx_lab"] is False
+    assert report["safety"]["invokes_launcher"] is False
+    assert report["safety"]["invokes_vendor_tools"] is False
+    assert report["safety"]["provider_calls"] is False
+    assert report["safety"]["hardware_access"] is False
+    assert report["writes_files"] is False
+    assert '"argv"' not in json.dumps(report)
+
+
+def test_build_module_fanout_report_blocks_unresolved_dependencies():
+    report = build_module_fanout_report(
+        str(UNRESOLVED_FIXTURE),
+        UNRESOLVED_FIXTURE,
+    )
+
+    assert report["report_state"] == "no-fanout-detected"
+    assert report["fanout_count"] == 0
+    assert report["fanout_names"] == []
+    assert report["blocked_reasons"] == [
+        "unresolved dependencies for fanout report: missing_child",
+        "no resolved fanout detected",
+    ]
+    module = report["modules"][0]
+    assert module["name"] == "unresolved_top"
+    assert module["refactor_preflight_state"] == "blocked"
+    assert module["unresolved_dependencies"] == ["missing_child"]
+    assert module["blocked_reasons"] == [
+        "unresolved dependencies for fanout report: missing_child"
+    ]
+
+
+def test_build_module_fanout_report_blocks_when_no_modules_detected():
+    empty_fixture = REPO_ROOT / "fixtures" / "empty.sv"
+    report = build_module_fanout_report(str(empty_fixture), empty_fixture)
+
+    assert report["report_state"] == "no-fanout-detected"
+    assert report["fanout_count"] == 0
+    assert report["modules"] == []
+    assert report["blocked_reasons"] == ["no module declarations detected"]
+    assert report["next_required_action"] == "continue module organization review"
 
 
 def test_build_module_graph_health_summary_combines_graph_signals():
@@ -2474,6 +2565,35 @@ def test_cli_module_depths_text():
     assert "read-only depth report: no command argv" in result.stdout
 
 
+def test_cli_module_fanout_json():
+    result = _run_cli("module-fanout", str(FANOUT_FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-fanout-report"
+    assert payload["report_state"] == "fanout-detected"
+    assert payload["fanout_names"] == ["fanout_top", "fanout_child_a"]
+    assert payload["max_direct_dependency_count"] == 2
+    assert payload["modules"][0]["name"] == "fanout_top"
+    assert payload["modules"][0]["direct_dependencies"] == [
+        "fanout_child_a",
+        "fanout_child_b",
+    ]
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["emits_command_descriptors"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_module_fanout_text():
+    result = _run_cli("module-fanout", str(FANOUT_FIXTURE), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "module fanout: fanout-detected" in result.stdout
+    assert "rank 1:" in result.stdout
+    assert "module fanout_top (ready-for-review)" in result.stdout
+    assert "dependencies=fanout_child_a, fanout_child_b" in result.stdout
+    assert "read-only fanout report: no command argv" in result.stdout
+
+
 def test_cli_module_health_json():
     result = _run_cli("module-health", str(FIXTURE), "--format", "json")
     assert result.returncode == 0, result.stderr
@@ -3115,6 +3235,12 @@ def test_cli_module_orphans_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_module_fanout_missing_path_exits_nonzero():
+    result = _run_cli("module-fanout", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_cli_module_summary_missing_path_exits_nonzero():
     result = _run_cli("module-summary", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
@@ -3289,6 +3415,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-leaves <path>" in contract
     assert "module-orphans <path>" in contract
     assert "module-depths <path>" in contract
+    assert "module-fanout <path>" in contract
     assert "module-health <path>" in contract
     assert "module-summary <path>" in contract
     assert "port-usage <path>" in contract
@@ -3315,6 +3442,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-leaf-candidate-report" in workflow
     assert "module-orphan-candidate-report" in workflow
     assert "module-depth-report" in workflow
+    assert "module-fanout-report" in workflow
     assert "module-graph-health-summary" in workflow
     assert "module-summary-view" in workflow
     assert "module-port-usage-view" in workflow


### PR DESCRIPTION
## Summary
- add a read-only `module-fanout` CLI report for scanner-detected direct dependency fanout
- add a synthetic fanout fixture, focused JSON/text tests, smoke coverage, and docs
- keep the report data-only with explicit no-write/no-execution safety flags

Refs #8.

## Validation
- `PYTHONPATH=src python3 -m pytest -q tests/test_module_organization.py`
- `PYTHONPATH=src python3 -m pytest -q`
- `PYTHONPATH=src python3 -m pccx_ide_cli module-fanout fixtures/organization/fanout_hierarchy.sv --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli module-fanout fixtures/organization/fanout_hierarchy.sv --format text`
- `python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `python3 scripts/check-source-headers.py`
- `find scripts -type f -name '*.sh' -exec bash -n {} +`
- local forbidden-claim scan matching CI pattern
- `git diff --check`
- `git diff --cached --check`

## Boundary
This is scanner-derived report data only. It does not emit command argv, run validation, execute shell commands, apply refactors, generate patches, write files, invoke pccx-lab or the launcher, call providers, run vendor tools, access hardware, claim LSP support, claim marketplace readiness, or claim stable API/ABI.