### PR TITLE
Add module fanin report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,13 @@ jobs:
               fixtures/organization/fanout_hierarchy.sv \
               | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-fanout-report'; assert d['safety']['writes_files'] is False; assert d['safety']['emits_command_descriptors'] is False"
           echo "module fanout smoke ok"
+      - name: cli smoke (module fanin exits zero)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli module-fanin \
+              fixtures/organization/fanout_hierarchy.sv \
+              | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-fanin-report'; assert d['safety']['writes_files'] is False; assert d['safety']['emits_command_descriptors'] is False"
+          echo "module fanin smoke ok"
       - name: cli smoke (module summary exits zero)
         run: |
           set -e

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ python -m pccx_ide_cli module-leaves fixtures/organization/hierarchy_top.sv --fo
 python -m pccx_ide_cli module-orphans fixtures/organization/orphan_modules.sv --format json
 python -m pccx_ide_cli module-depths fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli module-fanout fixtures/organization/fanout_hierarchy.sv --format json
+python -m pccx_ide_cli module-fanin fixtures/organization/fanout_hierarchy.sv --format json
 python -m pccx_ide_cli module-health fixtures/organization/hierarchy_top.sv --format json
 
 # Module header/port summary view (pre-stable, read-only)
@@ -237,6 +238,8 @@ resolved dependencies or dependents.
 for module organization review.
 `module-fanout` ranks scanner-detected modules by resolved direct dependency
 count for fanout review.
+`module-fanin` ranks scanner-detected modules by resolved direct dependent
+count for fanin review.
 `module-health` combines scanner-detected root, leaf, depth, cycle,
 unresolved-instance, and duplicate-name signals into a read-only module graph
 health summary for editor status panes.

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -57,6 +57,7 @@ python -m pccx_ide_cli module-leaves <path> --format json
 python -m pccx_ide_cli module-orphans <path> --format json
 python -m pccx_ide_cli module-depths <path> --format json
 python -m pccx_ide_cli module-fanout <path> --format json
+python -m pccx_ide_cli module-fanin <path> --format json
 python -m pccx_ide_cli module-health <path> --format json
 python -m pccx_ide_cli module-summary <path> --format json
 python -m pccx_ide_cli port-usage <path> --module <name> --format json
@@ -217,13 +218,14 @@ invoke pccx-lab or the launcher, run vendor tools, call providers, touch
 hardware, or perform automatic repository actions. `hierarchy`,
 `dependencies`, `hierarchy-cycles`, `unresolved-instances`, `module-roots`,
 `module-leaves`, `module-orphans`, `module-depths`, `module-fanout`,
+`module-fanin`,
 `module-health`,
 `module-summary`, `port-usage`, `module-context`, and `refactor-impact`
 render focused read-only views from the same scanner data, including
 hierarchy cycle warnings, unresolved instantiation warnings, root-candidate
 summaries, leaf-candidate summaries, orphan-candidate summaries,
 depth-level summaries,
-fanout rankings,
+fanout rankings, fanin rankings,
 module graph health summaries,
 conservative module header/port summaries, target port usage summaries,
 target module context bundles, and

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -5,7 +5,8 @@
 This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
 `hierarchy-cycles`, `unresolved-instances`, `module-roots`, `module-leaves`,
-`module-orphans`, `module-depths`, `module-fanout`, `module-health`,
+`module-orphans`, `module-depths`, `module-fanout`, `module-fanin`,
+`module-health`,
 `module-summary`,
 `boundary-audit`, `module-duplicates`, `refactor-candidates`, `port-usage`,
 `module-context`, `refactor-impact`,
@@ -17,7 +18,7 @@ scanner-based hierarchy data, direct dependency impact data, hierarchy cycle
 report metadata, unresolved instantiation report metadata, root-candidate
 report metadata, leaf-candidate report metadata, orphan-candidate report
 metadata, depth-level report metadata,
-`module-fanout-report` metadata,
+`module-fanout-report` metadata, `module-fanin-report` metadata,
 module graph health summary metadata,
 conservative module header/port summaries, duplicate-name report metadata,
 target port usage summaries, target module context bundles, target-specific
@@ -54,6 +55,8 @@ python -m pccx_ide_cli module-depths <path> --format json
 python -m pccx_ide_cli module-depths <path> --format text
 python -m pccx_ide_cli module-fanout <path> --format json
 python -m pccx_ide_cli module-fanout <path> --format text
+python -m pccx_ide_cli module-fanin <path> --format json
+python -m pccx_ide_cli module-fanin <path> --format text
 python -m pccx_ide_cli module-health <path> --format json
 python -m pccx_ide_cli module-health <path> --format text
 python -m pccx_ide_cli module-summary <path> --format json
@@ -404,6 +407,43 @@ root candidates:
 ```
 
 The depth report is display data only. It does not write files, apply
+refactors, generate patches, run validation, execute shell commands, emit
+command argv, invoke `pccx-lab`, invoke the launcher, call providers, touch
+hardware, upload telemetry, or perform automatic repository actions.
+
+The fanin report ranks modules by scanner-detected resolved direct dependents:
+
+```json
+{
+  "kind": "module-fanin-report",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "report_state": "fanin-detected",
+  "fanin_count": 3,
+  "max_direct_dependent_count": 1,
+  "fanin_names": ["fanout_child_a", "fanout_child_b", "fanout_leaf"],
+  "modules": [
+    {
+      "name": "fanout_child_a",
+      "rank": 1,
+      "direct_dependents": ["fanout_top"],
+      "direct_dependent_count": 1,
+      "fanin_state": "has-resolved-fanin"
+    }
+  ],
+  "safety": {
+    "read_only": true,
+    "fanin_report_only": true,
+    "writes_files": false,
+    "emits_command_descriptors": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The fanin report is display data only. It does not write files, apply
 refactors, generate patches, run validation, execute shell commands, emit
 command argv, invoke `pccx-lab`, invoke the launcher, call providers, touch
 hardware, upload telemetry, or perform automatic repository actions.

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -37,6 +37,7 @@ run_json module-unresolved-instance-report unresolved-instances fixtures/organiz
 run_json module-root-candidate-report module-roots fixtures/organization/hierarchy_top.sv --format json
 run_json module-orphan-candidate-report module-orphans fixtures/organization/orphan_modules.sv --format json
 run_json module-fanout-report module-fanout fixtures/organization/fanout_hierarchy.sv --format json
+run_json module-fanin-report module-fanin fixtures/organization/fanout_hierarchy.sv --format json
 run_json module-duplicate-report module-duplicates fixtures/organization/duplicate_modules.sv --format json
 run_json module-summary-view module-summary fixtures/organization/hierarchy_top.sv --format json
 run_json module-refactor-candidate-list refactor-candidates fixtures/organization/hierarchy_top.sv --format json

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -374,6 +374,24 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    module_fanin_cmd = sub.add_parser(
+        "module-fanin",
+        help=(
+            "Render scanner-based read-only module fanin report data."
+        ),
+    )
+    module_fanin_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    module_fanin_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     module_health_cmd = sub.add_parser(
         "module-health",
         help=(
@@ -1439,6 +1457,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_fanout_report_text(report))
+        return 0
+
+    if args.command == "module-fanin":
+        from .module_organization import (
+            build_module_fanin_report,
+            format_module_fanin_report_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        report = build_module_fanin_report(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(report, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_fanin_report_text(report))
         return 0
 
     if args.command == "module-health":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -207,6 +207,17 @@ MODULE_FANOUT_REPORT_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+MODULE_FANIN_REPORT_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based module fanin report only",
+    "uses resolved direct dependent edges from the organization scanner",
+    "single-line instantiation candidates only",
+    "unresolved instantiation candidates block fanin review readiness",
+    "no semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
+    "does not apply refactors, write files, generate patches, or run validation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 MODULE_GRAPH_HEALTH_LIMITATIONS: tuple[str, ...] = (
     "scanner-based module graph health summary only",
     "combines root, leaf, depth, cycle, unresolved-instance, and duplicate-name signals",
@@ -655,6 +666,28 @@ def _module_fanout_report_safety_flags() -> dict[str, bool]:
     return {
         "read_only": True,
         "fanout_report_only": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _module_fanin_report_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "fanin_report_only": True,
         "emits_command_descriptors": False,
         "writes_files": False,
         "moves_files": False,
@@ -2594,6 +2627,154 @@ def build_module_fanout_report(source: str, path: Path) -> dict[str, Any]:
         "report_state": "fanout-detected" if fanout_rows else "no-fanout-detected",
         "resolved_edge_count": resolved_edge_count,
         "safety": _module_fanout_report_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "tool": "pccx-ide-cli",
+        "unresolved_edge_count": len(hierarchy["edges"]) - resolved_edge_count,
+        "writes_files": False,
+    }
+
+
+def _module_fanin_rows(
+    modules: list[dict[str, Any]],
+    hierarchy: dict[str, Any],
+) -> list[dict[str, Any]]:
+    modules_by_name: dict[str, dict[str, Any]] = {}
+    declaration_counts: dict[str, int] = {}
+    for module in modules:
+        modules_by_name.setdefault(module["name"], module)
+        declaration_counts[module["name"]] = (
+            declaration_counts.get(module["name"], 0) + 1
+        )
+
+    module_names = sorted(modules_by_name)
+    dependencies_by_module: dict[str, set[str]] = {
+        name: set()
+        for name in module_names
+    }
+    dependents_by_module: dict[str, set[str]] = {
+        name: set()
+        for name in module_names
+    }
+    unresolved_by_module: dict[str, set[str]] = {
+        name: set()
+        for name in module_names
+    }
+
+    for edge in hierarchy["edges"]:
+        parent = edge["parent"]
+        child = edge["child"]
+        if parent not in modules_by_name:
+            continue
+        if edge["resolved"]:
+            dependencies_by_module.setdefault(parent, set()).add(child)
+            if child in dependents_by_module:
+                dependents_by_module[child].add(parent)
+        else:
+            unresolved_by_module.setdefault(parent, set()).add(child)
+
+    rows: list[dict[str, Any]] = []
+    for module_name in module_names:
+        module = modules_by_name[module_name]
+        direct_dependencies = sorted(dependencies_by_module.get(module_name, set()))
+        direct_dependents = sorted(dependents_by_module.get(module_name, set()))
+        unresolved_dependencies = sorted(unresolved_by_module.get(module_name, set()))
+        blocked_reasons: list[str] = []
+        if not module["complete"]:
+            blocked_reasons.append(f"module boundary is incomplete: {module_name}")
+        if declaration_counts[module_name] > 1:
+            blocked_reasons.append(f"ambiguous module name: {module_name}")
+        if unresolved_dependencies:
+            blocked_reasons.append(
+                "unresolved dependencies for fanin report: "
+                f"{', '.join(unresolved_dependencies)}"
+            )
+        rows.append({
+            "blocked_reasons": blocked_reasons,
+            "complete": module["complete"],
+            "declaration_count": declaration_counts[module_name],
+            "direct_dependencies": direct_dependencies,
+            "direct_dependency_count": len(direct_dependencies),
+            "direct_dependents": direct_dependents,
+            "direct_dependent_count": len(direct_dependents),
+            "fanin_state": (
+                "has-resolved-fanin"
+                if direct_dependents
+                else "no-resolved-fanin"
+            ),
+            "file": module["file"],
+            "name": module_name,
+            "reason": "ranked by scanner-detected resolved direct dependents",
+            "refactor_preflight_state": (
+                "blocked" if blocked_reasons else "ready-for-review"
+            ),
+            "start_column": module["start_column"],
+            "start_line": module["start_line"],
+            "unresolved_dependencies": unresolved_dependencies,
+            "unresolved_dependency_count": len(unresolved_dependencies),
+        })
+
+    rows.sort(
+        key=lambda row: (
+            -row["direct_dependent_count"],
+            -row["unresolved_dependency_count"],
+            row["name"],
+        )
+    )
+    for index, row in enumerate(rows, 1):
+        row["rank"] = index
+    return rows
+
+
+def build_module_fanin_report(source: str, path: Path) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    hierarchy = organization["hierarchy"]
+    resolved_edge_count = len([
+        edge
+        for edge in hierarchy["edges"]
+        if edge["resolved"]
+    ])
+    rows = _module_fanin_rows(modules, hierarchy)
+    fanin_rows = [
+        row
+        for row in rows
+        if row["direct_dependent_count"] > 0
+    ]
+    blocked_reasons = list(dict.fromkeys([
+        reason
+        for row in rows
+        for reason in row["blocked_reasons"]
+    ]))
+    if modules and not fanin_rows:
+        blocked_reasons.append("no resolved fanin detected")
+    if not modules:
+        blocked_reasons.append("no module declarations detected")
+
+    return {
+        "blocked_reasons": blocked_reasons,
+        "edge_count": len(hierarchy["edges"]),
+        "fanin_count": len(fanin_rows),
+        "fanin_names": [
+            row["name"]
+            for row in fanin_rows
+        ],
+        "kind": "module-fanin-report",
+        "limitations": list(MODULE_FANIN_REPORT_LIMITATIONS),
+        "max_direct_dependent_count": max(
+            (row["direct_dependent_count"] for row in rows),
+            default=0,
+        ),
+        "module_count": len(modules),
+        "modules": rows,
+        "next_required_action": (
+            "review scanner-detected fanin before refactor planning"
+            if fanin_rows
+            else "continue module organization review"
+        ),
+        "report_state": "fanin-detected" if fanin_rows else "no-fanin-detected",
+        "resolved_edge_count": resolved_edge_count,
+        "safety": _module_fanin_report_safety_flags(),
         "scanner": "line-scanner",
         "source": source,
         "tool": "pccx-ide-cli",
@@ -5441,6 +5622,43 @@ def format_module_fanout_report_text(report: dict[str, Any]) -> str:
     lines.append(f"next: {report['next_required_action']}")
     lines.append(
         "read-only fanout report: no command argv, validation, shell, "
+        "refactor, patch, file write, lab, launcher, vendor tool, provider, "
+        "or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_module_fanin_report_text(report: dict[str, Any]) -> str:
+    lines = [
+        f"source: {report['source']}",
+        f"module fanin: {report['report_state']}",
+        f"{report['module_count']} module"
+        f"{'s' if report['module_count'] != 1 else ''}",
+        f"{report['fanin_count']} fanin module"
+        f"{'s' if report['fanin_count'] != 1 else ''}",
+        f"max direct dependents: {report['max_direct_dependent_count']}",
+    ]
+    if not report["modules"]:
+        lines.append("modules: none")
+    for module in report["modules"]:
+        dependencies = ", ".join(module["direct_dependencies"]) or "none"
+        dependents = ", ".join(module["direct_dependents"]) or "none"
+        unresolved = ", ".join(module["unresolved_dependencies"]) or "none"
+        lines.append(
+            f"rank {module['rank']}: {module['file']}:{module['start_line']}: "
+            f"module {module['name']} ({module['refactor_preflight_state']})"
+        )
+        lines.append(
+            f"  dependencies={dependencies}; dependents={dependents}; "
+            f"unresolved={unresolved}; reason={module['reason']}"
+        )
+        for reason in module["blocked_reasons"]:
+            lines.append(f"  blocked: {reason}")
+    for reason in report["blocked_reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"next: {report['next_required_action']}")
+    lines.append(
+        "read-only fanin report: no command argv, validation, shell, "
         "refactor, patch, file write, lab, launcher, vendor tool, provider, "
         "or hardware execution"
     )

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -29,6 +29,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_context_bundle,
     build_module_depth_report,
     build_module_duplicate_report,
+    build_module_fanin_report,
     build_module_fanout_report,
     build_module_graph_health_summary,
     build_module_hierarchy_cycle_report,
@@ -63,6 +64,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_module_context_text,
     format_module_depth_report_text,
     format_module_duplicate_report_text,
+    format_module_fanin_report_text,
     format_module_fanout_report_text,
     format_module_graph_health_summary_text,
     format_module_hierarchy_cycle_text,
@@ -951,6 +953,103 @@ def test_build_module_fanout_report_blocks_when_no_modules_detected():
 
     assert report["report_state"] == "no-fanout-detected"
     assert report["fanout_count"] == 0
+    assert report["modules"] == []
+    assert report["blocked_reasons"] == ["no module declarations detected"]
+    assert report["next_required_action"] == "continue module organization review"
+
+
+def test_build_module_fanin_report_ranks_direct_dependents():
+    report = build_module_fanin_report(str(FANOUT_FIXTURE), FANOUT_FIXTURE)
+
+    assert report["kind"] == "module-fanin-report"
+    assert report["report_state"] == "fanin-detected"
+    assert report["module_count"] == 4
+    assert report["edge_count"] == 3
+    assert report["resolved_edge_count"] == 3
+    assert report["unresolved_edge_count"] == 0
+    assert report["fanin_count"] == 3
+    assert report["fanin_names"] == [
+        "fanout_child_a",
+        "fanout_child_b",
+        "fanout_leaf",
+    ]
+    assert report["max_direct_dependent_count"] == 1
+    assert report["blocked_reasons"] == []
+    assert report["next_required_action"] == (
+        "review scanner-detected fanin before refactor planning"
+    )
+    modules = {module["name"]: module for module in report["modules"]}
+    assert list(modules) == [
+        "fanout_child_a",
+        "fanout_child_b",
+        "fanout_leaf",
+        "fanout_top",
+    ]
+    child_a = modules["fanout_child_a"]
+    assert child_a["rank"] == 1
+    assert child_a["direct_dependencies"] == ["fanout_leaf"]
+    assert child_a["direct_dependents"] == ["fanout_top"]
+    assert child_a["direct_dependent_count"] == 1
+    assert child_a["fanin_state"] == "has-resolved-fanin"
+    child_b = modules["fanout_child_b"]
+    assert child_b["rank"] == 2
+    assert child_b["direct_dependencies"] == []
+    assert child_b["direct_dependents"] == ["fanout_top"]
+    assert child_b["fanin_state"] == "has-resolved-fanin"
+    leaf = modules["fanout_leaf"]
+    assert leaf["rank"] == 3
+    assert leaf["direct_dependencies"] == []
+    assert leaf["direct_dependents"] == ["fanout_child_a"]
+    assert leaf["fanin_state"] == "has-resolved-fanin"
+    top = modules["fanout_top"]
+    assert top["rank"] == 4
+    assert top["direct_dependents"] == []
+    assert top["fanin_state"] == "no-resolved-fanin"
+    assert report["safety"]["read_only"] is True
+    assert report["safety"]["fanin_report_only"] is True
+    assert report["safety"]["emits_command_descriptors"] is False
+    assert report["safety"]["writes_files"] is False
+    assert report["safety"]["applies_refactor"] is False
+    assert report["safety"]["generates_patch"] is False
+    assert report["safety"]["runs_validation"] is False
+    assert report["safety"]["runs_shell"] is False
+    assert report["safety"]["invokes_pccx_lab"] is False
+    assert report["safety"]["invokes_launcher"] is False
+    assert report["safety"]["invokes_vendor_tools"] is False
+    assert report["safety"]["provider_calls"] is False
+    assert report["safety"]["hardware_access"] is False
+    assert report["writes_files"] is False
+    assert '"argv"' not in json.dumps(report)
+
+
+def test_build_module_fanin_report_blocks_unresolved_dependencies():
+    report = build_module_fanin_report(
+        str(UNRESOLVED_FIXTURE),
+        UNRESOLVED_FIXTURE,
+    )
+
+    assert report["report_state"] == "no-fanin-detected"
+    assert report["fanin_count"] == 0
+    assert report["fanin_names"] == []
+    assert report["blocked_reasons"] == [
+        "unresolved dependencies for fanin report: missing_child",
+        "no resolved fanin detected",
+    ]
+    module = report["modules"][0]
+    assert module["name"] == "unresolved_top"
+    assert module["refactor_preflight_state"] == "blocked"
+    assert module["unresolved_dependencies"] == ["missing_child"]
+    assert module["blocked_reasons"] == [
+        "unresolved dependencies for fanin report: missing_child"
+    ]
+
+
+def test_build_module_fanin_report_blocks_when_no_modules_detected():
+    empty_fixture = REPO_ROOT / "fixtures" / "empty.sv"
+    report = build_module_fanin_report(str(empty_fixture), empty_fixture)
+
+    assert report["report_state"] == "no-fanin-detected"
+    assert report["fanin_count"] == 0
     assert report["modules"] == []
     assert report["blocked_reasons"] == ["no module declarations detected"]
     assert report["next_required_action"] == "continue module organization review"
@@ -2032,6 +2131,19 @@ def test_format_module_depth_report_text_mentions_boundary():
     assert "read-only depth report: no command argv" in text
 
 
+def test_format_module_fanin_report_text_mentions_boundary():
+    report = build_module_fanin_report(str(FANOUT_FIXTURE), FANOUT_FIXTURE)
+    text = format_module_fanin_report_text(report)
+
+    assert "module fanin: fanin-detected" in text
+    assert "3 fanin modules" in text
+    assert "max direct dependents: 1" in text
+    assert "rank 1:" in text
+    assert "module fanout_child_a (ready-for-review)" in text
+    assert "dependencies=fanout_leaf; dependents=fanout_top" in text
+    assert "read-only fanin report: no command argv" in text
+
+
 def test_format_module_graph_health_summary_text_mentions_boundary():
     report = build_module_graph_health_summary(str(FIXTURE), FIXTURE)
     text = format_module_graph_health_summary_text(report)
@@ -2592,6 +2704,36 @@ def test_cli_module_fanout_text():
     assert "module fanout_top (ready-for-review)" in result.stdout
     assert "dependencies=fanout_child_a, fanout_child_b" in result.stdout
     assert "read-only fanout report: no command argv" in result.stdout
+
+
+def test_cli_module_fanin_json():
+    result = _run_cli("module-fanin", str(FANOUT_FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-fanin-report"
+    assert payload["report_state"] == "fanin-detected"
+    assert payload["fanin_names"] == [
+        "fanout_child_a",
+        "fanout_child_b",
+        "fanout_leaf",
+    ]
+    assert payload["max_direct_dependent_count"] == 1
+    assert payload["modules"][0]["name"] == "fanout_child_a"
+    assert payload["modules"][0]["direct_dependents"] == ["fanout_top"]
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["emits_command_descriptors"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_module_fanin_text():
+    result = _run_cli("module-fanin", str(FANOUT_FIXTURE), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "module fanin: fanin-detected" in result.stdout
+    assert "rank 1:" in result.stdout
+    assert "module fanout_child_a (ready-for-review)" in result.stdout
+    assert "dependents=fanout_top" in result.stdout
+    assert "read-only fanin report: no command argv" in result.stdout
 
 
 def test_cli_module_health_json():
@@ -3241,6 +3383,12 @@ def test_cli_module_fanout_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_module_fanin_missing_path_exits_nonzero():
+    result = _run_cli("module-fanin", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_cli_module_summary_missing_path_exits_nonzero():
     result = _run_cli("module-summary", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
@@ -3416,6 +3564,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-orphans <path>" in contract
     assert "module-depths <path>" in contract
     assert "module-fanout <path>" in contract
+    assert "module-fanin <path>" in contract
     assert "module-health <path>" in contract
     assert "module-summary <path>" in contract
     assert "port-usage <path>" in contract
@@ -3443,6 +3592,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-orphan-candidate-report" in workflow
     assert "module-depth-report" in workflow
     assert "module-fanout-report" in workflow
+    assert "module-fanin-report" in workflow
     assert "module-graph-health-summary" in workflow
     assert "module-summary-view" in workflow
     assert "module-port-usage-view" in workflow


### PR DESCRIPTION
## Summary
- add a read-only `module-fanin` CLI report for scanner-detected direct dependent ranking
- include JSON/text output, docs, editor bridge smoke coverage, and CI smoke coverage
- keep the report data-only with no command argv, refactor application, validation execution, launcher/lab calls, vendor-tool calls, provider calls, or hardware access

## Validation
- `PYTHONPATH=src python3 -m pytest -q tests/test_module_organization.py`
- `PYTHONPATH=src python3 -m pytest -q`
- `PYTHONPATH=src python3 -m pccx_ide_cli module-fanin fixtures/organization/fanout_hierarchy.sv --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli module-fanin fixtures/organization/fanout_hierarchy.sv --format text`
- `python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `python3 scripts/check-source-headers.py`
- `find scripts -type f -name '*.sh' -exec bash -n {} +`
- local forbidden-claim scan
- `git diff --check`
- `git diff --cached --check`

Refs #8