### PR TITLE
Add module path report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,13 @@ jobs:
               fixtures/organization/fanout_hierarchy.sv \
               | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-fanin-report'; assert d['safety']['writes_files'] is False; assert d['safety']['emits_command_descriptors'] is False"
           echo "module fanin smoke ok"
+      - name: cli smoke (module paths exits zero)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli module-paths \
+              fixtures/organization/fanout_hierarchy.sv \
+              | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-path-report'; assert d['safety']['writes_files'] is False; assert d['safety']['emits_command_descriptors'] is False"
+          echo "module paths smoke ok"
       - name: cli smoke (module summary exits zero)
         run: |
           set -e

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ python -m pccx_ide_cli module-roots fixtures/organization/hierarchy_top.sv --for
 python -m pccx_ide_cli module-leaves fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli module-orphans fixtures/organization/orphan_modules.sv --format json
 python -m pccx_ide_cli module-depths fixtures/organization/hierarchy_top.sv --format json
+python -m pccx_ide_cli module-paths fixtures/organization/fanout_hierarchy.sv --format json
 python -m pccx_ide_cli module-fanout fixtures/organization/fanout_hierarchy.sv --format json
 python -m pccx_ide_cli module-fanin fixtures/organization/fanout_hierarchy.sv --format json
 python -m pccx_ide_cli module-health fixtures/organization/hierarchy_top.sv --format json
@@ -236,6 +237,8 @@ organization review.
 resolved dependencies or dependents.
 `module-depths` groups scanner-detected hierarchy levels from root candidates
 for module organization review.
+`module-paths` enumerates scanner-detected root-to-leaf hierarchy paths and
+blocked unresolved path terminals for path review.
 `module-fanout` ranks scanner-detected modules by resolved direct dependency
 count for fanout review.
 `module-fanin` ranks scanner-detected modules by resolved direct dependent

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -56,6 +56,7 @@ python -m pccx_ide_cli module-roots <path> --format json
 python -m pccx_ide_cli module-leaves <path> --format json
 python -m pccx_ide_cli module-orphans <path> --format json
 python -m pccx_ide_cli module-depths <path> --format json
+python -m pccx_ide_cli module-paths <path> --format json
 python -m pccx_ide_cli module-fanout <path> --format json
 python -m pccx_ide_cli module-fanin <path> --format json
 python -m pccx_ide_cli module-health <path> --format json
@@ -217,15 +218,15 @@ surfaces do not write files, apply refactors, generate patches, run validation,
 invoke pccx-lab or the launcher, run vendor tools, call providers, touch
 hardware, or perform automatic repository actions. `hierarchy`,
 `dependencies`, `hierarchy-cycles`, `unresolved-instances`, `module-roots`,
-`module-leaves`, `module-orphans`, `module-depths`, `module-fanout`,
-`module-fanin`,
+`module-leaves`, `module-orphans`, `module-depths`, `module-paths`,
+`module-fanout`, `module-fanin`,
 `module-health`,
 `module-summary`, `port-usage`, `module-context`, and `refactor-impact`
 render focused read-only views from the same scanner data, including
 hierarchy cycle warnings, unresolved instantiation warnings, root-candidate
 summaries, leaf-candidate summaries, orphan-candidate summaries,
 depth-level summaries,
-fanout rankings, fanin rankings,
+hierarchy path reports, fanout rankings, fanin rankings,
 module graph health summaries,
 conservative module header/port summaries, target port usage summaries,
 target module context bundles, and

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -5,7 +5,7 @@
 This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
 `hierarchy-cycles`, `unresolved-instances`, `module-roots`, `module-leaves`,
-`module-orphans`, `module-depths`, `module-fanout`, `module-fanin`,
+`module-orphans`, `module-depths`, `module-paths`, `module-fanout`, `module-fanin`,
 `module-health`,
 `module-summary`,
 `boundary-audit`, `module-duplicates`, `refactor-candidates`, `port-usage`,
@@ -17,7 +17,7 @@ projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
 scanner-based hierarchy data, direct dependency impact data, hierarchy cycle
 report metadata, unresolved instantiation report metadata, root-candidate
 report metadata, leaf-candidate report metadata, orphan-candidate report
-metadata, depth-level report metadata,
+metadata, depth-level report metadata, hierarchy path report metadata,
 `module-fanout-report` metadata, `module-fanin-report` metadata,
 module graph health summary metadata,
 conservative module header/port summaries, duplicate-name report metadata,
@@ -53,6 +53,8 @@ python -m pccx_ide_cli module-orphans <path> --format json
 python -m pccx_ide_cli module-orphans <path> --format text
 python -m pccx_ide_cli module-depths <path> --format json
 python -m pccx_ide_cli module-depths <path> --format text
+python -m pccx_ide_cli module-paths <path> --format json
+python -m pccx_ide_cli module-paths <path> --format text
 python -m pccx_ide_cli module-fanout <path> --format json
 python -m pccx_ide_cli module-fanout <path> --format text
 python -m pccx_ide_cli module-fanin <path> --format json
@@ -410,6 +412,46 @@ The depth report is display data only. It does not write files, apply
 refactors, generate patches, run validation, execute shell commands, emit
 command argv, invoke `pccx-lab`, invoke the launcher, call providers, touch
 hardware, upload telemetry, or perform automatic repository actions.
+
+The hierarchy path report enumerates scanner-detected root-to-leaf paths and
+blocked unresolved path terminals:
+
+```json
+{
+  "kind": "module-path-report",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "report_state": "paths-detected",
+  "path_count": 2,
+  "complete_path_count": 2,
+  "blocked_path_count": 0,
+  "root_names": ["fanout_top"],
+  "leaf_names": ["fanout_child_b", "fanout_leaf"],
+  "paths": [
+    {
+      "path_id": "path-1",
+      "module_path": ["fanout_top", "fanout_child_a", "fanout_leaf"],
+      "instance_path": ["u_child_a", "u_leaf"],
+      "path_state": "complete-root-to-leaf",
+      "refactor_preflight_state": "ready-for-review"
+    }
+  ],
+  "safety": {
+    "read_only": true,
+    "path_report_only": true,
+    "writes_files": false,
+    "emits_command_descriptors": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The hierarchy path report is display data only. It does not write files,
+apply refactors, generate patches, run validation, execute shell commands,
+emit command argv, invoke `pccx-lab`, invoke the launcher, call providers,
+touch hardware, upload telemetry, or perform automatic repository actions.
 
 The fanin report ranks modules by scanner-detected resolved direct dependents:
 

--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -36,6 +36,7 @@ run_json module-hierarchy-cycle-report hierarchy-cycles fixtures/organization/cy
 run_json module-unresolved-instance-report unresolved-instances fixtures/organization/unresolved_instances.sv --format json
 run_json module-root-candidate-report module-roots fixtures/organization/hierarchy_top.sv --format json
 run_json module-orphan-candidate-report module-orphans fixtures/organization/orphan_modules.sv --format json
+run_json module-path-report module-paths fixtures/organization/fanout_hierarchy.sv --format json
 run_json module-fanout-report module-fanout fixtures/organization/fanout_hierarchy.sv --format json
 run_json module-fanin-report module-fanin fixtures/organization/fanout_hierarchy.sv --format json
 run_json module-duplicate-report module-duplicates fixtures/organization/duplicate_modules.sv --format json

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -356,6 +356,24 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    module_paths_cmd = sub.add_parser(
+        "module-paths",
+        help=(
+            "Render scanner-based read-only module hierarchy path report data."
+        ),
+    )
+    module_paths_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    module_paths_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     module_fanout_cmd = sub.add_parser(
         "module-fanout",
         help=(
@@ -1439,6 +1457,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_depth_report_text(report))
+        return 0
+
+    if args.command == "module-paths":
+        from .module_organization import (
+            build_module_path_report,
+            format_module_path_report_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        report = build_module_path_report(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(report, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_path_report_text(report))
         return 0
 
     if args.command == "module-fanout":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -196,6 +196,18 @@ MODULE_DEPTH_REPORT_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+MODULE_PATH_REPORT_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based module hierarchy path report only",
+    "uses root candidates and resolved dependency edges from the organization scanner",
+    "single-line instantiation candidates only",
+    "unresolved instantiation candidates are reported as blocked path terminals",
+    "cycles or missing root candidates can block path review",
+    "no semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
+    "does not apply refactors, write files, generate patches, or run validation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 MODULE_FANOUT_REPORT_LIMITATIONS: tuple[str, ...] = (
     "scanner-based module fanout report only",
     "uses resolved direct dependency edges from the organization scanner",
@@ -644,6 +656,28 @@ def _module_depth_report_safety_flags() -> dict[str, bool]:
     return {
         "read_only": True,
         "depth_report_only": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _module_path_report_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "path_report_only": True,
         "emits_command_descriptors": False,
         "writes_files": False,
         "moves_files": False,
@@ -2482,6 +2516,263 @@ def build_module_depth_report(source: str, path: Path) -> dict[str, Any]:
         "tool": "pccx-ide-cli",
         "unplaced_module_count": len(unplaced_names),
         "unplaced_module_names": unplaced_names,
+        "unresolved_edge_count": len(hierarchy["edges"]) - resolved_edge_count,
+        "writes_files": False,
+    }
+
+
+def _module_path_edge_summary(edge: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "child": edge["child"],
+        "column": edge["column"],
+        "file": edge["file"],
+        "instance": edge["instance"],
+        "line": edge["line"],
+        "parent": edge["parent"],
+        "resolved": edge["resolved"],
+    }
+
+
+def _module_path_boundary_blockers(
+    module_names: list[str],
+    modules_by_name: dict[str, dict[str, Any]],
+    declaration_counts: dict[str, int],
+) -> list[str]:
+    reasons: list[str] = []
+    for module_name in module_names:
+        module = modules_by_name.get(module_name)
+        if module is None:
+            continue
+        if not module["complete"]:
+            reasons.append(f"module boundary is incomplete: {module_name}")
+        if declaration_counts[module_name] > 1:
+            reasons.append(f"ambiguous module name: {module_name}")
+    return list(dict.fromkeys(reasons))
+
+
+def _module_path_rows(
+    modules: list[dict[str, Any]],
+    hierarchy: dict[str, Any],
+) -> list[dict[str, Any]]:
+    modules_by_name: dict[str, dict[str, Any]] = {}
+    declaration_counts: dict[str, int] = {}
+    for module in modules:
+        modules_by_name.setdefault(module["name"], module)
+        declaration_counts[module["name"]] = (
+            declaration_counts.get(module["name"], 0) + 1
+        )
+
+    children_by_parent: dict[str, list[dict[str, Any]]] = {
+        name: []
+        for name in modules_by_name
+    }
+    unresolved_by_parent: dict[str, list[dict[str, Any]]] = {
+        name: []
+        for name in modules_by_name
+    }
+
+    for edge in hierarchy["edges"]:
+        parent = edge["parent"]
+        child = edge["child"]
+        if parent not in modules_by_name:
+            continue
+        if edge["resolved"] and child in modules_by_name:
+            children_by_parent.setdefault(parent, []).append(edge)
+        elif not edge["resolved"]:
+            unresolved_by_parent.setdefault(parent, []).append(edge)
+
+    edge_sort_key = lambda edge: (
+        edge["child"],
+        edge["line"],
+        edge["column"],
+        edge["instance"],
+    )
+    for edges in children_by_parent.values():
+        edges.sort(key=edge_sort_key)
+    for edges in unresolved_by_parent.values():
+        edges.sort(key=edge_sort_key)
+
+    rows: list[dict[str, Any]] = []
+    root_names = [
+        root
+        for root in hierarchy["roots"]
+        if root in modules_by_name
+    ]
+
+    def append_path(
+        *,
+        module_path: list[str],
+        edge_path: list[dict[str, Any]],
+        path_state: str,
+        reason: str,
+        terminal_module: str,
+        terminal_state: str,
+    ) -> None:
+        blocked_reasons = _module_path_boundary_blockers(
+            module_path,
+            modules_by_name,
+            declaration_counts,
+        )
+        if path_state != "complete-root-to-leaf":
+            blocked_reasons.append(reason)
+        blocked_reasons = list(dict.fromkeys(blocked_reasons))
+        effective_state = path_state
+        if blocked_reasons and path_state == "complete-root-to-leaf":
+            effective_state = "blocked-boundary"
+        rows.append({
+            "blocked_reasons": blocked_reasons,
+            "edge_count": len(edge_path),
+            "edges": [
+                _module_path_edge_summary(edge)
+                for edge in edge_path
+            ],
+            "instance_path": [
+                edge["instance"]
+                for edge in edge_path
+            ],
+            "module_path": module_path,
+            "path_depth": max(len(module_path) - 1, 0),
+            "path_state": effective_state,
+            "reason": reason,
+            "refactor_preflight_state": (
+                "blocked" if blocked_reasons else "ready-for-review"
+            ),
+            "root": module_path[0],
+            "terminal_module": terminal_module,
+            "terminal_state": terminal_state,
+        })
+
+    def visit(
+        module_name: str,
+        module_path: list[str],
+        edge_path: list[dict[str, Any]],
+    ) -> None:
+        unresolved_edges = unresolved_by_parent.get(module_name, [])
+        for edge in unresolved_edges:
+            append_path(
+                module_path=[*module_path, edge["child"]],
+                edge_path=[*edge_path, edge],
+                path_state="blocked-unresolved",
+                reason=(
+                    "unresolved dependency on path: "
+                    f"{module_name} -> {edge['child']}"
+                ),
+                terminal_module=edge["child"],
+                terminal_state="unresolved",
+            )
+
+        resolved_children = children_by_parent.get(module_name, [])
+        if not resolved_children and not unresolved_edges:
+            append_path(
+                module_path=module_path,
+                edge_path=edge_path,
+                path_state="complete-root-to-leaf",
+                reason="scanner-detected resolved root-to-leaf path",
+                terminal_module=module_name,
+                terminal_state="leaf",
+            )
+            return
+
+        for edge in resolved_children:
+            child = edge["child"]
+            if child in module_path:
+                append_path(
+                    module_path=[*module_path, child],
+                    edge_path=[*edge_path, edge],
+                    path_state="blocked-cycle",
+                    reason=(
+                        "cycle on scanner-detected path: "
+                        f"{' -> '.join([*module_path, child])}"
+                    ),
+                    terminal_module=child,
+                    terminal_state="cycle",
+                )
+                continue
+            visit(child, [*module_path, child], [*edge_path, edge])
+
+    for root in root_names:
+        visit(root, [root], [])
+
+    for index, row in enumerate(rows, 1):
+        row["path_id"] = f"path-{index}"
+    return rows
+
+
+def build_module_path_report(source: str, path: Path) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    hierarchy = organization["hierarchy"]
+    resolved_edge_count = len([
+        edge
+        for edge in hierarchy["edges"]
+        if edge["resolved"]
+    ])
+    root_names = [
+        root
+        for root in hierarchy["roots"]
+        if any(module["name"] == root for module in modules)
+    ]
+    paths = _module_path_rows(modules, hierarchy)
+    complete_paths = [
+        row
+        for row in paths
+        if row["path_state"] == "complete-root-to-leaf"
+    ]
+    blocked_paths = [
+        row
+        for row in paths
+        if row["refactor_preflight_state"] == "blocked"
+    ]
+    blocked_reasons = list(dict.fromkeys([
+        reason
+        for row in blocked_paths
+        for reason in row["blocked_reasons"]
+    ]))
+    if modules and not root_names:
+        blocked_reasons.append("no root candidates detected")
+    if not modules:
+        blocked_reasons.append("no module declarations detected")
+
+    if paths and blocked_paths:
+        report_state = (
+            "paths-detected-with-blockers"
+            if complete_paths
+            else "blocked"
+        )
+    elif paths:
+        report_state = "paths-detected"
+    else:
+        report_state = "no-paths-detected"
+
+    return {
+        "blocked_path_count": len(blocked_paths),
+        "blocked_reasons": blocked_reasons,
+        "complete_path_count": len(complete_paths),
+        "edge_count": len(hierarchy["edges"]),
+        "kind": "module-path-report",
+        "leaf_names": sorted({
+            row["terminal_module"]
+            for row in complete_paths
+        }),
+        "limitations": list(MODULE_PATH_REPORT_LIMITATIONS),
+        "max_path_depth": max((row["path_depth"] for row in paths), default=None),
+        "module_count": len(modules),
+        "next_required_action": (
+            "resolve hierarchy blockers before path review"
+            if blocked_paths or (modules and not root_names)
+            else "review scanner-detected hierarchy paths before refactor planning"
+            if paths
+            else "add module declarations before hierarchy path review"
+        ),
+        "path_count": len(paths),
+        "paths": paths,
+        "report_state": report_state,
+        "resolved_edge_count": resolved_edge_count,
+        "root_names": root_names,
+        "safety": _module_path_report_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "tool": "pccx-ide-cli",
         "unresolved_edge_count": len(hierarchy["edges"]) - resolved_edge_count,
         "writes_files": False,
     }
@@ -5585,6 +5876,56 @@ def format_module_depth_report_text(report: dict[str, Any]) -> str:
     lines.append(f"next: {report['next_required_action']}")
     lines.append(
         "read-only depth report: no command argv, validation, shell, "
+        "refactor, patch, file write, lab, launcher, vendor tool, provider, "
+        "or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_module_path_report_text(report: dict[str, Any]) -> str:
+    max_depth = (
+        report["max_path_depth"]
+        if report["max_path_depth"] is not None
+        else "none"
+    )
+    root_names = ", ".join(report["root_names"]) or "none"
+    leaf_names = ", ".join(report["leaf_names"]) or "none"
+    lines = [
+        f"source: {report['source']}",
+        f"module paths: {report['report_state']}",
+        f"{report['module_count']} module"
+        f"{'s' if report['module_count'] != 1 else ''}",
+        f"{report['path_count']} hierarchy path"
+        f"{'s' if report['path_count'] != 1 else ''}",
+        (
+            f"complete paths: {report['complete_path_count']}; "
+            f"blocked paths: {report['blocked_path_count']}; "
+            f"max depth: {max_depth}"
+        ),
+        f"root candidates: {root_names}",
+        f"leaf terminals: {leaf_names}",
+    ]
+    if not report["paths"]:
+        lines.append("paths: none")
+    for path in report["paths"]:
+        module_path = " -> ".join(path["module_path"])
+        instances = ", ".join(path["instance_path"]) or "none"
+        lines.append(
+            f"{path['path_id']}: {module_path} "
+            f"({path['refactor_preflight_state']})"
+        )
+        lines.append(
+            f"  state={path['path_state']}; terminal={path['terminal_module']} "
+            f"({path['terminal_state']}); instances={instances}; "
+            f"edges={path['edge_count']}; reason={path['reason']}"
+        )
+        for reason in path["blocked_reasons"]:
+            lines.append(f"  blocked: {reason}")
+    for reason in report["blocked_reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"next: {report['next_required_action']}")
+    lines.append(
+        "read-only path report: no command argv, validation, shell, "
         "refactor, patch, file write, lab, launcher, vendor tool, provider, "
         "or hardware execution"
     )

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -37,6 +37,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_leaf_candidate_report,
     build_module_orphan_candidate_report,
     build_module_organization_export,
+    build_module_path_report,
     build_module_port_usage_view,
     build_module_root_candidate_report,
     build_module_summary_view,
@@ -72,6 +73,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_module_leaf_candidate_report_text,
     format_module_orphan_candidate_report_text,
     format_module_organization_text,
+    format_module_path_report_text,
     format_module_port_usage_text,
     format_module_root_candidate_report_text,
     format_module_summary_text,
@@ -868,6 +870,105 @@ def test_build_module_depth_report_blocks_unresolved_dependencies():
     assert module["blocked_reasons"] == [
         "unresolved dependencies for depth report: missing_child"
     ]
+
+
+def test_build_module_path_report_lists_root_to_leaf_paths():
+    report = build_module_path_report(str(FANOUT_FIXTURE), FANOUT_FIXTURE)
+
+    assert report["kind"] == "module-path-report"
+    assert report["report_state"] == "paths-detected"
+    assert report["module_count"] == 4
+    assert report["edge_count"] == 3
+    assert report["resolved_edge_count"] == 3
+    assert report["unresolved_edge_count"] == 0
+    assert report["path_count"] == 2
+    assert report["complete_path_count"] == 2
+    assert report["blocked_path_count"] == 0
+    assert report["max_path_depth"] == 2
+    assert report["root_names"] == ["fanout_top"]
+    assert report["leaf_names"] == ["fanout_child_b", "fanout_leaf"]
+    assert report["blocked_reasons"] == []
+    assert report["next_required_action"] == (
+        "review scanner-detected hierarchy paths before refactor planning"
+    )
+
+    first_path = report["paths"][0]
+    assert first_path["path_id"] == "path-1"
+    assert first_path["module_path"] == [
+        "fanout_top",
+        "fanout_child_a",
+        "fanout_leaf",
+    ]
+    assert first_path["instance_path"] == ["u_child_a", "u_leaf"]
+    assert first_path["path_depth"] == 2
+    assert first_path["path_state"] == "complete-root-to-leaf"
+    assert first_path["terminal_module"] == "fanout_leaf"
+    assert first_path["terminal_state"] == "leaf"
+    assert first_path["refactor_preflight_state"] == "ready-for-review"
+    assert first_path["edges"][0]["parent"] == "fanout_top"
+    assert first_path["edges"][0]["child"] == "fanout_child_a"
+    assert first_path["edges"][0]["resolved"] is True
+
+    second_path = report["paths"][1]
+    assert second_path["module_path"] == ["fanout_top", "fanout_child_b"]
+    assert second_path["instance_path"] == ["u_child_b"]
+    assert second_path["terminal_module"] == "fanout_child_b"
+    assert report["safety"]["read_only"] is True
+    assert report["safety"]["path_report_only"] is True
+    assert report["safety"]["emits_command_descriptors"] is False
+    assert report["safety"]["writes_files"] is False
+    assert report["safety"]["applies_refactor"] is False
+    assert report["safety"]["generates_patch"] is False
+    assert report["safety"]["runs_validation"] is False
+    assert report["safety"]["runs_shell"] is False
+    assert report["safety"]["invokes_pccx_lab"] is False
+    assert report["safety"]["invokes_launcher"] is False
+    assert report["safety"]["invokes_vendor_tools"] is False
+    assert report["safety"]["provider_calls"] is False
+    assert report["safety"]["hardware_access"] is False
+    assert report["writes_files"] is False
+    assert '"argv"' not in json.dumps(report)
+
+
+def test_build_module_path_report_blocks_unresolved_path_terminals():
+    report = build_module_path_report(
+        str(UNRESOLVED_FIXTURE),
+        UNRESOLVED_FIXTURE,
+    )
+
+    assert report["report_state"] == "blocked"
+    assert report["path_count"] == 1
+    assert report["complete_path_count"] == 0
+    assert report["blocked_path_count"] == 1
+    assert report["root_names"] == ["unresolved_top"]
+    assert report["leaf_names"] == []
+    assert report["blocked_reasons"] == [
+        "unresolved dependency on path: unresolved_top -> missing_child"
+    ]
+    assert report["next_required_action"] == (
+        "resolve hierarchy blockers before path review"
+    )
+    path = report["paths"][0]
+    assert path["module_path"] == ["unresolved_top", "missing_child"]
+    assert path["instance_path"] == ["u_missing"]
+    assert path["path_state"] == "blocked-unresolved"
+    assert path["terminal_module"] == "missing_child"
+    assert path["terminal_state"] == "unresolved"
+    assert path["refactor_preflight_state"] == "blocked"
+    assert path["edges"][0]["resolved"] is False
+
+
+def test_build_module_path_report_blocks_when_no_modules_detected():
+    empty_fixture = REPO_ROOT / "fixtures" / "empty.sv"
+    report = build_module_path_report(str(empty_fixture), empty_fixture)
+
+    assert report["report_state"] == "no-paths-detected"
+    assert report["path_count"] == 0
+    assert report["paths"] == []
+    assert report["blocked_reasons"] == ["no module declarations detected"]
+    assert report["next_required_action"] == (
+        "add module declarations before hierarchy path review"
+    )
 
 
 def test_build_module_fanout_report_ranks_direct_dependencies():
@@ -2131,6 +2232,20 @@ def test_format_module_depth_report_text_mentions_boundary():
     assert "read-only depth report: no command argv" in text
 
 
+def test_format_module_path_report_text_mentions_boundary():
+    report = build_module_path_report(str(FANOUT_FIXTURE), FANOUT_FIXTURE)
+    text = format_module_path_report_text(report)
+
+    assert "module paths: paths-detected" in text
+    assert "2 hierarchy paths" in text
+    assert "complete paths: 2; blocked paths: 0; max depth: 2" in text
+    assert "root candidates: fanout_top" in text
+    assert "leaf terminals: fanout_child_b, fanout_leaf" in text
+    assert "path-1: fanout_top -> fanout_child_a -> fanout_leaf" in text
+    assert "instances=u_child_a, u_leaf" in text
+    assert "read-only path report: no command argv" in text
+
+
 def test_format_module_fanin_report_text_mentions_boundary():
     report = build_module_fanin_report(str(FANOUT_FIXTURE), FANOUT_FIXTURE)
     text = format_module_fanin_report_text(report)
@@ -2675,6 +2790,34 @@ def test_cli_module_depths_text():
     assert "depth 0: top_mod" in result.stdout
     assert "depth 1: leaf_mod" in result.stdout
     assert "read-only depth report: no command argv" in result.stdout
+
+
+def test_cli_module_paths_json():
+    result = _run_cli("module-paths", str(FANOUT_FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-path-report"
+    assert payload["report_state"] == "paths-detected"
+    assert payload["path_count"] == 2
+    assert payload["complete_path_count"] == 2
+    assert payload["blocked_path_count"] == 0
+    assert payload["paths"][0]["module_path"] == [
+        "fanout_top",
+        "fanout_child_a",
+        "fanout_leaf",
+    ]
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["emits_command_descriptors"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_module_paths_text():
+    result = _run_cli("module-paths", str(FANOUT_FIXTURE), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "module paths: paths-detected" in result.stdout
+    assert "path-1: fanout_top -> fanout_child_a -> fanout_leaf" in result.stdout
+    assert "read-only path report: no command argv" in result.stdout
 
 
 def test_cli_module_fanout_json():
@@ -3377,6 +3520,12 @@ def test_cli_module_orphans_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_module_paths_missing_path_exits_nonzero():
+    result = _run_cli("module-paths", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_cli_module_fanout_missing_path_exits_nonzero():
     result = _run_cli("module-fanout", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
@@ -3563,6 +3712,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-leaves <path>" in contract
     assert "module-orphans <path>" in contract
     assert "module-depths <path>" in contract
+    assert "module-paths <path>" in contract
     assert "module-fanout <path>" in contract
     assert "module-fanin <path>" in contract
     assert "module-health <path>" in contract
@@ -3591,6 +3741,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-leaf-candidate-report" in workflow
     assert "module-orphan-candidate-report" in workflow
     assert "module-depth-report" in workflow
+    assert "module-path-report" in workflow
     assert "module-fanout-report" in workflow
     assert "module-fanin-report" in workflow
     assert "module-graph-health-summary" in workflow
@@ -3620,6 +3771,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "hierarchy cycle report" in workflow
     assert "unresolved instantiation report" in workflow
     assert "root-candidate report" in workflow
+    assert "hierarchy path report" in workflow
     assert "module graph health summary" in workflow
     assert "does not write files" in workflow
     assert "not a full SystemVerilog parser" in workflow


### PR DESCRIPTION
## Summary
- Add a read-only `module-paths` CLI report for scanner-detected root-to-leaf hierarchy paths and unresolved path terminals.
- Wire the new report into CLI dispatch, docs, editor bridge smoke coverage, and CI smoke coverage.
- Add JSON, text, blocked-unresolved, empty-input, missing-path, and docs coverage for the new report.

## Validation
- `PYTHONPATH=src python3 -m pytest tests/test_module_organization.py`
- `PYTHONPATH=src python3 -m pytest`
- `python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py`
- `find scripts -type f -name '*.sh' -exec bash -n {} +`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `python3 scripts/check-source-headers.py`
- `git diff --check`
- local claim scan matching CI pattern

Refs #8
