### PR TITLE
Add module edge report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,13 @@ jobs:
               fixtures/organization/fanout_hierarchy.sv \
               | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-path-report'; assert d['safety']['writes_files'] is False; assert d['safety']['emits_command_descriptors'] is False"
           echo "module paths smoke ok"
+      - name: cli smoke (module edges exits zero)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli module-edges \
+              fixtures/organization/fanout_hierarchy.sv \
+              | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-edge-report'; assert d['safety']['writes_files'] is False; assert d['safety']['emits_command_descriptors'] is False"
+          echo "module edges smoke ok"
       - name: cli smoke (module summary exits zero)
         run: |
           set -e

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ python -m pccx_ide_cli module-leaves fixtures/organization/hierarchy_top.sv --fo
 python -m pccx_ide_cli module-orphans fixtures/organization/orphan_modules.sv --format json
 python -m pccx_ide_cli module-depths fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli module-paths fixtures/organization/fanout_hierarchy.sv --format json
+python -m pccx_ide_cli module-edges fixtures/organization/fanout_hierarchy.sv --format json
 python -m pccx_ide_cli module-fanout fixtures/organization/fanout_hierarchy.sv --format json
 python -m pccx_ide_cli module-fanin fixtures/organization/fanout_hierarchy.sv --format json
 python -m pccx_ide_cli module-health fixtures/organization/hierarchy_top.sv --format json
@@ -239,6 +240,8 @@ resolved dependencies or dependents.
 for module organization review.
 `module-paths` enumerates scanner-detected root-to-leaf hierarchy paths and
 blocked unresolved path terminals for path review.
+`module-edges` lists scanner-detected direct instantiation edges, including
+blocked unresolved targets, for dependency edge review.
 `module-fanout` ranks scanner-detected modules by resolved direct dependency
 count for fanout review.
 `module-fanin` ranks scanner-detected modules by resolved direct dependent

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -57,6 +57,7 @@ python -m pccx_ide_cli module-leaves <path> --format json
 python -m pccx_ide_cli module-orphans <path> --format json
 python -m pccx_ide_cli module-depths <path> --format json
 python -m pccx_ide_cli module-paths <path> --format json
+python -m pccx_ide_cli module-edges <path> --format json
 python -m pccx_ide_cli module-fanout <path> --format json
 python -m pccx_ide_cli module-fanin <path> --format json
 python -m pccx_ide_cli module-health <path> --format json
@@ -219,14 +220,15 @@ invoke pccx-lab or the launcher, run vendor tools, call providers, touch
 hardware, or perform automatic repository actions. `hierarchy`,
 `dependencies`, `hierarchy-cycles`, `unresolved-instances`, `module-roots`,
 `module-leaves`, `module-orphans`, `module-depths`, `module-paths`,
-`module-fanout`, `module-fanin`,
+`module-edges`, `module-fanout`, `module-fanin`,
 `module-health`,
 `module-summary`, `port-usage`, `module-context`, and `refactor-impact`
 render focused read-only views from the same scanner data, including
 hierarchy cycle warnings, unresolved instantiation warnings, root-candidate
 summaries, leaf-candidate summaries, orphan-candidate summaries,
 depth-level summaries,
-hierarchy path reports, fanout rankings, fanin rankings,
+hierarchy path reports, direct dependency edge reports, fanout rankings,
+fanin rankings,
 module graph health summaries,
 conservative module header/port summaries, target port usage summaries,
 target module context bundles, and

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -5,7 +5,8 @@
 This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
 `hierarchy-cycles`, `unresolved-instances`, `module-roots`, `module-leaves`,
-`module-orphans`, `module-depths`, `module-paths`, `module-fanout`, `module-fanin`,
+`module-orphans`, `module-depths`, `module-paths`, `module-edges`,
+`module-fanout`, `module-fanin`,
 `module-health`,
 `module-summary`,
 `boundary-audit`, `module-duplicates`, `refactor-candidates`, `port-usage`,
@@ -18,7 +19,8 @@ scanner-based hierarchy data, direct dependency impact data, hierarchy cycle
 report metadata, unresolved instantiation report metadata, root-candidate
 report metadata, leaf-candidate report metadata, orphan-candidate report
 metadata, depth-level report metadata, hierarchy path report metadata,
-`module-fanout-report` metadata, `module-fanin-report` metadata,
+`module-edge-report` metadata, `module-fanout-report` metadata,
+`module-fanin-report` metadata,
 module graph health summary metadata,
 conservative module header/port summaries, duplicate-name report metadata,
 target port usage summaries, target module context bundles, target-specific
@@ -55,6 +57,8 @@ python -m pccx_ide_cli module-depths <path> --format json
 python -m pccx_ide_cli module-depths <path> --format text
 python -m pccx_ide_cli module-paths <path> --format json
 python -m pccx_ide_cli module-paths <path> --format text
+python -m pccx_ide_cli module-edges <path> --format json
+python -m pccx_ide_cli module-edges <path> --format text
 python -m pccx_ide_cli module-fanout <path> --format json
 python -m pccx_ide_cli module-fanout <path> --format text
 python -m pccx_ide_cli module-fanin <path> --format json
@@ -452,6 +456,44 @@ The hierarchy path report is display data only. It does not write files,
 apply refactors, generate patches, run validation, execute shell commands,
 emit command argv, invoke `pccx-lab`, invoke the launcher, call providers,
 touch hardware, upload telemetry, or perform automatic repository actions.
+
+The module edge report lists scanner-detected direct instantiation edges and
+marks unresolved targets as blocked:
+
+```json
+{
+  "kind": "module-edge-report",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "report_state": "edges-detected",
+  "edge_count": 3,
+  "resolved_edge_count": 3,
+  "unresolved_edge_count": 0,
+  "edges": [
+    {
+      "edge_id": "edge-1",
+      "parent": "fanout_child_a",
+      "child": "fanout_leaf",
+      "instance": "u_leaf",
+      "resolution_state": "resolved"
+    }
+  ],
+  "safety": {
+    "read_only": true,
+    "edge_report_only": true,
+    "writes_files": false,
+    "emits_command_descriptors": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The module edge report is display data only. It does not write files, apply
+refactors, generate patches, run validation, execute shell commands, emit
+command argv, invoke `pccx-lab`, invoke the launcher, call providers, touch
+hardware, upload telemetry, or perform automatic repository actions.
 
 The fanin report ranks modules by scanner-detected resolved direct dependents:
 

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -374,6 +374,25 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    module_edges_cmd = sub.add_parser(
+        "module-edges",
+        help=(
+            "Render scanner-based read-only direct module dependency edge "
+            "report data."
+        ),
+    )
+    module_edges_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    module_edges_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     module_fanout_cmd = sub.add_parser(
         "module-fanout",
         help=(
@@ -1475,6 +1494,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_path_report_text(report))
+        return 0
+
+    if args.command == "module-edges":
+        from .module_organization import (
+            build_module_edge_report,
+            format_module_edge_report_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        report = build_module_edge_report(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(report, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_edge_report_text(report))
         return 0
 
     if args.command == "module-fanout":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -208,6 +208,17 @@ MODULE_PATH_REPORT_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+MODULE_EDGE_REPORT_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based module dependency edge report only",
+    "uses resolved and unresolved direct instantiation edges from the organization scanner",
+    "single-line instantiation candidates only",
+    "unresolved instantiation candidates are listed but not resolved",
+    "no semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
+    "does not apply refactors, write files, generate patches, or run validation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 MODULE_FANOUT_REPORT_LIMITATIONS: tuple[str, ...] = (
     "scanner-based module fanout report only",
     "uses resolved direct dependency edges from the organization scanner",
@@ -678,6 +689,28 @@ def _module_path_report_safety_flags() -> dict[str, bool]:
     return {
         "read_only": True,
         "path_report_only": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _module_edge_report_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "edge_report_only": True,
         "emits_command_descriptors": False,
         "writes_files": False,
         "moves_files": False,
@@ -2774,6 +2807,124 @@ def build_module_path_report(source: str, path: Path) -> dict[str, Any]:
         "source": source,
         "tool": "pccx-ide-cli",
         "unresolved_edge_count": len(hierarchy["edges"]) - resolved_edge_count,
+        "writes_files": False,
+    }
+
+
+def _module_edge_report_rows(hierarchy: dict[str, Any]) -> list[dict[str, Any]]:
+    edges = sorted(
+        hierarchy["edges"],
+        key=lambda edge: (
+            edge["file"],
+            edge["line"],
+            edge["column"],
+            edge["parent"],
+            edge["child"],
+            edge["instance"],
+        ),
+    )
+    rows: list[dict[str, Any]] = []
+    for index, edge in enumerate(edges, 1):
+        if edge["resolved"]:
+            blocked_reasons: list[str] = []
+            reason = "scanner-detected resolved direct instantiation edge"
+            refactor_preflight_state = "ready-for-review"
+            resolution_state = "resolved"
+            edge_state = "resolved-dependency"
+        else:
+            blocked_reasons = [
+                "unresolved module instantiation edge: "
+                f"{edge['parent']} -> {edge['child']} as {edge['instance']}"
+            ]
+            reason = "scanner-detected unresolved direct instantiation edge"
+            refactor_preflight_state = "blocked"
+            resolution_state = "unresolved"
+            edge_state = "unresolved-dependency"
+        rows.append({
+            "blocked_reasons": blocked_reasons,
+            "child": edge["child"],
+            "column": edge["column"],
+            "edge_id": f"edge-{index}",
+            "edge_state": edge_state,
+            "file": edge["file"],
+            "instance": edge["instance"],
+            "line": edge["line"],
+            "parent": edge["parent"],
+            "reason": reason,
+            "refactor_preflight_state": refactor_preflight_state,
+            "resolved": edge["resolved"],
+            "resolution_state": resolution_state,
+        })
+    return rows
+
+
+def build_module_edge_report(source: str, path: Path) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    hierarchy = organization["hierarchy"]
+    edges = _module_edge_report_rows(hierarchy)
+    resolved_edges = [
+        edge
+        for edge in edges
+        if edge["resolved"]
+    ]
+    unresolved_edges = [
+        edge
+        for edge in edges
+        if not edge["resolved"]
+    ]
+    blocked_reasons = list(dict.fromkeys([
+        reason
+        for edge in unresolved_edges
+        for reason in edge["blocked_reasons"]
+    ]))
+    if modules and not edges:
+        blocked_reasons.append("no instantiation edges detected")
+    if not modules:
+        blocked_reasons.append("no module declarations detected")
+
+    if resolved_edges and unresolved_edges:
+        report_state = "edges-detected-with-blockers"
+    elif resolved_edges:
+        report_state = "edges-detected"
+    elif unresolved_edges:
+        report_state = "blocked"
+    else:
+        report_state = "no-edges-detected"
+
+    return {
+        "blocked_reasons": blocked_reasons,
+        "edge_count": len(edges),
+        "edges": edges,
+        "kind": "module-edge-report",
+        "limitations": list(MODULE_EDGE_REPORT_LIMITATIONS),
+        "module_count": len(modules),
+        "next_required_action": (
+            "resolve scanner-detected unresolved edges before edge review"
+            if unresolved_edges
+            else "review scanner-detected direct module edges before refactor planning"
+            if edges
+            else "continue module organization review"
+        ),
+        "parent_names": sorted({
+            edge["parent"]
+            for edge in edges
+        }),
+        "report_state": report_state,
+        "resolved_child_names": sorted({
+            edge["child"]
+            for edge in resolved_edges
+        }),
+        "resolved_edge_count": len(resolved_edges),
+        "safety": _module_edge_report_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "tool": "pccx-ide-cli",
+        "unresolved_edge_count": len(unresolved_edges),
+        "unresolved_target_names": sorted({
+            edge["child"]
+            for edge in unresolved_edges
+        }),
         "writes_files": False,
     }
 
@@ -5926,6 +6077,43 @@ def format_module_path_report_text(report: dict[str, Any]) -> str:
     lines.append(f"next: {report['next_required_action']}")
     lines.append(
         "read-only path report: no command argv, validation, shell, "
+        "refactor, patch, file write, lab, launcher, vendor tool, provider, "
+        "or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_module_edge_report_text(report: dict[str, Any]) -> str:
+    lines = [
+        f"source: {report['source']}",
+        f"module edges: {report['report_state']}",
+        f"{report['module_count']} module"
+        f"{'s' if report['module_count'] != 1 else ''}",
+        f"{report['edge_count']} dependency edge"
+        f"{'s' if report['edge_count'] != 1 else ''}",
+        (
+            f"resolved edges: {report['resolved_edge_count']}; "
+            f"unresolved edges: {report['unresolved_edge_count']}"
+        ),
+    ]
+    if not report["edges"]:
+        lines.append("edges: none")
+    for edge in report["edges"]:
+        lines.append(
+            f"{edge['edge_id']}: {edge['parent']} -> {edge['child']} "
+            f"as {edge['instance']} ({edge['refactor_preflight_state']})"
+        )
+        lines.append(
+            f"  {edge['file']}:{edge['line']}:{edge['column']}; "
+            f"state={edge['edge_state']}; reason={edge['reason']}"
+        )
+        for reason in edge["blocked_reasons"]:
+            lines.append(f"  blocked: {reason}")
+    for reason in report["blocked_reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"next: {report['next_required_action']}")
+    lines.append(
+        "read-only edge report: no command argv, validation, shell, "
         "refactor, patch, file write, lab, launcher, vendor tool, provider, "
         "or hardware execution"
     )

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -29,6 +29,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_context_bundle,
     build_module_depth_report,
     build_module_duplicate_report,
+    build_module_edge_report,
     build_module_fanin_report,
     build_module_fanout_report,
     build_module_graph_health_summary,
@@ -65,6 +66,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_module_context_text,
     format_module_depth_report_text,
     format_module_duplicate_report_text,
+    format_module_edge_report_text,
     format_module_fanin_report_text,
     format_module_fanout_report_text,
     format_module_graph_health_summary_text,
@@ -969,6 +971,94 @@ def test_build_module_path_report_blocks_when_no_modules_detected():
     assert report["next_required_action"] == (
         "add module declarations before hierarchy path review"
     )
+
+
+def test_build_module_edge_report_lists_direct_instantiation_edges():
+    report = build_module_edge_report(str(FANOUT_FIXTURE), FANOUT_FIXTURE)
+
+    assert report["kind"] == "module-edge-report"
+    assert report["report_state"] == "edges-detected"
+    assert report["module_count"] == 4
+    assert report["edge_count"] == 3
+    assert report["resolved_edge_count"] == 3
+    assert report["unresolved_edge_count"] == 0
+    assert report["parent_names"] == ["fanout_child_a", "fanout_top"]
+    assert report["resolved_child_names"] == [
+        "fanout_child_a",
+        "fanout_child_b",
+        "fanout_leaf",
+    ]
+    assert report["unresolved_target_names"] == []
+    assert report["blocked_reasons"] == []
+    assert report["next_required_action"] == (
+        "review scanner-detected direct module edges before refactor planning"
+    )
+
+    first_edge = report["edges"][0]
+    assert first_edge["edge_id"] == "edge-1"
+    assert first_edge["parent"] == "fanout_child_a"
+    assert first_edge["child"] == "fanout_leaf"
+    assert first_edge["instance"] == "u_leaf"
+    assert first_edge["resolved"] is True
+    assert first_edge["resolution_state"] == "resolved"
+    assert first_edge["edge_state"] == "resolved-dependency"
+    assert first_edge["refactor_preflight_state"] == "ready-for-review"
+    assert first_edge["blocked_reasons"] == []
+    assert report["safety"]["read_only"] is True
+    assert report["safety"]["edge_report_only"] is True
+    assert report["safety"]["emits_command_descriptors"] is False
+    assert report["safety"]["writes_files"] is False
+    assert report["safety"]["applies_refactor"] is False
+    assert report["safety"]["generates_patch"] is False
+    assert report["safety"]["runs_validation"] is False
+    assert report["safety"]["runs_shell"] is False
+    assert report["safety"]["invokes_pccx_lab"] is False
+    assert report["safety"]["invokes_launcher"] is False
+    assert report["safety"]["invokes_vendor_tools"] is False
+    assert report["safety"]["provider_calls"] is False
+    assert report["safety"]["hardware_access"] is False
+    assert report["writes_files"] is False
+    assert '"argv"' not in json.dumps(report)
+
+
+def test_build_module_edge_report_marks_unresolved_edges_blocked():
+    report = build_module_edge_report(
+        str(UNRESOLVED_FIXTURE),
+        UNRESOLVED_FIXTURE,
+    )
+
+    assert report["report_state"] == "blocked"
+    assert report["edge_count"] == 1
+    assert report["resolved_edge_count"] == 0
+    assert report["unresolved_edge_count"] == 1
+    assert report["unresolved_target_names"] == ["missing_child"]
+    assert report["blocked_reasons"] == [
+        "unresolved module instantiation edge: "
+        "unresolved_top -> missing_child as u_missing"
+    ]
+    edge = report["edges"][0]
+    assert edge["parent"] == "unresolved_top"
+    assert edge["child"] == "missing_child"
+    assert edge["instance"] == "u_missing"
+    assert edge["resolved"] is False
+    assert edge["resolution_state"] == "unresolved"
+    assert edge["edge_state"] == "unresolved-dependency"
+    assert edge["refactor_preflight_state"] == "blocked"
+    assert edge["blocked_reasons"] == report["blocked_reasons"]
+    assert report["next_required_action"] == (
+        "resolve scanner-detected unresolved edges before edge review"
+    )
+
+
+def test_build_module_edge_report_blocks_when_no_modules_detected():
+    empty_fixture = REPO_ROOT / "fixtures" / "empty.sv"
+    report = build_module_edge_report(str(empty_fixture), empty_fixture)
+
+    assert report["report_state"] == "no-edges-detected"
+    assert report["edge_count"] == 0
+    assert report["edges"] == []
+    assert report["blocked_reasons"] == ["no module declarations detected"]
+    assert report["next_required_action"] == "continue module organization review"
 
 
 def test_build_module_fanout_report_ranks_direct_dependencies():
@@ -2246,6 +2336,18 @@ def test_format_module_path_report_text_mentions_boundary():
     assert "read-only path report: no command argv" in text
 
 
+def test_format_module_edge_report_text_mentions_boundary():
+    report = build_module_edge_report(str(FANOUT_FIXTURE), FANOUT_FIXTURE)
+    text = format_module_edge_report_text(report)
+
+    assert "module edges: edges-detected" in text
+    assert "3 dependency edges" in text
+    assert "resolved edges: 3; unresolved edges: 0" in text
+    assert "edge-1: fanout_child_a -> fanout_leaf as u_leaf" in text
+    assert "state=resolved-dependency" in text
+    assert "read-only edge report: no command argv" in text
+
+
 def test_format_module_fanin_report_text_mentions_boundary():
     report = build_module_fanin_report(str(FANOUT_FIXTURE), FANOUT_FIXTURE)
     text = format_module_fanin_report_text(report)
@@ -2818,6 +2920,31 @@ def test_cli_module_paths_text():
     assert "module paths: paths-detected" in result.stdout
     assert "path-1: fanout_top -> fanout_child_a -> fanout_leaf" in result.stdout
     assert "read-only path report: no command argv" in result.stdout
+
+
+def test_cli_module_edges_json():
+    result = _run_cli("module-edges", str(FANOUT_FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-edge-report"
+    assert payload["report_state"] == "edges-detected"
+    assert payload["edge_count"] == 3
+    assert payload["resolved_edge_count"] == 3
+    assert payload["unresolved_edge_count"] == 0
+    assert payload["edges"][0]["parent"] == "fanout_child_a"
+    assert payload["edges"][0]["child"] == "fanout_leaf"
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["emits_command_descriptors"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_module_edges_text():
+    result = _run_cli("module-edges", str(FANOUT_FIXTURE), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "module edges: edges-detected" in result.stdout
+    assert "edge-1: fanout_child_a -> fanout_leaf as u_leaf" in result.stdout
+    assert "read-only edge report: no command argv" in result.stdout
 
 
 def test_cli_module_fanout_json():
@@ -3526,6 +3653,12 @@ def test_cli_module_paths_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_module_edges_missing_path_exits_nonzero():
+    result = _run_cli("module-edges", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_cli_module_fanout_missing_path_exits_nonzero():
     result = _run_cli("module-fanout", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
@@ -3713,6 +3846,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-orphans <path>" in contract
     assert "module-depths <path>" in contract
     assert "module-paths <path>" in contract
+    assert "module-edges <path>" in contract
     assert "module-fanout <path>" in contract
     assert "module-fanin <path>" in contract
     assert "module-health <path>" in contract
@@ -3742,6 +3876,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-orphan-candidate-report" in workflow
     assert "module-depth-report" in workflow
     assert "module-path-report" in workflow
+    assert "module-edge-report" in workflow
     assert "module-fanout-report" in workflow
     assert "module-fanin-report" in workflow
     assert "module-graph-health-summary" in workflow


### PR DESCRIPTION
Refs #8.

## Summary
- add a read-only `module-edges` report for scanner-detected direct instantiation edges
- list resolved and unresolved edge rows with explicit blocked reasons and safety flags
- document the CLI surface and include the new command in CI smoke coverage

## Validation
- `python3 -m compileall -q src tests`
- `python3 -m pytest tests/test_module_organization.py -q`
- `python3 -m pytest -q`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `git diff --check`
- `PYTHONPATH=src python3 -m pccx_ide_cli module-edges fixtures/organization/fanout_hierarchy.sv --format json`