### PR TITLE
Add module reachability report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,13 @@ jobs:
               fixtures/organization/fanout_hierarchy.sv \
               | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-edge-report'; assert d['safety']['writes_files'] is False; assert d['safety']['emits_command_descriptors'] is False"
           echo "module edges smoke ok"
+      - name: cli smoke (module reachability exits zero)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli module-reachability \
+              fixtures/organization/fanout_hierarchy.sv \
+              | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-reachability-report'; assert d['safety']['writes_files'] is False; assert d['safety']['emits_command_descriptors'] is False"
+          echo "module reachability smoke ok"
       - name: cli smoke (module summary exits zero)
         run: |
           set -e

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ python -m pccx_ide_cli module-orphans fixtures/organization/orphan_modules.sv --
 python -m pccx_ide_cli module-depths fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli module-paths fixtures/organization/fanout_hierarchy.sv --format json
 python -m pccx_ide_cli module-edges fixtures/organization/fanout_hierarchy.sv --format json
+python -m pccx_ide_cli module-reachability fixtures/organization/fanout_hierarchy.sv --format json
 python -m pccx_ide_cli module-fanout fixtures/organization/fanout_hierarchy.sv --format json
 python -m pccx_ide_cli module-fanin fixtures/organization/fanout_hierarchy.sv --format json
 python -m pccx_ide_cli module-health fixtures/organization/hierarchy_top.sv --format json
@@ -242,6 +243,8 @@ for module organization review.
 blocked unresolved path terminals for path review.
 `module-edges` lists scanner-detected direct instantiation edges, including
 blocked unresolved targets, for dependency edge review.
+`module-reachability` reports scanner-detected transitive dependency and
+dependent names for reachability review.
 `module-fanout` ranks scanner-detected modules by resolved direct dependency
 count for fanout review.
 `module-fanin` ranks scanner-detected modules by resolved direct dependent

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -58,6 +58,7 @@ python -m pccx_ide_cli module-orphans <path> --format json
 python -m pccx_ide_cli module-depths <path> --format json
 python -m pccx_ide_cli module-paths <path> --format json
 python -m pccx_ide_cli module-edges <path> --format json
+python -m pccx_ide_cli module-reachability <path> --format json
 python -m pccx_ide_cli module-fanout <path> --format json
 python -m pccx_ide_cli module-fanin <path> --format json
 python -m pccx_ide_cli module-health <path> --format json
@@ -220,15 +221,15 @@ invoke pccx-lab or the launcher, run vendor tools, call providers, touch
 hardware, or perform automatic repository actions. `hierarchy`,
 `dependencies`, `hierarchy-cycles`, `unresolved-instances`, `module-roots`,
 `module-leaves`, `module-orphans`, `module-depths`, `module-paths`,
-`module-edges`, `module-fanout`, `module-fanin`,
+`module-edges`, `module-reachability`, `module-fanout`, `module-fanin`,
 `module-health`,
 `module-summary`, `port-usage`, `module-context`, and `refactor-impact`
 render focused read-only views from the same scanner data, including
 hierarchy cycle warnings, unresolved instantiation warnings, root-candidate
 summaries, leaf-candidate summaries, orphan-candidate summaries,
 depth-level summaries,
-hierarchy path reports, direct dependency edge reports, fanout rankings,
-fanin rankings,
+hierarchy path reports, direct dependency edge reports, reachability reports,
+fanout rankings, fanin rankings,
 module graph health summaries,
 conservative module header/port summaries, target port usage summaries,
 target module context bundles, and

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -6,7 +6,7 @@ This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
 `hierarchy-cycles`, `unresolved-instances`, `module-roots`, `module-leaves`,
 `module-orphans`, `module-depths`, `module-paths`, `module-edges`,
-`module-fanout`, `module-fanin`,
+`module-reachability`, `module-fanout`, `module-fanin`,
 `module-health`,
 `module-summary`,
 `boundary-audit`, `module-duplicates`, `refactor-candidates`, `port-usage`,
@@ -19,7 +19,8 @@ scanner-based hierarchy data, direct dependency impact data, hierarchy cycle
 report metadata, unresolved instantiation report metadata, root-candidate
 report metadata, leaf-candidate report metadata, orphan-candidate report
 metadata, depth-level report metadata, hierarchy path report metadata,
-`module-edge-report` metadata, `module-fanout-report` metadata,
+`module-edge-report` metadata, `module-reachability-report` metadata,
+`module-fanout-report` metadata,
 `module-fanin-report` metadata,
 module graph health summary metadata,
 conservative module header/port summaries, duplicate-name report metadata,
@@ -59,6 +60,8 @@ python -m pccx_ide_cli module-paths <path> --format json
 python -m pccx_ide_cli module-paths <path> --format text
 python -m pccx_ide_cli module-edges <path> --format json
 python -m pccx_ide_cli module-edges <path> --format text
+python -m pccx_ide_cli module-reachability <path> --format json
+python -m pccx_ide_cli module-reachability <path> --format text
 python -m pccx_ide_cli module-fanout <path> --format json
 python -m pccx_ide_cli module-fanout <path> --format text
 python -m pccx_ide_cli module-fanin <path> --format json
@@ -491,6 +494,46 @@ marks unresolved targets as blocked:
 ```
 
 The module edge report is display data only. It does not write files, apply
+refactors, generate patches, run validation, execute shell commands, emit
+command argv, invoke `pccx-lab`, invoke the launcher, call providers, touch
+hardware, upload telemetry, or perform automatic repository actions.
+
+The reachability report summarizes transitive dependencies and dependents from
+resolved scanner edges:
+
+```json
+{
+  "kind": "module-reachability-report",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "report_state": "reachability-detected",
+  "reachable_module_count": 4,
+  "max_transitive_dependency_count": 3,
+  "max_transitive_dependent_count": 2,
+  "modules": [
+    {
+      "name": "fanout_top",
+      "transitive_dependencies": [
+        "fanout_child_a",
+        "fanout_child_b",
+        "fanout_leaf"
+      ],
+      "transitive_dependents": []
+    }
+  ],
+  "safety": {
+    "read_only": true,
+    "reachability_report_only": true,
+    "writes_files": false,
+    "emits_command_descriptors": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The reachability report is display data only. It does not write files, apply
 refactors, generate patches, run validation, execute shell commands, emit
 command argv, invoke `pccx-lab`, invoke the launcher, call providers, touch
 hardware, upload telemetry, or perform automatic repository actions.

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -393,6 +393,25 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    module_reachability_cmd = sub.add_parser(
+        "module-reachability",
+        help=(
+            "Render scanner-based read-only transitive module reachability "
+            "report data."
+        ),
+    )
+    module_reachability_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    module_reachability_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     module_fanout_cmd = sub.add_parser(
         "module-fanout",
         help=(
@@ -1512,6 +1531,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_edge_report_text(report))
+        return 0
+
+    if args.command == "module-reachability":
+        from .module_organization import (
+            build_module_reachability_report,
+            format_module_reachability_report_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        report = build_module_reachability_report(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(report, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_reachability_report_text(report))
         return 0
 
     if args.command == "module-fanout":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -219,6 +219,18 @@ MODULE_EDGE_REPORT_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+MODULE_REACHABILITY_REPORT_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based module reachability report only",
+    "uses resolved direct instantiation edges from the organization scanner",
+    "reports transitive dependency and dependent names only",
+    "single-line instantiation candidates only",
+    "unresolved instantiation candidates block reachability review readiness",
+    "no semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
+    "does not apply refactors, write files, generate patches, or run validation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 MODULE_FANOUT_REPORT_LIMITATIONS: tuple[str, ...] = (
     "scanner-based module fanout report only",
     "uses resolved direct dependency edges from the organization scanner",
@@ -711,6 +723,28 @@ def _module_edge_report_safety_flags() -> dict[str, bool]:
     return {
         "read_only": True,
         "edge_report_only": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _module_reachability_report_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "reachability_report_only": True,
         "emits_command_descriptors": False,
         "writes_files": False,
         "moves_files": False,
@@ -2925,6 +2959,204 @@ def build_module_edge_report(source: str, path: Path) -> dict[str, Any]:
             edge["child"]
             for edge in unresolved_edges
         }),
+        "writes_files": False,
+    }
+
+
+def _reachable_names(
+    start: str,
+    adjacency: dict[str, set[str]],
+) -> tuple[list[str], list[str]]:
+    reachable: set[str] = set()
+    cycle_markers: set[str] = set()
+
+    def visit(current: str, stack: tuple[str, ...]) -> None:
+        for child in sorted(adjacency.get(current, set())):
+            if child == start or child in stack:
+                cycle_markers.add(child)
+                continue
+            if child in reachable:
+                continue
+            reachable.add(child)
+            visit(child, (*stack, child))
+
+    visit(start, (start,))
+    return sorted(reachable), sorted(cycle_markers)
+
+
+def _module_reachability_rows(
+    modules: list[dict[str, Any]],
+    hierarchy: dict[str, Any],
+) -> list[dict[str, Any]]:
+    modules_by_name: dict[str, dict[str, Any]] = {}
+    declaration_counts: dict[str, int] = {}
+    for module in modules:
+        modules_by_name.setdefault(module["name"], module)
+        declaration_counts[module["name"]] = (
+            declaration_counts.get(module["name"], 0) + 1
+        )
+
+    module_names = sorted(modules_by_name)
+    adjacency: dict[str, set[str]] = {
+        name: set()
+        for name in module_names
+    }
+    reverse_adjacency: dict[str, set[str]] = {
+        name: set()
+        for name in module_names
+    }
+    unresolved_by_module: dict[str, set[str]] = {
+        name: set()
+        for name in module_names
+    }
+
+    for edge in hierarchy["edges"]:
+        parent = edge["parent"]
+        child = edge["child"]
+        if parent not in modules_by_name:
+            continue
+        if edge["resolved"] and child in modules_by_name:
+            adjacency.setdefault(parent, set()).add(child)
+            reverse_adjacency.setdefault(child, set()).add(parent)
+        elif not edge["resolved"]:
+            unresolved_by_module.setdefault(parent, set()).add(child)
+
+    rows: list[dict[str, Any]] = []
+    for module_name in module_names:
+        module = modules_by_name[module_name]
+        direct_dependencies = sorted(adjacency.get(module_name, set()))
+        direct_dependents = sorted(reverse_adjacency.get(module_name, set()))
+        transitive_dependencies, dependency_cycles = _reachable_names(
+            module_name,
+            adjacency,
+        )
+        transitive_dependents, dependent_cycles = _reachable_names(
+            module_name,
+            reverse_adjacency,
+        )
+        unresolved_dependencies = sorted(unresolved_by_module.get(module_name, set()))
+        blocked_reasons: list[str] = []
+        if not module["complete"]:
+            blocked_reasons.append(f"module boundary is incomplete: {module_name}")
+        if declaration_counts[module_name] > 1:
+            blocked_reasons.append(f"ambiguous module name: {module_name}")
+        if unresolved_dependencies:
+            blocked_reasons.append(
+                "unresolved dependencies for reachability report: "
+                f"{', '.join(unresolved_dependencies)}"
+            )
+        if dependency_cycles or dependent_cycles:
+            blocked_reasons.append(
+                "cycle encountered during reachability review: "
+                f"{module_name}"
+            )
+        has_reachability = bool(transitive_dependencies or transitive_dependents)
+        rows.append({
+            "blocked_reasons": blocked_reasons,
+            "complete": module["complete"],
+            "declaration_count": declaration_counts[module_name],
+            "dependency_cycle_markers": dependency_cycles,
+            "dependent_cycle_markers": dependent_cycles,
+            "direct_dependencies": direct_dependencies,
+            "direct_dependency_count": len(direct_dependencies),
+            "direct_dependents": direct_dependents,
+            "direct_dependent_count": len(direct_dependents),
+            "file": module["file"],
+            "name": module_name,
+            "reachability_state": (
+                "has-reachable-modules"
+                if has_reachability
+                else "no-reachable-modules"
+            ),
+            "reason": "scanner-detected transitive module reachability",
+            "refactor_preflight_state": (
+                "blocked" if blocked_reasons else "ready-for-review"
+            ),
+            "start_column": module["start_column"],
+            "start_line": module["start_line"],
+            "transitive_dependencies": transitive_dependencies,
+            "transitive_dependency_count": len(transitive_dependencies),
+            "transitive_dependents": transitive_dependents,
+            "transitive_dependent_count": len(transitive_dependents),
+            "unresolved_dependencies": unresolved_dependencies,
+            "unresolved_dependency_count": len(unresolved_dependencies),
+        })
+    return rows
+
+
+def build_module_reachability_report(source: str, path: Path) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    hierarchy = organization["hierarchy"]
+    resolved_edge_count = len([
+        edge
+        for edge in hierarchy["edges"]
+        if edge["resolved"]
+    ])
+    rows = _module_reachability_rows(modules, hierarchy)
+    reachable_rows = [
+        row
+        for row in rows
+        if (
+            row["transitive_dependency_count"]
+            or row["transitive_dependent_count"]
+        )
+    ]
+    blocked_rows = [
+        row
+        for row in rows
+        if row["blocked_reasons"]
+    ]
+    blocked_reasons = list(dict.fromkeys([
+        reason
+        for row in blocked_rows
+        for reason in row["blocked_reasons"]
+    ]))
+    if modules and not reachable_rows and not blocked_reasons:
+        blocked_reasons.append("no reachable module links detected")
+    if not modules:
+        blocked_reasons.append("no module declarations detected")
+
+    if blocked_rows and reachable_rows:
+        report_state = "reachability-detected-with-blockers"
+    elif blocked_rows:
+        report_state = "blocked"
+    elif reachable_rows:
+        report_state = "reachability-detected"
+    else:
+        report_state = "no-reachability-detected"
+
+    return {
+        "blocked_module_count": len(blocked_rows),
+        "blocked_reasons": blocked_reasons,
+        "edge_count": len(hierarchy["edges"]),
+        "kind": "module-reachability-report",
+        "limitations": list(MODULE_REACHABILITY_REPORT_LIMITATIONS),
+        "max_transitive_dependency_count": max(
+            (row["transitive_dependency_count"] for row in rows),
+            default=0,
+        ),
+        "max_transitive_dependent_count": max(
+            (row["transitive_dependent_count"] for row in rows),
+            default=0,
+        ),
+        "module_count": len(modules),
+        "modules": rows,
+        "next_required_action": (
+            "resolve reachability blockers before refactor planning"
+            if blocked_rows
+            else "review scanner-detected transitive reachability before refactor planning"
+            if reachable_rows
+            else "continue module organization review"
+        ),
+        "reachable_module_count": len(reachable_rows),
+        "report_state": report_state,
+        "resolved_edge_count": resolved_edge_count,
+        "safety": _module_reachability_report_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "tool": "pccx-ide-cli",
+        "unresolved_edge_count": len(hierarchy["edges"]) - resolved_edge_count,
         "writes_files": False,
     }
 
@@ -6114,6 +6346,55 @@ def format_module_edge_report_text(report: dict[str, Any]) -> str:
     lines.append(f"next: {report['next_required_action']}")
     lines.append(
         "read-only edge report: no command argv, validation, shell, "
+        "refactor, patch, file write, lab, launcher, vendor tool, provider, "
+        "or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_module_reachability_report_text(report: dict[str, Any]) -> str:
+    lines = [
+        f"source: {report['source']}",
+        f"module reachability: {report['report_state']}",
+        f"{report['module_count']} module"
+        f"{'s' if report['module_count'] != 1 else ''}",
+        f"{report['reachable_module_count']} reachable module"
+        f"{'s' if report['reachable_module_count'] != 1 else ''}",
+        (
+            f"max transitive dependencies: "
+            f"{report['max_transitive_dependency_count']}; "
+            f"max transitive dependents: "
+            f"{report['max_transitive_dependent_count']}"
+        ),
+    ]
+    if not report["modules"]:
+        lines.append("modules: none")
+    for module in report["modules"]:
+        dependencies = ", ".join(module["transitive_dependencies"]) or "none"
+        dependents = ", ".join(module["transitive_dependents"]) or "none"
+        direct_dependencies = ", ".join(module["direct_dependencies"]) or "none"
+        direct_dependents = ", ".join(module["direct_dependents"]) or "none"
+        unresolved = ", ".join(module["unresolved_dependencies"]) or "none"
+        lines.append(
+            f"{module['file']}:{module['start_line']}: "
+            f"module {module['name']} ({module['refactor_preflight_state']})"
+        )
+        lines.append(
+            f"  transitive_dependencies={dependencies}; "
+            f"transitive_dependents={dependents}"
+        )
+        lines.append(
+            f"  direct_dependencies={direct_dependencies}; "
+            f"direct_dependents={direct_dependents}; unresolved={unresolved}; "
+            f"reason={module['reason']}"
+        )
+        for reason in module["blocked_reasons"]:
+            lines.append(f"  blocked: {reason}")
+    for reason in report["blocked_reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"next: {report['next_required_action']}")
+    lines.append(
+        "read-only reachability report: no command argv, validation, shell, "
         "refactor, patch, file write, lab, launcher, vendor tool, provider, "
         "or hardware execution"
     )

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -40,6 +40,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_organization_export,
     build_module_path_report,
     build_module_port_usage_view,
+    build_module_reachability_report,
     build_module_root_candidate_report,
     build_module_summary_view,
     build_module_unresolved_instance_report,
@@ -77,6 +78,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_module_organization_text,
     format_module_path_report_text,
     format_module_port_usage_text,
+    format_module_reachability_report_text,
     format_module_root_candidate_report_text,
     format_module_summary_text,
     format_module_unresolved_instance_report_text,
@@ -1057,6 +1059,94 @@ def test_build_module_edge_report_blocks_when_no_modules_detected():
     assert report["report_state"] == "no-edges-detected"
     assert report["edge_count"] == 0
     assert report["edges"] == []
+    assert report["blocked_reasons"] == ["no module declarations detected"]
+    assert report["next_required_action"] == "continue module organization review"
+
+
+def test_build_module_reachability_report_lists_transitive_links():
+    report = build_module_reachability_report(str(FANOUT_FIXTURE), FANOUT_FIXTURE)
+
+    assert report["kind"] == "module-reachability-report"
+    assert report["report_state"] == "reachability-detected"
+    assert report["module_count"] == 4
+    assert report["edge_count"] == 3
+    assert report["resolved_edge_count"] == 3
+    assert report["unresolved_edge_count"] == 0
+    assert report["reachable_module_count"] == 4
+    assert report["blocked_module_count"] == 0
+    assert report["max_transitive_dependency_count"] == 3
+    assert report["max_transitive_dependent_count"] == 2
+    assert report["blocked_reasons"] == []
+    assert report["next_required_action"] == (
+        "review scanner-detected transitive reachability before refactor planning"
+    )
+    modules = {module["name"]: module for module in report["modules"]}
+    top = modules["fanout_top"]
+    assert top["direct_dependencies"] == ["fanout_child_a", "fanout_child_b"]
+    assert top["transitive_dependencies"] == [
+        "fanout_child_a",
+        "fanout_child_b",
+        "fanout_leaf",
+    ]
+    assert top["transitive_dependents"] == []
+    assert top["reachability_state"] == "has-reachable-modules"
+    assert top["refactor_preflight_state"] == "ready-for-review"
+    leaf = modules["fanout_leaf"]
+    assert leaf["direct_dependencies"] == []
+    assert leaf["direct_dependents"] == ["fanout_child_a"]
+    assert leaf["transitive_dependencies"] == []
+    assert leaf["transitive_dependents"] == [
+        "fanout_child_a",
+        "fanout_top",
+    ]
+    assert report["safety"]["read_only"] is True
+    assert report["safety"]["reachability_report_only"] is True
+    assert report["safety"]["emits_command_descriptors"] is False
+    assert report["safety"]["writes_files"] is False
+    assert report["safety"]["applies_refactor"] is False
+    assert report["safety"]["generates_patch"] is False
+    assert report["safety"]["runs_validation"] is False
+    assert report["safety"]["runs_shell"] is False
+    assert report["safety"]["invokes_pccx_lab"] is False
+    assert report["safety"]["invokes_launcher"] is False
+    assert report["safety"]["invokes_vendor_tools"] is False
+    assert report["safety"]["provider_calls"] is False
+    assert report["safety"]["hardware_access"] is False
+    assert report["writes_files"] is False
+    assert '"argv"' not in json.dumps(report)
+
+
+def test_build_module_reachability_report_marks_unresolved_edges_blocked():
+    report = build_module_reachability_report(
+        str(UNRESOLVED_FIXTURE),
+        UNRESOLVED_FIXTURE,
+    )
+
+    assert report["report_state"] == "blocked"
+    assert report["reachable_module_count"] == 0
+    assert report["blocked_module_count"] == 1
+    assert report["blocked_reasons"] == [
+        "unresolved dependencies for reachability report: missing_child"
+    ]
+    module = report["modules"][0]
+    assert module["name"] == "unresolved_top"
+    assert module["transitive_dependencies"] == []
+    assert module["transitive_dependents"] == []
+    assert module["unresolved_dependencies"] == ["missing_child"]
+    assert module["refactor_preflight_state"] == "blocked"
+    assert module["blocked_reasons"] == report["blocked_reasons"]
+    assert report["next_required_action"] == (
+        "resolve reachability blockers before refactor planning"
+    )
+
+
+def test_build_module_reachability_report_blocks_when_no_modules_detected():
+    empty_fixture = REPO_ROOT / "fixtures" / "empty.sv"
+    report = build_module_reachability_report(str(empty_fixture), empty_fixture)
+
+    assert report["report_state"] == "no-reachability-detected"
+    assert report["reachable_module_count"] == 0
+    assert report["modules"] == []
     assert report["blocked_reasons"] == ["no module declarations detected"]
     assert report["next_required_action"] == "continue module organization review"
 
@@ -2348,6 +2438,21 @@ def test_format_module_edge_report_text_mentions_boundary():
     assert "read-only edge report: no command argv" in text
 
 
+def test_format_module_reachability_report_text_mentions_boundary():
+    report = build_module_reachability_report(str(FANOUT_FIXTURE), FANOUT_FIXTURE)
+    text = format_module_reachability_report_text(report)
+
+    assert "module reachability: reachability-detected" in text
+    assert "4 reachable modules" in text
+    assert "max transitive dependencies: 3; max transitive dependents: 2" in text
+    assert "module fanout_top (ready-for-review)" in text
+    assert (
+        "transitive_dependencies=fanout_child_a, fanout_child_b, fanout_leaf"
+        in text
+    )
+    assert "read-only reachability report: no command argv" in text
+
+
 def test_format_module_fanin_report_text_mentions_boundary():
     report = build_module_fanin_report(str(FANOUT_FIXTURE), FANOUT_FIXTURE)
     text = format_module_fanin_report_text(report)
@@ -2945,6 +3050,34 @@ def test_cli_module_edges_text():
     assert "module edges: edges-detected" in result.stdout
     assert "edge-1: fanout_child_a -> fanout_leaf as u_leaf" in result.stdout
     assert "read-only edge report: no command argv" in result.stdout
+
+
+def test_cli_module_reachability_json():
+    result = _run_cli("module-reachability", str(FANOUT_FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-reachability-report"
+    assert payload["report_state"] == "reachability-detected"
+    assert payload["reachable_module_count"] == 4
+    assert payload["max_transitive_dependency_count"] == 3
+    modules = {module["name"]: module for module in payload["modules"]}
+    assert modules["fanout_top"]["transitive_dependencies"] == [
+        "fanout_child_a",
+        "fanout_child_b",
+        "fanout_leaf",
+    ]
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["emits_command_descriptors"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_module_reachability_text():
+    result = _run_cli("module-reachability", str(FANOUT_FIXTURE), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "module reachability: reachability-detected" in result.stdout
+    assert "module fanout_top (ready-for-review)" in result.stdout
+    assert "read-only reachability report: no command argv" in result.stdout
 
 
 def test_cli_module_fanout_json():
@@ -3659,6 +3792,12 @@ def test_cli_module_edges_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_module_reachability_missing_path_exits_nonzero():
+    result = _run_cli("module-reachability", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_cli_module_fanout_missing_path_exits_nonzero():
     result = _run_cli("module-fanout", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
@@ -3847,6 +3986,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-depths <path>" in contract
     assert "module-paths <path>" in contract
     assert "module-edges <path>" in contract
+    assert "module-reachability <path>" in contract
     assert "module-fanout <path>" in contract
     assert "module-fanin <path>" in contract
     assert "module-health <path>" in contract
@@ -3877,6 +4017,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-depth-report" in workflow
     assert "module-path-report" in workflow
     assert "module-edge-report" in workflow
+    assert "module-reachability-report" in workflow
     assert "module-fanout-report" in workflow
     assert "module-fanin-report" in workflow
     assert "module-graph-health-summary" in workflow


### PR DESCRIPTION
## Summary
- add a read-only module-reachability CLI/report for scanner-derived transitive dependency and dependent names
- mark unresolved dependencies, cycles, duplicate names, and incomplete declarations as blockers before refactor planning
- document the report and add CI/test coverage

Refs pccxai/systemverilog-ide#8

## Validation
- python3 -m compileall -q src tests
- PYTHONPATH=src python3 -m pccx_ide_cli module-reachability fixtures/organization/fanout_hierarchy.sv --format json
- PYTHONPATH=src python3 -m pccx_ide_cli module-reachability fixtures/organization/fanout_hierarchy.sv --format text
- PYTHONPATH=src python3 -m pccx_ide_cli module-reachability fixtures/organization/unresolved_instances.sv --format json
- python3 -m pytest tests/test_module_organization.py -q
- python3 -m pytest -q
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- bash scripts/vscode-adapter-smoke.sh
- git diff --check
- python3 -m pytest tests/test_repository_hygiene.py -q
- python3 -m pytest tests/test_editor_bridge_examples.py -q
- local workflow claim-scan logic