### PR TITLE
Add module order report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,13 @@ jobs:
               fixtures/organization/fanout_hierarchy.sv \
               | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-reachability-report'; assert d['safety']['writes_files'] is False; assert d['safety']['emits_command_descriptors'] is False"
           echo "module reachability smoke ok"
+      - name: cli smoke (module order exits zero)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli module-order \
+              fixtures/organization/fanout_hierarchy.sv \
+              | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-order-report'; assert d['safety']['writes_files'] is False; assert d['safety']['emits_command_descriptors'] is False"
+          echo "module order smoke ok"
       - name: cli smoke (module summary exits zero)
         run: |
           set -e

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ python -m pccx_ide_cli module-depths fixtures/organization/hierarchy_top.sv --fo
 python -m pccx_ide_cli module-paths fixtures/organization/fanout_hierarchy.sv --format json
 python -m pccx_ide_cli module-edges fixtures/organization/fanout_hierarchy.sv --format json
 python -m pccx_ide_cli module-reachability fixtures/organization/fanout_hierarchy.sv --format json
+python -m pccx_ide_cli module-order fixtures/organization/fanout_hierarchy.sv --format json
 python -m pccx_ide_cli module-fanout fixtures/organization/fanout_hierarchy.sv --format json
 python -m pccx_ide_cli module-fanin fixtures/organization/fanout_hierarchy.sv --format json
 python -m pccx_ide_cli module-health fixtures/organization/hierarchy_top.sv --format json
@@ -245,6 +246,8 @@ blocked unresolved path terminals for path review.
 blocked unresolved targets, for dependency edge review.
 `module-reachability` reports scanner-detected transitive dependency and
 dependent names for reachability review.
+`module-order` lists a scanner-detected dependency-first module review order
+and blocks unresolved or cyclic order readiness.
 `module-fanout` ranks scanner-detected modules by resolved direct dependency
 count for fanout review.
 `module-fanin` ranks scanner-detected modules by resolved direct dependent

--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -59,6 +59,7 @@ python -m pccx_ide_cli module-depths <path> --format json
 python -m pccx_ide_cli module-paths <path> --format json
 python -m pccx_ide_cli module-edges <path> --format json
 python -m pccx_ide_cli module-reachability <path> --format json
+python -m pccx_ide_cli module-order <path> --format json
 python -m pccx_ide_cli module-fanout <path> --format json
 python -m pccx_ide_cli module-fanin <path> --format json
 python -m pccx_ide_cli module-health <path> --format json
@@ -221,7 +222,8 @@ invoke pccx-lab or the launcher, run vendor tools, call providers, touch
 hardware, or perform automatic repository actions. `hierarchy`,
 `dependencies`, `hierarchy-cycles`, `unresolved-instances`, `module-roots`,
 `module-leaves`, `module-orphans`, `module-depths`, `module-paths`,
-`module-edges`, `module-reachability`, `module-fanout`, `module-fanin`,
+`module-edges`, `module-reachability`, `module-order`, `module-fanout`,
+`module-fanin`,
 `module-health`,
 `module-summary`, `port-usage`, `module-context`, and `refactor-impact`
 render focused read-only views from the same scanner data, including
@@ -229,7 +231,7 @@ hierarchy cycle warnings, unresolved instantiation warnings, root-candidate
 summaries, leaf-candidate summaries, orphan-candidate summaries,
 depth-level summaries,
 hierarchy path reports, direct dependency edge reports, reachability reports,
-fanout rankings, fanin rankings,
+dependency-first order reports, fanout rankings, fanin rankings,
 module graph health summaries,
 conservative module header/port summaries, target port usage summaries,
 target module context bundles, and

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -6,7 +6,7 @@ This is a pre-stable, scanner-based workflow for organizing modular RTL
 projects. It adds read-only `organization`, `hierarchy`, `dependencies`,
 `hierarchy-cycles`, `unresolved-instances`, `module-roots`, `module-leaves`,
 `module-orphans`, `module-depths`, `module-paths`, `module-edges`,
-`module-reachability`, `module-fanout`, `module-fanin`,
+`module-reachability`, `module-order`, `module-fanout`, `module-fanin`,
 `module-health`,
 `module-summary`,
 `boundary-audit`, `module-duplicates`, `refactor-candidates`, `port-usage`,
@@ -20,6 +20,7 @@ report metadata, unresolved instantiation report metadata, root-candidate
 report metadata, leaf-candidate report metadata, orphan-candidate report
 metadata, depth-level report metadata, hierarchy path report metadata,
 `module-edge-report` metadata, `module-reachability-report` metadata,
+`module-order-report` metadata,
 `module-fanout-report` metadata,
 `module-fanin-report` metadata,
 module graph health summary metadata,
@@ -62,6 +63,8 @@ python -m pccx_ide_cli module-edges <path> --format json
 python -m pccx_ide_cli module-edges <path> --format text
 python -m pccx_ide_cli module-reachability <path> --format json
 python -m pccx_ide_cli module-reachability <path> --format text
+python -m pccx_ide_cli module-order <path> --format json
+python -m pccx_ide_cli module-order <path> --format text
 python -m pccx_ide_cli module-fanout <path> --format json
 python -m pccx_ide_cli module-fanout <path> --format text
 python -m pccx_ide_cli module-fanin <path> --format json
@@ -537,6 +540,51 @@ The reachability report is display data only. It does not write files, apply
 refactors, generate patches, run validation, execute shell commands, emit
 command argv, invoke `pccx-lab`, invoke the launcher, call providers, touch
 hardware, upload telemetry, or perform automatic repository actions.
+
+The module order report summarizes a dependency-first module review order from
+resolved scanner edges:
+
+```json
+{
+  "kind": "module-order-report",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "report_state": "order-detected",
+  "order_direction": "dependency-first",
+  "ordered_module_names": [
+    "fanout_child_b",
+    "fanout_leaf",
+    "fanout_child_a",
+    "fanout_top"
+  ],
+  "max_dependency_level": 2,
+  "modules": [
+    {
+      "name": "fanout_top",
+      "order_index": 4,
+      "dependency_level": 2,
+      "direct_dependencies": ["fanout_child_a", "fanout_child_b"]
+    }
+  ],
+  "safety": {
+    "read_only": true,
+    "order_report_only": true,
+    "writes_files": false,
+    "emits_command_descriptors": false,
+    "runs_validation": false,
+    "runs_build": false,
+    "runs_compile": false
+  },
+  "limitations": []
+}
+```
+
+The module order report is display data only. It does not write files, apply
+refactors, generate patches, run validation, run builds or compilers, execute
+shell commands, emit command argv, invoke `pccx-lab`, invoke the launcher, call
+providers, touch hardware, upload telemetry, or perform automatic repository
+actions.
 
 The fanin report ranks modules by scanner-detected resolved direct dependents:
 

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -412,6 +412,25 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    module_order_cmd = sub.add_parser(
+        "module-order",
+        help=(
+            "Render scanner-based read-only dependency-first module order "
+            "report data."
+        ),
+    )
+    module_order_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    module_order_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     module_fanout_cmd = sub.add_parser(
         "module-fanout",
         help=(
@@ -1549,6 +1568,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_reachability_report_text(report))
+        return 0
+
+    if args.command == "module-order":
+        from .module_organization import (
+            build_module_order_report,
+            format_module_order_report_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        report = build_module_order_report(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(report, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_order_report_text(report))
         return 0
 
     if args.command == "module-fanout":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -231,6 +231,19 @@ MODULE_REACHABILITY_REPORT_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+MODULE_ORDER_REPORT_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based module dependency order report only",
+    "uses resolved direct instantiation edges from the organization scanner",
+    "reports dependency-first module review order only",
+    "single-line instantiation candidates only",
+    "unresolved instantiation candidates block order review readiness",
+    "cycles block complete dependency-first ordering",
+    "no build, compile, semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
+    "does not apply refactors, write files, generate patches, or run validation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 MODULE_FANOUT_REPORT_LIMITATIONS: tuple[str, ...] = (
     "scanner-based module fanout report only",
     "uses resolved direct dependency edges from the organization scanner",
@@ -753,6 +766,30 @@ def _module_reachability_report_safety_flags() -> dict[str, bool]:
         "generates_patch": False,
         "runs_validation": False,
         "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _module_order_report_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "order_report_only": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "runs_build": False,
+        "runs_compile": False,
         "invokes_pccx_lab": False,
         "invokes_launcher": False,
         "invokes_vendor_tools": False,
@@ -3153,6 +3190,227 @@ def build_module_reachability_report(source: str, path: Path) -> dict[str, Any]:
         "report_state": report_state,
         "resolved_edge_count": resolved_edge_count,
         "safety": _module_reachability_report_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "tool": "pccx-ide-cli",
+        "unresolved_edge_count": len(hierarchy["edges"]) - resolved_edge_count,
+        "writes_files": False,
+    }
+
+
+def _module_order_rows(
+    modules: list[dict[str, Any]],
+    hierarchy: dict[str, Any],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    modules_by_name: dict[str, dict[str, Any]] = {}
+    declaration_counts: dict[str, int] = {}
+    for module in modules:
+        modules_by_name.setdefault(module["name"], module)
+        declaration_counts[module["name"]] = (
+            declaration_counts.get(module["name"], 0) + 1
+        )
+
+    module_names = sorted(modules_by_name)
+    dependencies_by_module: dict[str, set[str]] = {
+        name: set()
+        for name in module_names
+    }
+    dependents_by_module: dict[str, set[str]] = {
+        name: set()
+        for name in module_names
+    }
+    unresolved_by_module: dict[str, set[str]] = {
+        name: set()
+        for name in module_names
+    }
+
+    for edge in hierarchy["edges"]:
+        parent = edge["parent"]
+        child = edge["child"]
+        if parent not in modules_by_name:
+            continue
+        if edge["resolved"] and child in modules_by_name:
+            dependencies_by_module.setdefault(parent, set()).add(child)
+            dependents_by_module.setdefault(child, set()).add(parent)
+        elif not edge["resolved"]:
+            unresolved_by_module.setdefault(parent, set()).add(child)
+
+    remaining_dependency_count = {
+        name: len(dependencies_by_module.get(name, set()))
+        for name in module_names
+    }
+    dependency_levels = {
+        name: 0
+        for name in module_names
+    }
+    ready = sorted(
+        name
+        for name, count in remaining_dependency_count.items()
+        if count == 0
+    )
+    ordered_names: list[str] = []
+    while ready:
+        current = ready.pop(0)
+        ordered_names.append(current)
+        for dependent in sorted(dependents_by_module.get(current, set())):
+            remaining_dependency_count[dependent] -= 1
+            dependency_levels[dependent] = max(
+                dependency_levels[dependent],
+                dependency_levels[current] + 1,
+            )
+            if remaining_dependency_count[dependent] == 0:
+                ready.append(dependent)
+                ready.sort()
+
+    order_index_by_name = {
+        name: index
+        for index, name in enumerate(ordered_names, start=1)
+    }
+    cycle_names = sorted(
+        name
+        for name, count in remaining_dependency_count.items()
+        if count > 0
+    )
+
+    rows: list[dict[str, Any]] = []
+    for module_name in module_names:
+        module = modules_by_name[module_name]
+        direct_dependencies = sorted(dependencies_by_module.get(module_name, set()))
+        direct_dependents = sorted(dependents_by_module.get(module_name, set()))
+        unresolved_dependencies = sorted(unresolved_by_module.get(module_name, set()))
+        blocked_reasons: list[str] = []
+        if not module["complete"]:
+            blocked_reasons.append(f"module boundary is incomplete: {module_name}")
+        if declaration_counts[module_name] > 1:
+            blocked_reasons.append(f"ambiguous module name: {module_name}")
+        if unresolved_dependencies:
+            blocked_reasons.append(
+                "unresolved dependencies for order report: "
+                f"{', '.join(unresolved_dependencies)}"
+            )
+        if module_name in cycle_names:
+            blocked_reasons.append(
+                f"cycle blocks dependency order: {module_name}"
+            )
+        order_index = order_index_by_name.get(module_name)
+        if order_index is None:
+            order_state = "blocked-cycle"
+        elif blocked_reasons:
+            order_state = "ordered-with-blockers"
+        else:
+            order_state = "ordered"
+        rows.append({
+            "blocked_reasons": blocked_reasons,
+            "complete": module["complete"],
+            "declaration_count": declaration_counts[module_name],
+            "dependency_level": (
+                dependency_levels[module_name]
+                if order_index is not None
+                else None
+            ),
+            "direct_dependencies": direct_dependencies,
+            "direct_dependency_count": len(direct_dependencies),
+            "direct_dependents": direct_dependents,
+            "direct_dependent_count": len(direct_dependents),
+            "file": module["file"],
+            "name": module_name,
+            "order_index": order_index,
+            "order_state": order_state,
+            "reason": "scanner-detected dependency-first module order",
+            "refactor_preflight_state": (
+                "blocked" if blocked_reasons else "ready-for-review"
+            ),
+            "start_column": module["start_column"],
+            "start_line": module["start_line"],
+            "unresolved_dependencies": unresolved_dependencies,
+            "unresolved_dependency_count": len(unresolved_dependencies),
+        })
+
+    rows.sort(key=lambda row: (
+        row["order_index"] is None,
+        row["order_index"] or 0,
+        row["name"],
+    ))
+    return rows, cycle_names
+
+
+def build_module_order_report(source: str, path: Path) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    hierarchy = organization["hierarchy"]
+    resolved_edge_count = len([
+        edge
+        for edge in hierarchy["edges"]
+        if edge["resolved"]
+    ])
+    rows, cycle_names = _module_order_rows(modules, hierarchy)
+    ordered_rows = [
+        row
+        for row in rows
+        if row["order_index"] is not None
+    ]
+    ready_rows = [
+        row
+        for row in ordered_rows
+        if not row["blocked_reasons"]
+    ]
+    blocked_rows = [
+        row
+        for row in rows
+        if row["blocked_reasons"]
+    ]
+    blocked_reasons = list(dict.fromkeys([
+        reason
+        for row in blocked_rows
+        for reason in row["blocked_reasons"]
+    ]))
+    if not modules:
+        blocked_reasons.append("no module declarations detected")
+
+    if blocked_rows and ready_rows:
+        report_state = "order-detected-with-blockers"
+    elif blocked_rows:
+        report_state = "blocked"
+    elif ordered_rows:
+        report_state = "order-detected"
+    else:
+        report_state = "no-order-detected"
+
+    return {
+        "blocked_module_count": len(blocked_rows),
+        "blocked_reasons": blocked_reasons,
+        "cycle_module_count": len(cycle_names),
+        "cycle_module_names": cycle_names,
+        "edge_count": len(hierarchy["edges"]),
+        "kind": "module-order-report",
+        "limitations": list(MODULE_ORDER_REPORT_LIMITATIONS),
+        "max_dependency_level": max(
+            (
+                row["dependency_level"]
+                for row in ordered_rows
+                if row["dependency_level"] is not None
+            ),
+            default=0,
+        ),
+        "module_count": len(modules),
+        "modules": rows,
+        "next_required_action": (
+            "resolve dependency order blockers before refactor planning"
+            if blocked_rows
+            else "review scanner-detected dependency order before refactor planning"
+            if ordered_rows
+            else "continue module organization review"
+        ),
+        "order_direction": "dependency-first",
+        "ordered_module_count": len(ordered_rows),
+        "ordered_module_names": [
+            row["name"]
+            for row in ordered_rows
+        ],
+        "ready_module_count": len(ready_rows),
+        "report_state": report_state,
+        "resolved_edge_count": resolved_edge_count,
+        "safety": _module_order_report_safety_flags(),
         "scanner": "line-scanner",
         "source": source,
         "tool": "pccx-ide-cli",
@@ -6397,6 +6655,58 @@ def format_module_reachability_report_text(report: dict[str, Any]) -> str:
         "read-only reachability report: no command argv, validation, shell, "
         "refactor, patch, file write, lab, launcher, vendor tool, provider, "
         "or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_module_order_report_text(report: dict[str, Any]) -> str:
+    lines = [
+        f"source: {report['source']}",
+        f"module order: {report['report_state']}",
+        f"order direction: {report['order_direction']}",
+        f"{report['module_count']} module"
+        f"{'s' if report['module_count'] != 1 else ''}",
+        f"{report['ordered_module_count']} ordered module"
+        f"{'s' if report['ordered_module_count'] != 1 else ''}",
+        f"max dependency level: {report['max_dependency_level']}",
+    ]
+    if not report["modules"]:
+        lines.append("modules: none")
+    for module in report["modules"]:
+        dependencies = ", ".join(module["direct_dependencies"]) or "none"
+        dependents = ", ".join(module["direct_dependents"]) or "none"
+        unresolved = ", ".join(module["unresolved_dependencies"]) or "none"
+        order_index = (
+            str(module["order_index"])
+            if module["order_index"] is not None
+            else "blocked"
+        )
+        dependency_level = (
+            str(module["dependency_level"])
+            if module["dependency_level"] is not None
+            else "blocked"
+        )
+        lines.append(
+            f"order {order_index}: {module['file']}:{module['start_line']}: "
+            f"module {module['name']} ({module['refactor_preflight_state']})"
+        )
+        lines.append(
+            f"  dependency_level={dependency_level}; "
+            f"state={module['order_state']}; reason={module['reason']}"
+        )
+        lines.append(
+            f"  dependencies={dependencies}; dependents={dependents}; "
+            f"unresolved={unresolved}"
+        )
+        for reason in module["blocked_reasons"]:
+            lines.append(f"  blocked: {reason}")
+    for reason in report["blocked_reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"next: {report['next_required_action']}")
+    lines.append(
+        "read-only order report: no command argv, validation, shell, build, "
+        "compile, refactor, patch, file write, lab, launcher, vendor tool, "
+        "provider, or hardware execution"
     )
     return "\n".join(lines) + "\n"
 

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -38,6 +38,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_leaf_candidate_report,
     build_module_orphan_candidate_report,
     build_module_organization_export,
+    build_module_order_report,
     build_module_path_report,
     build_module_port_usage_view,
     build_module_reachability_report,
@@ -76,6 +77,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_module_leaf_candidate_report_text,
     format_module_orphan_candidate_report_text,
     format_module_organization_text,
+    format_module_order_report_text,
     format_module_path_report_text,
     format_module_port_usage_text,
     format_module_reachability_report_text,
@@ -1146,6 +1148,117 @@ def test_build_module_reachability_report_blocks_when_no_modules_detected():
 
     assert report["report_state"] == "no-reachability-detected"
     assert report["reachable_module_count"] == 0
+    assert report["modules"] == []
+    assert report["blocked_reasons"] == ["no module declarations detected"]
+    assert report["next_required_action"] == "continue module organization review"
+
+
+def test_build_module_order_report_lists_dependency_first_order():
+    report = build_module_order_report(str(FANOUT_FIXTURE), FANOUT_FIXTURE)
+
+    assert report["kind"] == "module-order-report"
+    assert report["report_state"] == "order-detected"
+    assert report["module_count"] == 4
+    assert report["edge_count"] == 3
+    assert report["resolved_edge_count"] == 3
+    assert report["unresolved_edge_count"] == 0
+    assert report["ordered_module_count"] == 4
+    assert report["ready_module_count"] == 4
+    assert report["blocked_module_count"] == 0
+    assert report["cycle_module_count"] == 0
+    assert report["max_dependency_level"] == 2
+    assert report["order_direction"] == "dependency-first"
+    assert report["ordered_module_names"] == [
+        "fanout_child_b",
+        "fanout_leaf",
+        "fanout_child_a",
+        "fanout_top",
+    ]
+    assert report["blocked_reasons"] == []
+    assert report["next_required_action"] == (
+        "review scanner-detected dependency order before refactor planning"
+    )
+    modules = {module["name"]: module for module in report["modules"]}
+    assert modules["fanout_child_b"]["order_index"] == 1
+    assert modules["fanout_child_b"]["dependency_level"] == 0
+    assert modules["fanout_leaf"]["order_index"] == 2
+    assert modules["fanout_leaf"]["dependency_level"] == 0
+    assert modules["fanout_child_a"]["order_index"] == 3
+    assert modules["fanout_child_a"]["dependency_level"] == 1
+    top = modules["fanout_top"]
+    assert top["order_index"] == 4
+    assert top["dependency_level"] == 2
+    assert top["direct_dependencies"] == ["fanout_child_a", "fanout_child_b"]
+    assert top["direct_dependents"] == []
+    assert top["order_state"] == "ordered"
+    assert top["refactor_preflight_state"] == "ready-for-review"
+    assert report["safety"]["read_only"] is True
+    assert report["safety"]["order_report_only"] is True
+    assert report["safety"]["emits_command_descriptors"] is False
+    assert report["safety"]["writes_files"] is False
+    assert report["safety"]["applies_refactor"] is False
+    assert report["safety"]["generates_patch"] is False
+    assert report["safety"]["runs_validation"] is False
+    assert report["safety"]["runs_shell"] is False
+    assert report["safety"]["runs_build"] is False
+    assert report["safety"]["runs_compile"] is False
+    assert report["safety"]["invokes_pccx_lab"] is False
+    assert report["safety"]["invokes_launcher"] is False
+    assert report["safety"]["invokes_vendor_tools"] is False
+    assert report["safety"]["provider_calls"] is False
+    assert report["safety"]["hardware_access"] is False
+    assert report["writes_files"] is False
+    assert '"argv"' not in json.dumps(report)
+
+
+def test_build_module_order_report_marks_unresolved_edges_blocked():
+    report = build_module_order_report(str(UNRESOLVED_FIXTURE), UNRESOLVED_FIXTURE)
+
+    assert report["report_state"] == "blocked"
+    assert report["ordered_module_count"] == 1
+    assert report["ready_module_count"] == 0
+    assert report["blocked_module_count"] == 1
+    assert report["blocked_reasons"] == [
+        "unresolved dependencies for order report: missing_child"
+    ]
+    module = report["modules"][0]
+    assert module["name"] == "unresolved_top"
+    assert module["order_index"] == 1
+    assert module["order_state"] == "ordered-with-blockers"
+    assert module["unresolved_dependencies"] == ["missing_child"]
+    assert module["refactor_preflight_state"] == "blocked"
+    assert module["blocked_reasons"] == report["blocked_reasons"]
+    assert report["next_required_action"] == (
+        "resolve dependency order blockers before refactor planning"
+    )
+
+
+def test_build_module_order_report_blocks_cycles():
+    report = build_module_order_report(str(CYCLIC_FIXTURE), CYCLIC_FIXTURE)
+
+    assert report["report_state"] == "blocked"
+    assert report["ordered_module_count"] == 0
+    assert report["ready_module_count"] == 0
+    assert report["blocked_module_count"] == 2
+    assert report["cycle_module_names"] == ["alpha_mod", "beta_mod"]
+    assert report["cycle_module_count"] == 2
+    modules = {module["name"]: module for module in report["modules"]}
+    assert modules["alpha_mod"]["order_index"] is None
+    assert modules["alpha_mod"]["order_state"] == "blocked-cycle"
+    assert modules["alpha_mod"]["blocked_reasons"] == [
+        "cycle blocks dependency order: alpha_mod"
+    ]
+    assert modules["beta_mod"]["blocked_reasons"] == [
+        "cycle blocks dependency order: beta_mod"
+    ]
+
+
+def test_build_module_order_report_blocks_when_no_modules_detected():
+    empty_fixture = REPO_ROOT / "fixtures" / "empty.sv"
+    report = build_module_order_report(str(empty_fixture), empty_fixture)
+
+    assert report["report_state"] == "no-order-detected"
+    assert report["ordered_module_count"] == 0
     assert report["modules"] == []
     assert report["blocked_reasons"] == ["no module declarations detected"]
     assert report["next_required_action"] == "continue module organization review"
@@ -2453,6 +2566,20 @@ def test_format_module_reachability_report_text_mentions_boundary():
     assert "read-only reachability report: no command argv" in text
 
 
+def test_format_module_order_report_text_mentions_boundary():
+    report = build_module_order_report(str(FANOUT_FIXTURE), FANOUT_FIXTURE)
+    text = format_module_order_report_text(report)
+
+    assert "module order: order-detected" in text
+    assert "order direction: dependency-first" in text
+    assert "4 ordered modules" in text
+    assert "max dependency level: 2" in text
+    assert "order 4:" in text
+    assert "module fanout_top (ready-for-review)" in text
+    assert "dependencies=fanout_child_a, fanout_child_b" in text
+    assert "read-only order report: no command argv" in text
+
+
 def test_format_module_fanin_report_text_mentions_boundary():
     report = build_module_fanin_report(str(FANOUT_FIXTURE), FANOUT_FIXTURE)
     text = format_module_fanin_report_text(report)
@@ -3078,6 +3205,35 @@ def test_cli_module_reachability_text():
     assert "module reachability: reachability-detected" in result.stdout
     assert "module fanout_top (ready-for-review)" in result.stdout
     assert "read-only reachability report: no command argv" in result.stdout
+
+
+def test_cli_module_order_json():
+    result = _run_cli("module-order", str(FANOUT_FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-order-report"
+    assert payload["report_state"] == "order-detected"
+    assert payload["ordered_module_names"] == [
+        "fanout_child_b",
+        "fanout_leaf",
+        "fanout_child_a",
+        "fanout_top",
+    ]
+    assert payload["max_dependency_level"] == 2
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["emits_command_descriptors"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert payload["safety"]["runs_build"] is False
+    assert payload["safety"]["runs_compile"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_module_order_text():
+    result = _run_cli("module-order", str(FANOUT_FIXTURE), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "module order: order-detected" in result.stdout
+    assert "module fanout_top (ready-for-review)" in result.stdout
+    assert "read-only order report: no command argv" in result.stdout
 
 
 def test_cli_module_fanout_json():
@@ -3798,6 +3954,12 @@ def test_cli_module_reachability_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_module_order_missing_path_exits_nonzero():
+    result = _run_cli("module-order", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_cli_module_fanout_missing_path_exits_nonzero():
     result = _run_cli("module-fanout", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
@@ -3987,6 +4149,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-paths <path>" in contract
     assert "module-edges <path>" in contract
     assert "module-reachability <path>" in contract
+    assert "module-order <path>" in contract
     assert "module-fanout <path>" in contract
     assert "module-fanin <path>" in contract
     assert "module-health <path>" in contract
@@ -4018,6 +4181,7 @@ def test_docs_cover_organization_flow_and_limits():
     assert "module-path-report" in workflow
     assert "module-edge-report" in workflow
     assert "module-reachability-report" in workflow
+    assert "module-order-report" in workflow
     assert "module-fanout-report" in workflow
     assert "module-fanin-report" in workflow
     assert "module-graph-health-summary" in workflow


### PR DESCRIPTION
## Summary
- add a read-only module-order CLI/report for scanner-derived dependency-first module review order
- block order readiness on unresolved dependencies, dependency cycles, duplicate declarations, and incomplete module boundaries
- document the report and add CI/test coverage

Refs pccxai/systemverilog-ide#8

## Validation
- python3 -m compileall -q src tests
- PYTHONPATH=src python3 -m pccx_ide_cli module-order fixtures/organization/fanout_hierarchy.sv --format json
- PYTHONPATH=src python3 -m pccx_ide_cli module-order fixtures/organization/cyclic_hierarchy.sv --format json
- PYTHONPATH=src python3 -m pccx_ide_cli module-order fixtures/organization/fanout_hierarchy.sv --format text
- PYTHONPATH=src python3 -m pccx_ide_cli module-order fixtures/organization/unresolved_instances.sv --format json
- python3 -m pytest tests/test_module_organization.py -q
- python3 -m pytest -q
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- bash scripts/vscode-adapter-smoke.sh
- git diff --check
- git diff --cached --check
- python3 -m pytest tests/test_repository_hygiene.py -q
- python3 -m pytest tests/test_editor_bridge_examples.py -q
- local workflow claim-scan logic