### PR TITLE
Add module port connection audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,13 @@ jobs:
               fixtures/organization/hierarchy_top.sv \
               | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-summary-view'; assert d['safety']['writes_files'] is False"
           echo "module summary smoke ok"
+      - name: cli smoke (port connection audit exits zero)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli port-connections \
+              fixtures/organization/port_connection_audit.sv --module child_mod \
+              | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-port-connection-audit'; assert d['safety']['writes_files'] is False; assert d['safety']['emits_command_descriptors'] is False"
+          echo "port connection audit smoke ok"
       - name: cli smoke (boundary audit exits zero)
         run: |
           set -e

--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ python -m pccx_ide_cli refactor-readiness fixtures/organization/hierarchy_top.sv
 python -m pccx_ide_cli port-usage fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
 python -m pccx_ide_cli port-usage fixtures/organization/hierarchy_top.sv --module leaf_mod --format text
 
+# Target port connection audit (pre-stable, read-only)
+python -m pccx_ide_cli port-connections fixtures/organization/port_connection_audit.sv --module child_mod --format json
+python -m pccx_ide_cli port-connections fixtures/organization/port_connection_audit.sv --module child_mod --format text
+
 # Target module context bundle (pre-stable, read-only)
 python -m pccx_ide_cli module-context fixtures/organization/hierarchy_top.sv --module leaf_mod --format json
 python -m pccx_ide_cli module-context fixtures/organization/hierarchy_top.sv --module leaf_mod --format text
@@ -258,9 +262,11 @@ health summary for editor status panes.
 `module-summary` renders conservative module header and port summaries
 for editor sidebars and reviewed refactoring planning. `port-usage`
 renders target port declarations with scanner-detected dependent
-instantiation connection summaries. `module-context` bundles target
-summary, dependency, port-usage, and refactor-impact review data for
-editor context panes. `refactor-candidates` lists scanner-detected
+instantiation connection summaries. `port-connections` compares
+scanner-detected target port names with named instantiation connections
+and flags ordered or wildcard sites for manual review. `module-context`
+bundles target summary, dependency, port-usage, and refactor-impact
+review data for editor context panes. `refactor-candidates` lists scanner-detected
 modules and proposal-only helper action metadata for editor action
 menus. `refactor-readiness` summarizes boundary-audit and candidate
 counts for editor status panes without selecting an action or emitting

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -880,6 +880,57 @@ generate patches, run validation, execute shell commands, invoke
 `pccx-lab`, invoke the launcher, call providers, touch hardware, upload
 telemetry, or perform automatic repository actions.
 
+The port connection audit compares a target module's scanner-detected
+ANSI-style port names with scanner-detected named instantiation
+connections:
+
+```json
+{
+  "kind": "module-port-connection-audit",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "target": "child_mod",
+  "audit_state": "review-required",
+  "ready_for_review": false,
+  "writes_files": false,
+  "declared_port_names": ["clk", "rst_n", "done_o"],
+  "usage_site_count": 4,
+  "ready_site_count": 1,
+  "review_site_count": 3,
+  "missing_named_port_count": 2,
+  "unknown_named_port_count": 1,
+  "usage_sites": [
+    {
+      "parent": "top_mod",
+      "child": "child_mod",
+      "instance": "u_missing",
+      "connection_style": "named",
+      "named_connections": ["clk", "extra_i"],
+      "missing_named_ports": ["rst_n", "done_o"],
+      "unknown_named_ports": ["extra_i"],
+      "semantically_resolved": false
+    }
+  ],
+  "safety": {
+    "read_only": true,
+    "emits_command_descriptors": false,
+    "writes_files": false,
+    "applies_refactor": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The port connection audit is display data only. It does not semantically
+resolve ordered, wildcard, macro, generate-block, or interface/modport
+connections. Ordered and wildcard connection sites are marked for manual
+review. It does not write files, apply refactors, generate patches, run
+validation, execute shell commands, emit command argv, invoke `pccx-lab`,
+invoke the launcher, call providers, touch hardware, upload telemetry, or
+perform automatic repository actions.
+
 The module context bundle combines the existing target-specific view
 outputs into a bounded editor context packet:
 

--- a/fixtures/organization/port_connection_audit.sv
+++ b/fixtures/organization/port_connection_audit.sv
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
+
+module child_mod (
+    input logic clk,
+    input logic rst_n,
+    output logic done_o
+);
+endmodule
+
+module top_mod (
+    input logic clk,
+    input logic rst_n,
+    output logic done_o
+);
+    child_mod u_good (
+        .clk(clk),
+        .rst_n(rst_n),
+        .done_o(done_o)
+    );
+
+    child_mod u_missing (
+        .clk(clk),
+        .extra_i(rst_n)
+    );
+
+    child_mod u_ordered (
+        clk,
+        rst_n,
+        done_o
+    );
+
+    child_mod u_wildcard (.*);
+endmodule

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -527,6 +527,29 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    port_connections_cmd = sub.add_parser(
+        "port-connections",
+        help=(
+            "Emit a read-only scanner-based target port connection audit."
+        ),
+    )
+    port_connections_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    port_connections_cmd.add_argument(
+        "--module",
+        required=True,
+        help="Exact module name to inspect for port connection review.",
+    )
+    port_connections_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     module_context_cmd = sub.add_parser(
         "module-context",
         help=(
@@ -1676,6 +1699,28 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_port_usage_text(view))
+        return 0
+
+    if args.command == "port-connections":
+        from .module_organization import (
+            build_module_port_connection_audit,
+            format_module_port_connection_audit_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        audit = build_module_port_connection_audit(
+            str(args.path),
+            args.path,
+            args.module,
+        )
+        if args.format == "json":
+            json.dump(audit, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_port_connection_audit_text(audit))
         return 0
 
     if args.command == "module-context":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -17,6 +17,7 @@ _IDENT_RE = re.compile(r"\b[A-Za-z_]\w*\b")
 _PORT_DIRECTION_RE = re.compile(r"\b(input|output|inout)\b")
 _PORT_WIDTH_RE = re.compile(r"(\[[^\]]+\])")
 _PORT_NAMED_CONNECTION_RE = re.compile(r"\.\s*([A-Za-z_]\w*)\s*\(")
+_PORT_WILDCARD_CONNECTION_RE = re.compile(r"\.\s*\*")
 _PORT_CONNECTION_SCAN_LINE_LIMIT = 40
 
 _NON_INSTANCE_WORDS: frozenset[str] = frozenset({
@@ -292,6 +293,17 @@ PORT_USAGE_LIMITATIONS: tuple[str, ...] = (
     "instantiation candidates come from the existing line scanner",
     "connection summaries are bounded to the scanner-detected instantiation statement",
     "named and ordered port connections are not semantically resolved",
+    "no semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
+    "no refactor application, file write, validation run, or patch generation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
+PORT_CONNECTION_AUDIT_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based target module port connection audit data only",
+    "ANSI-style target port declarations are detected conservatively",
+    "named instantiation connections are compared by scanner-detected names only",
+    "ordered and wildcard connections require manual review",
     "no semantic elaboration, preprocessor expansion, generate-block expansion, or LSP",
     "no refactor application, file write, validation run, or patch generation",
     "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
@@ -917,6 +929,28 @@ def _port_usage_safety_flags() -> dict[str, bool]:
         "runs_shell": False,
         "invokes_pccx_lab": False,
         "invokes_launcher": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _port_connection_audit_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "port_connection_audit_only": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
         "provider_calls": False,
         "hardware_access": False,
         "telemetry": False,
@@ -4244,6 +4278,240 @@ def build_module_port_usage_view(
     }
 
 
+def _instance_connection_audit_site(
+    edge: dict[str, Any],
+    visible_lines: list[tuple[int, str]],
+    declared_port_names: list[str],
+) -> dict[str, Any]:
+    statement = _instantiation_statement(edge, visible_lines)
+    argument_text = _instantiation_argument_text(edge, statement["text"])
+    named_connections = list(dict.fromkeys(
+        _PORT_NAMED_CONNECTION_RE.findall(argument_text)
+    ))
+    wildcard_connection = _PORT_WILDCARD_CONNECTION_RE.search(argument_text) is not None
+
+    if named_connections:
+        connection_style = "named"
+        connection_count = len(named_connections)
+    elif wildcard_connection:
+        connection_style = "wildcard"
+        connection_count = 1
+    elif argument_text:
+        connection_style = "ordered"
+        connection_count = _ordered_connection_count(argument_text)
+    else:
+        connection_style = "empty"
+        connection_count = 0
+
+    declared_set = set(declared_port_names)
+    named_set = set(named_connections)
+    missing_named_ports = [
+        name for name in declared_port_names
+        if connection_style == "named" and name not in named_set
+    ]
+    unknown_named_ports = [
+        name for name in named_connections
+        if name not in declared_set
+    ]
+
+    reasons: list[str] = []
+    blocked = False
+    if not edge["resolved"]:
+        blocked = True
+        reasons.append("unresolved module instantiation")
+    if not statement["complete"]:
+        blocked = True
+        reasons.append("instantiation statement scan incomplete")
+    if statement["truncated"]:
+        blocked = True
+        reasons.append("instantiation statement scan truncated")
+    if missing_named_ports:
+        missing = ", ".join(missing_named_ports)
+        reasons.append(f"missing named connections: {missing}")
+    if unknown_named_ports:
+        unknown = ", ".join(unknown_named_ports)
+        reasons.append(f"unknown named connections: {unknown}")
+    if connection_style == "ordered":
+        reasons.append("ordered connections require manual review")
+    if connection_style == "wildcard":
+        reasons.append("wildcard connections require manual review")
+    if connection_style == "empty" and declared_port_names:
+        reasons.append("no named connections detected for declared ports")
+
+    if blocked:
+        audit_state = "blocked"
+    elif reasons:
+        audit_state = "review-required"
+    else:
+        audit_state = "ready-for-review"
+
+    return {
+        "audit_state": audit_state,
+        "child": edge["child"],
+        "column": edge["column"],
+        "connection_count": connection_count,
+        "connection_style": connection_style,
+        "declared_port_count": len(declared_port_names),
+        "file": edge["file"],
+        "instance": edge["instance"],
+        "line": edge["line"],
+        "missing_named_port_count": len(missing_named_ports),
+        "missing_named_ports": missing_named_ports,
+        "named_connection_count": len(named_connections),
+        "named_connections": named_connections,
+        "parent": edge["parent"],
+        "reasons": reasons,
+        "resolved": edge["resolved"],
+        "scan_complete": statement["complete"],
+        "scan_line_count": statement["line_count"],
+        "scan_truncated": statement["truncated"],
+        "semantically_resolved": False,
+        "unknown_named_port_count": len(unknown_named_ports),
+        "unknown_named_ports": unknown_named_ports,
+        "wildcard_connection": wildcard_connection,
+    }
+
+
+def _port_connection_audit_state(
+    preflight: dict[str, Any],
+    sites: list[dict[str, Any]],
+) -> str:
+    if preflight["status"] == "blocked":
+        return "blocked"
+    if any(site["audit_state"] == "blocked" for site in sites):
+        return "blocked"
+    if any(site["audit_state"] == "review-required" for site in sites):
+        return "review-required"
+    return "ready-for-review"
+
+
+def _site_reasons(
+    sites: list[dict[str, Any]],
+    state: str,
+) -> list[str]:
+    reasons: list[str] = []
+    for site in sites:
+        if site["audit_state"] != state:
+            continue
+        for reason in site["reasons"]:
+            reasons.append(
+                f"{site['parent']}.{site['instance']}: {reason}"
+            )
+    return reasons
+
+
+def build_module_port_connection_audit(
+    source: str,
+    path: Path,
+    module_name: str,
+) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    hierarchy = organization["hierarchy"]
+    files = sorted({module["file"] for module in modules})
+    visible_lines_by_file = {
+        file_name: _visible_lines(Path(file_name))
+        for file_name in files
+    }
+
+    matches = _module_lookup(modules, module_name)
+    selected_module = matches[0] if len(matches) == 1 else None
+    header = None
+    ports: list[dict[str, Any]] = []
+    if selected_module is not None:
+        header = _module_header(
+            selected_module,
+            visible_lines_by_file[selected_module["file"]],
+        )
+        ports = _scan_header_ports(selected_module, header["lines"])
+
+    declared_port_names = [port["name"] for port in ports]
+    dependent_edges = [
+        edge
+        for edge in hierarchy["edges"]
+        if edge["child"] == module_name
+    ]
+    usage_sites = [
+        _instance_connection_audit_site(
+            edge,
+            visible_lines_by_file.get(edge["file"], []),
+            declared_port_names,
+        )
+        for edge in dependent_edges
+    ]
+    preflight = _refactor_impact_preflight(module_name, matches)
+    audit_state = _port_connection_audit_state(preflight, usage_sites)
+    direct_dependents = sorted({
+        edge["parent"]
+        for edge in dependent_edges
+    })
+
+    blocked_reasons = list(preflight["reasons"]) + _site_reasons(
+        usage_sites,
+        "blocked",
+    )
+    review_reasons = _site_reasons(usage_sites, "review-required")
+
+    return {
+        "audit_state": audit_state,
+        "blocked_site_count": sum(
+            1 for site in usage_sites
+            if site["audit_state"] == "blocked"
+        ),
+        "blocked_reasons": blocked_reasons,
+        "declared_port_names": declared_port_names,
+        "direct_dependent_count": len(direct_dependents),
+        "direct_dependents": direct_dependents,
+        "header": (
+            {
+                "complete": header["complete"],
+                "end_line": header["end_line"],
+                "line_count": header["line_count"],
+                "start_line": header["start_line"],
+            }
+            if header is not None
+            else None
+        ),
+        "kind": "module-port-connection-audit",
+        "limitations": list(PORT_CONNECTION_AUDIT_LIMITATIONS),
+        "missing_named_port_count": sum(
+            site["missing_named_port_count"] for site in usage_sites
+        ),
+        "module": selected_module,
+        "ordered_site_count": sum(
+            1 for site in usage_sites if site["connection_style"] == "ordered"
+        ),
+        "port_count": len(ports),
+        "ports": ports,
+        "preflight": preflight,
+        "ready_for_review": audit_state == "ready-for-review",
+        "ready_site_count": sum(
+            1 for site in usage_sites
+            if site["audit_state"] == "ready-for-review"
+        ),
+        "review_reason_count": len(review_reasons),
+        "review_reasons": review_reasons,
+        "review_site_count": sum(
+            1 for site in usage_sites
+            if site["audit_state"] == "review-required"
+        ),
+        "safety": _port_connection_audit_safety_flags(),
+        "scanner": "line-scanner",
+        "source": source,
+        "target": module_name,
+        "tool": "pccx-ide-cli",
+        "unknown_named_port_count": sum(
+            site["unknown_named_port_count"] for site in usage_sites
+        ),
+        "usage_site_count": len(usage_sites),
+        "usage_sites": usage_sites,
+        "wildcard_site_count": sum(
+            1 for site in usage_sites if site["wildcard_connection"]
+        ),
+        "writes_files": False,
+    }
+
+
 def _refactor_impact_preflight(
     module_name: str,
     matches: list[dict[str, Any]],
@@ -6924,6 +7192,86 @@ def format_module_port_usage_text(view: dict[str, Any]) -> str:
     lines.append(
         "read-only: no file writes, refactors, validation, lab, launcher, "
         "provider, or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _port_connection_audit_label(site: dict[str, Any]) -> str:
+    if site["connection_style"] == "named":
+        names = ", ".join(site["named_connections"]) or "none"
+        missing = ", ".join(site["missing_named_ports"]) or "none"
+        unknown = ", ".join(site["unknown_named_ports"]) or "none"
+        return (
+            f"named={names}; missing={missing}; unknown={unknown}; "
+            "not semantically resolved"
+        )
+    if site["connection_style"] == "ordered":
+        return (
+            f"ordered={site['connection_count']}; manual review; "
+            "not semantically resolved"
+        )
+    if site["connection_style"] == "wildcard":
+        return "wildcard connection; manual review; not semantically resolved"
+    return "connections empty or unknown; not semantically resolved"
+
+
+def format_module_port_connection_audit_text(report: dict[str, Any]) -> str:
+    lines = [
+        f"source: {report['source']}",
+        f"target: {report['target']}",
+        f"port connection audit: {report['audit_state']}",
+        f"preflight: {report['preflight']['status']}",
+        "writes files: no",
+    ]
+
+    module = report["module"]
+    if module is not None:
+        lines.append(
+            f"declaration: {module['file']}:{module['start_line']}:"
+            f"{module['start_column']}"
+        )
+
+    ports = ", ".join(report["declared_port_names"]) or "none"
+    dependents = ", ".join(report["direct_dependents"]) or "none"
+    lines.append(
+        f"{report['port_count']} target port"
+        f"{'s' if report['port_count'] != 1 else ''}: {ports}"
+    )
+    lines.append(f"dependents: {dependents}")
+    lines.append(
+        f"usage sites: {report['usage_site_count']} "
+        f"(ready={report['ready_site_count']}; "
+        f"review={report['review_site_count']}; "
+        f"blocked={report['blocked_site_count']})"
+    )
+    lines.append(
+        f"missing named ports: {report['missing_named_port_count']}; "
+        f"unknown named ports: {report['unknown_named_port_count']}; "
+        f"ordered sites: {report['ordered_site_count']}; "
+        f"wildcard sites: {report['wildcard_site_count']}"
+    )
+
+    if not report["usage_sites"]:
+        lines.append("usage sites: none")
+    for site in report["usage_sites"]:
+        connection_label = _port_connection_audit_label(site)
+        lines.append(
+            f"  {site['parent']} instantiates {site['child']} "
+            f"as {site['instance']} at {site['file']}:"
+            f"{site['line']}:{site['column']} "
+            f"({site['audit_state']}; {connection_label})"
+        )
+        for reason in site["reasons"]:
+            lines.append(f"    review: {reason}")
+
+    for reason in report["blocked_reasons"]:
+        lines.append(f"blocked: {reason}")
+    for reason in report["review_reasons"]:
+        lines.append(f"review: {reason}")
+    lines.append(
+        "read-only port connection audit: no command argv, validation, shell, "
+        "refactor, patch, file write, lab, launcher, vendor tool, provider, "
+        "or hardware execution"
     )
     return "\n".join(lines) + "\n"
 

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -17,6 +17,9 @@ DUPLICATE_FIXTURE = REPO_ROOT / "fixtures" / "organization" / "duplicate_modules
 UNRESOLVED_FIXTURE = REPO_ROOT / "fixtures" / "organization" / "unresolved_instances.sv"
 ORPHAN_FIXTURE = REPO_ROOT / "fixtures" / "organization" / "orphan_modules.sv"
 FANOUT_FIXTURE = REPO_ROOT / "fixtures" / "organization" / "fanout_hierarchy.sv"
+PORT_CONNECTION_FIXTURE = (
+    REPO_ROOT / "fixtures" / "organization" / "port_connection_audit.sv"
+)
 INCOMPLETE_FIXTURE = REPO_ROOT / "fixtures" / "missing_endmodule.sv"
 CONTRACT_DOC = REPO_ROOT / "docs" / "EDITOR_BRIDGE_CONTRACT.md"
 WORKFLOW_DOC = REPO_ROOT / "docs" / "MODULE_ORGANIZATION_WORKFLOW.md"
@@ -40,6 +43,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_organization_export,
     build_module_order_report,
     build_module_path_report,
+    build_module_port_connection_audit,
     build_module_port_usage_view,
     build_module_reachability_report,
     build_module_root_candidate_report,
@@ -79,6 +83,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_module_organization_text,
     format_module_order_report_text,
     format_module_path_report_text,
+    format_module_port_connection_audit_text,
     format_module_port_usage_text,
     format_module_reachability_report_text,
     format_module_root_candidate_report_text,
@@ -1663,6 +1668,67 @@ def test_build_module_port_usage_view_blocks_missing_module():
     assert view["writes_files"] is False
 
 
+def test_build_module_port_connection_audit_reports_named_port_gaps():
+    audit = build_module_port_connection_audit(
+        str(PORT_CONNECTION_FIXTURE),
+        PORT_CONNECTION_FIXTURE,
+        "child_mod",
+    )
+
+    assert audit["kind"] == "module-port-connection-audit"
+    assert audit["audit_state"] == "review-required"
+    assert audit["ready_for_review"] is False
+    assert audit["preflight"]["status"] == "ready-for-review"
+    assert audit["target"] == "child_mod"
+    assert audit["declared_port_names"] == ["clk", "rst_n", "done_o"]
+    assert audit["usage_site_count"] == 4
+    assert audit["ready_site_count"] == 1
+    assert audit["review_site_count"] == 3
+    assert audit["blocked_site_count"] == 0
+    assert audit["missing_named_port_count"] == 2
+    assert audit["unknown_named_port_count"] == 1
+    assert audit["ordered_site_count"] == 1
+    assert audit["wildcard_site_count"] == 1
+    sites = {site["instance"]: site for site in audit["usage_sites"]}
+    assert sites["u_good"]["audit_state"] == "ready-for-review"
+    assert sites["u_good"]["named_connections"] == ["clk", "rst_n", "done_o"]
+    assert sites["u_missing"]["audit_state"] == "review-required"
+    assert sites["u_missing"]["missing_named_ports"] == ["rst_n", "done_o"]
+    assert sites["u_missing"]["unknown_named_ports"] == ["extra_i"]
+    assert sites["u_ordered"]["connection_style"] == "ordered"
+    assert "ordered connections require manual review" in sites["u_ordered"]["reasons"]
+    assert sites["u_wildcard"]["connection_style"] == "wildcard"
+    assert sites["u_wildcard"]["wildcard_connection"] is True
+    assert "wildcard connections require manual review" in sites["u_wildcard"]["reasons"]
+    assert audit["safety"]["read_only"] is True
+    assert audit["safety"]["writes_files"] is False
+    assert audit["safety"]["applies_refactor"] is False
+    assert audit["safety"]["generates_patch"] is False
+    assert audit["safety"]["emits_command_descriptors"] is False
+    assert audit["safety"]["runs_validation"] is False
+    assert audit["safety"]["invokes_pccx_lab"] is False
+    assert audit["safety"]["invokes_launcher"] is False
+    assert audit["safety"]["provider_calls"] is False
+    assert audit["safety"]["hardware_access"] is False
+
+
+def test_build_module_port_connection_audit_blocks_missing_module():
+    audit = build_module_port_connection_audit(
+        str(PORT_CONNECTION_FIXTURE),
+        PORT_CONNECTION_FIXTURE,
+        "missing_mod",
+    )
+
+    assert audit["audit_state"] == "blocked"
+    assert audit["ready_for_review"] is False
+    assert audit["preflight"]["status"] == "blocked"
+    assert audit["blocked_reasons"] == ["module not found: missing_mod"]
+    assert audit["module"] is None
+    assert audit["ports"] == []
+    assert audit["usage_sites"] == []
+    assert audit["writes_files"] is False
+
+
 def test_build_module_context_bundle_summarizes_target_views():
     bundle = build_module_context_bundle(str(FIXTURE), FIXTURE, "leaf_mod")
 
@@ -2630,6 +2696,27 @@ def test_format_module_port_usage_text_mentions_usage_and_no_execution():
     assert "read-only: no file writes" in text
 
 
+def test_format_module_port_connection_audit_text_mentions_review_boundary():
+    audit = build_module_port_connection_audit(
+        str(PORT_CONNECTION_FIXTURE),
+        PORT_CONNECTION_FIXTURE,
+        "child_mod",
+    )
+    text = format_module_port_connection_audit_text(audit)
+
+    assert "port connection audit: review-required" in text
+    assert "preflight: ready-for-review" in text
+    assert "3 target ports: clk, rst_n, done_o" in text
+    assert "usage sites: 4 (ready=1; review=3; blocked=0)" in text
+    assert "missing named ports: 2; unknown named ports: 1" in text
+    assert "top_mod instantiates child_mod as u_missing" in text
+    assert "missing=rst_n, done_o; unknown=extra_i" in text
+    assert "ordered=3; manual review" in text
+    assert "wildcard connection; manual review" in text
+    assert "writes files: no" in text
+    assert "read-only port connection audit: no command argv" in text
+
+
 def test_format_module_context_text_mentions_context_and_no_execution():
     bundle = build_module_context_bundle(str(FIXTURE), FIXTURE, "leaf_mod")
     text = format_module_context_text(bundle)
@@ -3365,6 +3452,45 @@ def test_cli_port_usage_text():
     assert result.returncode == 0, result.stderr
     assert "port usage: available_as_data" in result.stdout
     assert "top_mod instantiates leaf_mod as u_leaf" in result.stdout
+
+
+def test_cli_port_connections_json():
+    result = _run_cli(
+        "port-connections",
+        str(PORT_CONNECTION_FIXTURE),
+        "--module",
+        "child_mod",
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-port-connection-audit"
+    assert payload["audit_state"] == "review-required"
+    assert payload["target"] == "child_mod"
+    assert payload["missing_named_port_count"] == 2
+    assert payload["unknown_named_port_count"] == 1
+    assert payload["ordered_site_count"] == 1
+    assert payload["wildcard_site_count"] == 1
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["emits_command_descriptors"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_port_connections_text():
+    result = _run_cli(
+        "port-connections",
+        str(PORT_CONNECTION_FIXTURE),
+        "--module",
+        "child_mod",
+        "--format",
+        "text",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "port connection audit: review-required" in result.stdout
+    assert "top_mod instantiates child_mod as u_missing" in result.stdout
+    assert "read-only port connection audit: no command argv" in result.stdout
 
 
 def test_cli_module_context_json():


### PR DESCRIPTION
## Summary
- add a read-only `port-connections` CLI report for scanner-detected target port connection review
- flag missing and unknown named connections, plus ordered and wildcard sites that need manual review
- document the pre-stable boundary and add focused fixture, tests, and CI smoke coverage

Refs #8

## Validation
- `python3 -m py_compile src/pccx_ide_cli/module_organization.py src/pccx_ide_cli/cli.py tests/test_module_organization.py`
- `python3 -m pytest tests/test_module_organization.py`
- `python3 -m pytest -q`
- `python3 scripts/check-source-headers.py`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `git diff --check`
- `git diff --cached --check`
- local forbidden-claim scan