### PR TITLE
Add module file layout report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,13 @@ jobs:
               fixtures/organization/hierarchy_top.sv \
               | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-boundary-audit'; assert d['safety']['writes_files'] is False"
           echo "boundary audit smoke ok"
+      - name: cli smoke (module files exits zero)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli module-files \
+              fixtures/organization/hierarchy_top.sv \
+              | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-file-report'; assert d['safety']['writes_files'] is False; assert d['safety']['emits_command_descriptors'] is False"
+          echo "module files smoke ok"
       - name: cli smoke (refactor candidates exits zero)
         run: |
           set -e

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ python -m pccx_ide_cli module-summary fixtures/organization/hierarchy_top.sv --f
 # Module boundary audit and refactor candidate list (pre-stable, read-only)
 python -m pccx_ide_cli boundary-audit fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli module-duplicates fixtures/organization/duplicate_modules.sv --format text
+python -m pccx_ide_cli module-files fixtures/organization/hierarchy_top.sv --format text
 python -m pccx_ide_cli refactor-candidates fixtures/organization/hierarchy_top.sv --format text
 python -m pccx_ide_cli refactor-readiness fixtures/organization/hierarchy_top.sv --format json
 
@@ -272,6 +273,8 @@ menus. `refactor-readiness` summarizes boundary-audit and candidate
 counts for editor status panes without selecting an action or emitting
 command argv. `module-duplicates` reports scanner-detected duplicate
 module names that would block unambiguous refactor planning.
+`module-files` groups scanner-detected module declarations by source file
+for move-module and file-layout review without moving or rewriting files.
 `refactor-impact` renders target-specific declaration,
 dependent, and dependency review data for a named module.
 These commands do not edit files, apply

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -780,6 +780,48 @@ emit command argv, invoke `pccx-lab`, invoke the launcher, run vendor
 tools, call providers, touch hardware, upload telemetry, or perform
 automatic repository actions.
 
+The module file report groups scanner-detected module declarations by
+source file for file-layout and move-module review:
+
+```json
+{
+  "kind": "module-file-report",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "report_state": "multi-module-review",
+  "file_count": 1,
+  "module_count": 2,
+  "single_module_file_count": 0,
+  "multi_module_file_count": 1,
+  "files": [
+    {
+      "file": "fixtures/organization/hierarchy_top.sv",
+      "layout_state": "multi-module-file",
+      "refactor_preflight_state": "ready-for-review",
+      "module_names": ["leaf_mod", "top_mod"],
+      "modules": []
+    }
+  ],
+  "safety": {
+    "read_only": true,
+    "file_layout_report_only": true,
+    "emits_command_descriptors": false,
+    "writes_files": false,
+    "moves_files": false,
+    "applies_refactor": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The module file report is display data only. It does not move modules,
+rewrite declarations, generate patches, run validation, execute shell
+commands, emit command argv, invoke `pccx-lab`, invoke the launcher, run
+vendor tools, call providers, touch hardware, upload telemetry, or perform
+automatic repository actions.
+
 The refactor candidate list reports scanner-detected modules and
 proposal-only helper action metadata for editor menus:
 

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -173,6 +173,24 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    module_files_cmd = sub.add_parser(
+        "module-files",
+        help=(
+            "Emit a read-only scanner-based module file layout report."
+        ),
+    )
+    module_files_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    module_files_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     refactor_candidates_cmd = sub.add_parser(
         "refactor-candidates",
         help=(
@@ -1357,6 +1375,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_duplicate_report_text(report))
+        return 0
+
+    if args.command == "module-files":
+        from .module_organization import (
+            build_module_file_report,
+            format_module_file_report_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        report = build_module_file_report(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(report, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_file_report_text(report))
         return 0
 
     if args.command == "refactor-candidates":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -97,6 +97,16 @@ MODULE_DUPLICATE_REPORT_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+MODULE_FILE_REPORT_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based module file layout report only",
+    "groups scanner-detected module declaration spans by source file",
+    "does not move modules, rewrite declarations, or generate patches",
+    "does not semantically elaborate modules or resolve packages/namespaces",
+    "does not apply refactors, write files, generate patches, or run validation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 REFACTOR_CANDIDATE_LIST_LIMITATIONS: tuple[str, ...] = (
     "scanner-based refactor candidate metadata only",
     "lists scanner-detected modules and proposal-only helper actions for editor menus",
@@ -487,6 +497,28 @@ def _module_duplicate_report_safety_flags() -> dict[str, bool]:
     return {
         "read_only": True,
         "duplicate_report_only": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _module_file_report_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "file_layout_report_only": True,
         "emits_command_descriptors": False,
         "writes_files": False,
         "moves_files": False,
@@ -1509,6 +1541,129 @@ def build_module_duplicate_report(source: str, path: Path) -> dict[str, Any]:
         "source": source,
         "tool": "pccx-ide-cli",
         "unique_module_name_count": len({module["name"] for module in modules}),
+        "writes_files": False,
+    }
+
+
+def _module_file_rows(
+    modules: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    modules_by_file: dict[str, list[dict[str, Any]]] = {}
+    for module in modules:
+        modules_by_file.setdefault(module["file"], []).append(module)
+
+    rows: list[dict[str, Any]] = []
+    for file_name, declarations in sorted(modules_by_file.items()):
+        sorted_declarations = sorted(
+            declarations,
+            key=lambda module: (module["start_line"], module["start_column"]),
+        )
+        incomplete_modules = [
+            module
+            for module in sorted_declarations
+            if not module["complete"]
+        ]
+        reasons: list[str] = []
+        for module in incomplete_modules:
+            reasons.append(f"incomplete module boundary: {module['name']}")
+
+        if incomplete_modules:
+            layout_state = "blocked"
+            refactor_preflight_state = "blocked"
+        elif len(sorted_declarations) > 1:
+            layout_state = "multi-module-file"
+            refactor_preflight_state = "ready-for-review"
+        else:
+            layout_state = "single-module-file"
+            refactor_preflight_state = "ready-for-review"
+
+        rows.append({
+            "complete_module_count": len(sorted_declarations) - len(incomplete_modules),
+            "file": file_name,
+            "incomplete_module_count": len(incomplete_modules),
+            "layout_state": layout_state,
+            "module_count": len(sorted_declarations),
+            "module_names": [module["name"] for module in sorted_declarations],
+            "modules": [
+                {
+                    "complete": module["complete"],
+                    "end_line": module["end_line"],
+                    "name": module["name"],
+                    "span_lines": module["span_lines"],
+                    "start_column": module["start_column"],
+                    "start_line": module["start_line"],
+                }
+                for module in sorted_declarations
+            ],
+            "reasons": reasons,
+            "refactor_preflight_state": refactor_preflight_state,
+        })
+    return rows
+
+
+def _module_file_report_state(
+    file_rows: list[dict[str, Any]],
+    duplicates: list[dict[str, Any]],
+) -> str:
+    if not file_rows:
+        return "blocked"
+    if any(row["layout_state"] == "blocked" for row in file_rows):
+        return "blocked"
+    if duplicates:
+        return "blocked"
+    if any(row["layout_state"] == "multi-module-file" for row in file_rows):
+        return "multi-module-review"
+    return "ready-for-review"
+
+
+def build_module_file_report(source: str, path: Path) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    file_rows = _module_file_rows(modules)
+    duplicates = _module_duplicate_rows(modules)
+    blocked_reasons: list[str] = []
+    if not modules:
+        blocked_reasons.append("no module declarations detected")
+    for row in file_rows:
+        blocked_reasons.extend(
+            f"{row['file']}: {reason}"
+            for reason in row["reasons"]
+        )
+    blocked_reasons.extend(row["reason"] for row in duplicates)
+    report_state = _module_file_report_state(file_rows, duplicates)
+
+    return {
+        "blocked_reasons": blocked_reasons,
+        "duplicate_name_count": len(duplicates),
+        "duplicate_names": [row["name"] for row in duplicates],
+        "file_count": len(file_rows),
+        "files": file_rows,
+        "incomplete_module_count": sum(
+            row["incomplete_module_count"] for row in file_rows
+        ),
+        "kind": "module-file-report",
+        "limitations": list(MODULE_FILE_REPORT_LIMITATIONS),
+        "module_count": len(modules),
+        "multi_module_file_count": sum(
+            1 for row in file_rows
+            if row["layout_state"] == "multi-module-file"
+        ),
+        "next_required_action": (
+            "resolve module file layout blockers before refactor planning"
+            if report_state == "blocked"
+            else "review multi-module files before move-module planning"
+            if report_state == "multi-module-review"
+            else "continue module organization and refactor review"
+        ),
+        "report_state": report_state,
+        "safety": _module_file_report_safety_flags(),
+        "scanner": "line-scanner",
+        "single_module_file_count": sum(
+            1 for row in file_rows
+            if row["layout_state"] == "single-module-file"
+        ),
+        "source": source,
+        "tool": "pccx-ide-cli",
         "writes_files": False,
     }
 
@@ -6421,6 +6576,51 @@ def format_module_duplicate_report_text(report: dict[str, Any]) -> str:
     lines.append(f"next: {report['next_required_action']}")
     lines.append(
         "read-only duplicate report: no command argv, validation, shell, "
+        "refactor, patch, file write, lab, launcher, vendor tool, provider, "
+        "or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_module_file_report_text(report: dict[str, Any]) -> str:
+    lines = [
+        f"source: {report['source']}",
+        f"module files: {report['report_state']}",
+        f"{report['file_count']} source file"
+        f"{'s' if report['file_count'] != 1 else ''}",
+        f"{report['module_count']} module declaration"
+        f"{'s' if report['module_count'] != 1 else ''}",
+        (
+            f"single-module files: {report['single_module_file_count']}; "
+            f"multi-module files: {report['multi_module_file_count']}; "
+            f"incomplete modules: {report['incomplete_module_count']}"
+        ),
+    ]
+    if not report["files"]:
+        lines.append("files: none")
+    for file_row in report["files"]:
+        names = ", ".join(file_row["module_names"]) or "none"
+        lines.append(
+            f"{file_row['file']}: {file_row['module_count']} module"
+            f"{'s' if file_row['module_count'] != 1 else ''} "
+            f"({file_row['layout_state']}; "
+            f"{file_row['refactor_preflight_state']})"
+        )
+        lines.append(f"  modules: {names}")
+        for module in file_row["modules"]:
+            end_line = module["end_line"] or "?"
+            state = "complete" if module["complete"] else "incomplete"
+            lines.append(
+                f"  {module['name']} lines {module['start_line']}-{end_line} "
+                f"({state}; span={module['span_lines']})"
+            )
+        for reason in file_row["reasons"]:
+            lines.append(f"  blocked: {reason}")
+    for reason in report["blocked_reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"next: {report['next_required_action']}")
+    lines.append(
+        "read-only file report: no command argv, validation, shell, "
         "refactor, patch, file write, lab, launcher, vendor tool, provider, "
         "or hardware execution"
     )

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -35,6 +35,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_edge_report,
     build_module_fanin_report,
     build_module_fanout_report,
+    build_module_file_report,
     build_module_graph_health_summary,
     build_module_hierarchy_cycle_report,
     build_module_hierarchy_view,
@@ -75,6 +76,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_module_edge_report_text,
     format_module_fanin_report_text,
     format_module_fanout_report_text,
+    format_module_file_report_text,
     format_module_graph_health_summary_text,
     format_module_hierarchy_cycle_text,
     format_module_hierarchy_text,
@@ -250,6 +252,64 @@ def test_build_module_duplicate_report_allows_unique_names():
     assert report["duplicates"] == []
     assert report["blocked_reasons"] == []
     assert report["next_required_action"] == "continue module organization and refactor review"
+
+
+def test_build_module_file_report_groups_modules_by_file():
+    report = build_module_file_report(str(FIXTURE), FIXTURE)
+
+    assert report["kind"] == "module-file-report"
+    assert report["report_state"] == "multi-module-review"
+    assert report["file_count"] == 1
+    assert report["module_count"] == 2
+    assert report["single_module_file_count"] == 0
+    assert report["multi_module_file_count"] == 1
+    assert report["incomplete_module_count"] == 0
+    assert report["duplicate_name_count"] == 0
+    assert report["blocked_reasons"] == []
+    assert report["next_required_action"] == (
+        "review multi-module files before move-module planning"
+    )
+    file_row = report["files"][0]
+    assert file_row["file"] == str(FIXTURE)
+    assert file_row["layout_state"] == "multi-module-file"
+    assert file_row["refactor_preflight_state"] == "ready-for-review"
+    assert file_row["module_names"] == ["leaf_mod", "top_mod"]
+    assert [module["name"] for module in file_row["modules"]] == [
+        "leaf_mod",
+        "top_mod",
+    ]
+    assert report["safety"]["read_only"] is True
+    assert report["safety"]["file_layout_report_only"] is True
+    assert report["safety"]["emits_command_descriptors"] is False
+    assert report["safety"]["writes_files"] is False
+    assert report["safety"]["moves_files"] is False
+    assert report["safety"]["applies_refactor"] is False
+    assert report["safety"]["generates_patch"] is False
+    assert report["safety"]["runs_validation"] is False
+    assert report["safety"]["invokes_pccx_lab"] is False
+    assert report["safety"]["invokes_launcher"] is False
+    assert report["safety"]["hardware_access"] is False
+    assert report["writes_files"] is False
+    assert '"argv"' not in json.dumps(report)
+
+
+def test_build_module_file_report_blocks_incomplete_boundaries():
+    report = build_module_file_report(str(INCOMPLETE_FIXTURE), INCOMPLETE_FIXTURE)
+
+    assert report["report_state"] == "blocked"
+    assert report["file_count"] == 1
+    assert report["module_count"] == 1
+    assert report["incomplete_module_count"] == 1
+    assert report["files"][0]["layout_state"] == "blocked"
+    assert report["files"][0]["reasons"] == [
+        "incomplete module boundary: bad_module"
+    ]
+    assert report["blocked_reasons"] == [
+        f"{INCOMPLETE_FIXTURE}: incomplete module boundary: bad_module"
+    ]
+    assert report["next_required_action"] == (
+        "resolve module file layout blockers before refactor planning"
+    )
 
 
 def test_build_refactor_candidate_list_reports_action_enablement():
@@ -2481,6 +2541,20 @@ def test_format_module_duplicate_report_text_mentions_duplicates_and_boundary():
     assert "read-only duplicate report: no command argv" in text
 
 
+def test_format_module_file_report_text_mentions_layout_and_no_execution():
+    report = build_module_file_report(str(FIXTURE), FIXTURE)
+    text = format_module_file_report_text(report)
+
+    assert "module files: multi-module-review" in text
+    assert "1 source file" in text
+    assert "2 module declarations" in text
+    assert "multi-module files: 1" in text
+    assert "modules: leaf_mod, top_mod" in text
+    assert "leaf_mod lines 4-7 (complete; span=4)" in text
+    assert "next: review multi-module files before move-module planning" in text
+    assert "read-only file report: no command argv" in text
+
+
 def test_format_refactor_candidate_list_text_mentions_actions_and_no_execution():
     candidates = build_refactor_candidate_list(str(FIXTURE), FIXTURE)
     text = format_refactor_candidate_list_text(candidates)
@@ -2978,6 +3052,29 @@ def test_cli_module_duplicates_text():
     assert "module duplicates: duplicates-detected" in result.stdout
     assert "dup_mod: 2 declarations" in result.stdout
     assert "read-only duplicate report: no command argv" in result.stdout
+
+
+def test_cli_module_files_json():
+    result = _run_cli("module-files", str(FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-file-report"
+    assert payload["report_state"] == "multi-module-review"
+    assert payload["file_count"] == 1
+    assert payload["multi_module_file_count"] == 1
+    assert payload["files"][0]["module_names"] == ["leaf_mod", "top_mod"]
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["emits_command_descriptors"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_module_files_text():
+    result = _run_cli("module-files", str(FIXTURE), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "module files: multi-module-review" in result.stdout
+    assert "modules: leaf_mod, top_mod" in result.stdout
+    assert "read-only file report: no command argv" in result.stdout
 
 
 def test_cli_refactor_candidates_json():
@@ -4022,6 +4119,12 @@ def test_cli_boundary_audit_missing_path_exits_nonzero():
 
 def test_cli_module_duplicates_missing_path_exits_nonzero():
     result = _run_cli("module-duplicates", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
+def test_cli_module_files_missing_path_exits_nonzero():
+    result = _run_cli("module-files", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
     assert "does not exist" in result.stderr
 


### PR DESCRIPTION
## Summary
- add a read-only `module-files` CLI report for scanner-detected module file layout review
- group module declarations by source file with single/multi-module and incomplete-boundary signals
- document the pre-stable boundary and add focused tests plus CI smoke coverage

Refs #8

## Validation
- `python3 -m py_compile src/pccx_ide_cli/module_organization.py src/pccx_ide_cli/cli.py tests/test_module_organization.py`
- `python3 -m pytest tests/test_module_organization.py`
- `python3 -m pytest -q`
- `python3 scripts/check-source-headers.py`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `PYTHONPATH=src python3 -m pccx_ide_cli module-files fixtures/organization/hierarchy_top.sv --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli module-files fixtures/organization/hierarchy_top.sv --format text`
- `git diff --check`
- `git diff --cached --check`
- local forbidden-claim scan