### PR TITLE
Add module span report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,13 @@ jobs:
               fixtures/organization/hierarchy_top.sv \
               | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-file-report'; assert d['safety']['writes_files'] is False; assert d['safety']['emits_command_descriptors'] is False"
           echo "module files smoke ok"
+      - name: cli smoke (module spans exits zero)
+        run: |
+          set -e
+          PYTHONPATH=src python -m pccx_ide_cli module-spans \
+              fixtures/organization/hierarchy_top.sv \
+              | python -c "import json,sys; d=json.load(sys.stdin); assert d['kind']=='module-span-report'; assert d['safety']['writes_files'] is False; assert d['safety']['emits_command_descriptors'] is False"
+          echo "module spans smoke ok"
       - name: cli smoke (refactor candidates exits zero)
         run: |
           set -e

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ python -m pccx_ide_cli module-summary fixtures/organization/hierarchy_top.sv --f
 python -m pccx_ide_cli boundary-audit fixtures/organization/hierarchy_top.sv --format json
 python -m pccx_ide_cli module-duplicates fixtures/organization/duplicate_modules.sv --format text
 python -m pccx_ide_cli module-files fixtures/organization/hierarchy_top.sv --format text
+python -m pccx_ide_cli module-spans fixtures/organization/hierarchy_top.sv --format text
 python -m pccx_ide_cli refactor-candidates fixtures/organization/hierarchy_top.sv --format text
 python -m pccx_ide_cli refactor-readiness fixtures/organization/hierarchy_top.sv --format json
 
@@ -275,6 +276,8 @@ command argv. `module-duplicates` reports scanner-detected duplicate
 module names that would block unambiguous refactor planning.
 `module-files` groups scanner-detected module declarations by source file
 for move-module and file-layout review without moving or rewriting files.
+`module-spans` ranks scanner-detected module declaration spans for
+large-module review without semantic elaboration or rewrite actions.
 `refactor-impact` renders target-specific declaration,
 dependent, and dependency review data for a named module.
 These commands do not edit files, apply

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -822,6 +822,50 @@ commands, emit command argv, invoke `pccx-lab`, invoke the launcher, run
 vendor tools, call providers, touch hardware, upload telemetry, or perform
 automatic repository actions.
 
+The module span report ranks scanner-detected module declaration spans for
+large-module review:
+
+```json
+{
+  "kind": "module-span-report",
+  "tool": "pccx-ide-cli",
+  "scanner": "line-scanner",
+  "source": "<path passed on CLI>",
+  "report_state": "spans-detected",
+  "module_count": 2,
+  "complete_module_count": 2,
+  "incomplete_module_count": 0,
+  "min_span_lines": 4,
+  "max_span_lines": 7,
+  "modules": [
+    {
+      "rank": 1,
+      "name": "top_mod",
+      "file": "fixtures/organization/hierarchy_top.sv",
+      "start_line": 9,
+      "end_line": 15,
+      "span_lines": 7,
+      "span_state": "ready-for-review"
+    }
+  ],
+  "safety": {
+    "read_only": true,
+    "span_report_only": true,
+    "emits_command_descriptors": false,
+    "writes_files": false,
+    "applies_refactor": false,
+    "runs_validation": false
+  },
+  "limitations": []
+}
+```
+
+The module span report is display data only. It does not rewrite modules,
+extract code, generate patches, run validation, execute shell commands,
+emit command argv, invoke `pccx-lab`, invoke the launcher, run vendor tools,
+call providers, touch hardware, upload telemetry, or perform automatic
+repository actions.
+
 The refactor candidate list reports scanner-detected modules and
 proposal-only helper action metadata for editor menus:
 

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -191,6 +191,24 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    module_spans_cmd = sub.add_parser(
+        "module-spans",
+        help=(
+            "Emit a read-only scanner-based module declaration span report."
+        ),
+    )
+    module_spans_cmd.add_argument(
+        "path",
+        type=Path,
+        help="Path to a .sv/.v file or a directory to scan recursively.",
+    )
+    module_spans_cmd.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+
     refactor_candidates_cmd = sub.add_parser(
         "refactor-candidates",
         help=(
@@ -1393,6 +1411,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stdout.write("\n")
         else:
             sys.stdout.write(format_module_file_report_text(report))
+        return 0
+
+    if args.command == "module-spans":
+        from .module_organization import (
+            build_module_span_report,
+            format_module_span_report_text,
+        )
+
+        if not args.path.exists():
+            sys.stderr.write(f"error: path does not exist: {args.path}\n")
+            return 2
+
+        report = build_module_span_report(str(args.path), args.path)
+        if args.format == "json":
+            json.dump(report, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_module_span_report_text(report))
         return 0
 
     if args.command == "refactor-candidates":

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -107,6 +107,16 @@ MODULE_FILE_REPORT_LIMITATIONS: tuple[str, ...] = (
     "pre-stable JSON shape",
 )
 
+MODULE_SPAN_REPORT_LIMITATIONS: tuple[str, ...] = (
+    "scanner-based module span report only",
+    "uses scanner-detected declaration start and end lines",
+    "incomplete boundaries block span review readiness",
+    "does not semantically elaborate modules or resolve packages/namespaces",
+    "does not apply refactors, write files, generate patches, or run validation",
+    "no pccx-lab, launcher, vendor tool, provider, or hardware invocation",
+    "pre-stable JSON shape",
+)
+
 REFACTOR_CANDIDATE_LIST_LIMITATIONS: tuple[str, ...] = (
     "scanner-based refactor candidate metadata only",
     "lists scanner-detected modules and proposal-only helper actions for editor menus",
@@ -519,6 +529,28 @@ def _module_file_report_safety_flags() -> dict[str, bool]:
     return {
         "read_only": True,
         "file_layout_report_only": True,
+        "emits_command_descriptors": False,
+        "writes_files": False,
+        "moves_files": False,
+        "applies_refactor": False,
+        "applies_patch": False,
+        "generates_patch": False,
+        "runs_validation": False,
+        "runs_shell": False,
+        "invokes_pccx_lab": False,
+        "invokes_launcher": False,
+        "invokes_vendor_tools": False,
+        "provider_calls": False,
+        "hardware_access": False,
+        "telemetry": False,
+        "automatic_repository_action": False,
+    }
+
+
+def _module_span_report_safety_flags() -> dict[str, bool]:
+    return {
+        "read_only": True,
+        "span_report_only": True,
         "emits_command_descriptors": False,
         "writes_files": False,
         "moves_files": False,
@@ -1662,6 +1694,83 @@ def build_module_file_report(source: str, path: Path) -> dict[str, Any]:
             1 for row in file_rows
             if row["layout_state"] == "single-module-file"
         ),
+        "source": source,
+        "tool": "pccx-ide-cli",
+        "writes_files": False,
+    }
+
+
+def _module_span_rows(modules: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    sorted_modules = sorted(
+        modules,
+        key=lambda module: (
+            -(
+                module["span_lines"]
+                if isinstance(module["span_lines"], int)
+                else 0
+            ),
+            module["file"],
+            module["start_line"],
+            module["name"],
+        ),
+    )
+    rows: list[dict[str, Any]] = []
+    for index, module in enumerate(sorted_modules, start=1):
+        reasons: list[str] = []
+        if not module["complete"]:
+            reasons.append(f"incomplete module boundary: {module['name']}")
+        rows.append({
+            "complete": module["complete"],
+            "end_line": module["end_line"],
+            "file": module["file"],
+            "name": module["name"],
+            "rank": index,
+            "reasons": reasons,
+            "refactor_preflight_state": "blocked" if reasons else "ready-for-review",
+            "span_lines": module["span_lines"],
+            "span_state": "blocked" if reasons else "ready-for-review",
+            "start_column": module["start_column"],
+            "start_line": module["start_line"],
+        })
+    return rows
+
+
+def build_module_span_report(source: str, path: Path) -> dict[str, Any]:
+    organization = build_module_organization_export(source, path)
+    modules = organization["modules"]
+    rows = _module_span_rows(modules)
+    blocked_reasons = [
+        reason
+        for row in rows
+        for reason in row["reasons"]
+    ]
+    if not modules:
+        blocked_reasons.append("no module declarations detected")
+    complete_rows = [row for row in rows if row["complete"]]
+    span_line_values = [
+        row["span_lines"]
+        for row in rows
+        if isinstance(row["span_lines"], int)
+    ]
+
+    return {
+        "blocked_reasons": blocked_reasons,
+        "complete_module_count": len(complete_rows),
+        "incomplete_module_count": len(rows) - len(complete_rows),
+        "kind": "module-span-report",
+        "limitations": list(MODULE_SPAN_REPORT_LIMITATIONS),
+        "max_span_lines": max(span_line_values, default=0),
+        "min_span_lines": min(span_line_values, default=0),
+        "module_count": len(rows),
+        "modules": rows,
+        "next_required_action": (
+            "resolve module span blockers before refactor planning"
+            if blocked_reasons
+            else "review largest scanner-detected module spans before refactor planning"
+        ),
+        "report_state": "blocked" if blocked_reasons else "spans-detected",
+        "safety": _module_span_report_safety_flags(),
+        "scanner": "line-scanner",
         "source": source,
         "tool": "pccx-ide-cli",
         "writes_files": False,
@@ -6621,6 +6730,44 @@ def format_module_file_report_text(report: dict[str, Any]) -> str:
     lines.append(f"next: {report['next_required_action']}")
     lines.append(
         "read-only file report: no command argv, validation, shell, "
+        "refactor, patch, file write, lab, launcher, vendor tool, provider, "
+        "or hardware execution"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_module_span_report_text(report: dict[str, Any]) -> str:
+    lines = [
+        f"source: {report['source']}",
+        f"module spans: {report['report_state']}",
+        f"{report['module_count']} module declaration"
+        f"{'s' if report['module_count'] != 1 else ''}",
+        (
+            f"complete: {report['complete_module_count']}; "
+            f"incomplete: {report['incomplete_module_count']}"
+        ),
+        (
+            f"span range: {report['min_span_lines']}-"
+            f"{report['max_span_lines']} lines"
+        ),
+    ]
+    if not report["modules"]:
+        lines.append("modules: none")
+    for module in report["modules"]:
+        end_line = module["end_line"] or "?"
+        lines.append(
+            f"rank {module['rank']}: {module['file']}:"
+            f"{module['start_line']}-{end_line}: "
+            f"module {module['name']} span={module['span_lines']} "
+            f"({module['span_state']}; {module['refactor_preflight_state']})"
+        )
+        for reason in module["reasons"]:
+            lines.append(f"  blocked: {reason}")
+    for reason in report["blocked_reasons"]:
+        lines.append(f"blocked: {reason}")
+    lines.append(f"next: {report['next_required_action']}")
+    lines.append(
+        "read-only span report: no command argv, validation, shell, "
         "refactor, patch, file write, lab, launcher, vendor tool, provider, "
         "or hardware execution"
     )

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -48,6 +48,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     build_module_port_usage_view,
     build_module_reachability_report,
     build_module_root_candidate_report,
+    build_module_span_report,
     build_module_summary_view,
     build_module_unresolved_instance_report,
     build_refactor_candidate_list,
@@ -89,6 +90,7 @@ from pccx_ide_cli.module_organization import (  # noqa: E402
     format_module_port_usage_text,
     format_module_reachability_report_text,
     format_module_root_candidate_report_text,
+    format_module_span_report_text,
     format_module_summary_text,
     format_module_unresolved_instance_report_text,
     format_refactor_candidate_list_text,
@@ -309,6 +311,63 @@ def test_build_module_file_report_blocks_incomplete_boundaries():
     ]
     assert report["next_required_action"] == (
         "resolve module file layout blockers before refactor planning"
+    )
+
+
+def test_build_module_span_report_ranks_modules_by_span():
+    report = build_module_span_report(str(FIXTURE), FIXTURE)
+
+    assert report["kind"] == "module-span-report"
+    assert report["report_state"] == "spans-detected"
+    assert report["module_count"] == 2
+    assert report["complete_module_count"] == 2
+    assert report["incomplete_module_count"] == 0
+    assert report["min_span_lines"] == 4
+    assert report["max_span_lines"] == 7
+    assert report["blocked_reasons"] == []
+    assert report["next_required_action"] == (
+        "review largest scanner-detected module spans before refactor planning"
+    )
+    assert [module["name"] for module in report["modules"]] == [
+        "top_mod",
+        "leaf_mod",
+    ]
+    assert report["modules"][0]["rank"] == 1
+    assert report["modules"][0]["span_lines"] == 7
+    assert report["modules"][0]["span_state"] == "ready-for-review"
+    assert report["modules"][0]["refactor_preflight_state"] == "ready-for-review"
+    assert report["safety"]["read_only"] is True
+    assert report["safety"]["span_report_only"] is True
+    assert report["safety"]["emits_command_descriptors"] is False
+    assert report["safety"]["writes_files"] is False
+    assert report["safety"]["moves_files"] is False
+    assert report["safety"]["applies_refactor"] is False
+    assert report["safety"]["generates_patch"] is False
+    assert report["safety"]["runs_validation"] is False
+    assert report["safety"]["invokes_pccx_lab"] is False
+    assert report["safety"]["invokes_launcher"] is False
+    assert report["safety"]["hardware_access"] is False
+    assert report["writes_files"] is False
+    assert '"argv"' not in json.dumps(report)
+
+
+def test_build_module_span_report_blocks_incomplete_boundaries():
+    report = build_module_span_report(str(INCOMPLETE_FIXTURE), INCOMPLETE_FIXTURE)
+
+    assert report["report_state"] == "blocked"
+    assert report["module_count"] == 1
+    assert report["complete_module_count"] == 0
+    assert report["incomplete_module_count"] == 1
+    assert report["modules"][0]["name"] == "bad_module"
+    assert report["modules"][0]["span_state"] == "blocked"
+    assert report["modules"][0]["reasons"] == [
+        "incomplete module boundary: bad_module"
+    ]
+    assert report["blocked_reasons"] == [
+        "incomplete module boundary: bad_module"
+    ]
+    assert report["next_required_action"] == (
+        "resolve module span blockers before refactor planning"
     )
 
 
@@ -2555,6 +2614,19 @@ def test_format_module_file_report_text_mentions_layout_and_no_execution():
     assert "read-only file report: no command argv" in text
 
 
+def test_format_module_span_report_text_mentions_ranks_and_no_execution():
+    report = build_module_span_report(str(FIXTURE), FIXTURE)
+    text = format_module_span_report_text(report)
+
+    assert "module spans: spans-detected" in text
+    assert "2 module declarations" in text
+    assert "span range: 4-7 lines" in text
+    assert "rank 1:" in text
+    assert "module top_mod span=7" in text
+    assert "next: review largest scanner-detected module spans" in text
+    assert "read-only span report: no command argv" in text
+
+
 def test_format_refactor_candidate_list_text_mentions_actions_and_no_execution():
     candidates = build_refactor_candidate_list(str(FIXTURE), FIXTURE)
     text = format_refactor_candidate_list_text(candidates)
@@ -3075,6 +3147,28 @@ def test_cli_module_files_text():
     assert "module files: multi-module-review" in result.stdout
     assert "modules: leaf_mod, top_mod" in result.stdout
     assert "read-only file report: no command argv" in result.stdout
+
+
+def test_cli_module_spans_json():
+    result = _run_cli("module-spans", str(FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-span-report"
+    assert payload["report_state"] == "spans-detected"
+    assert payload["max_span_lines"] == 7
+    assert payload["modules"][0]["name"] == "top_mod"
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["emits_command_descriptors"] is False
+    assert payload["safety"]["runs_validation"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_module_spans_text():
+    result = _run_cli("module-spans", str(FIXTURE), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "module spans: spans-detected" in result.stdout
+    assert "module top_mod span=7" in result.stdout
+    assert "read-only span report: no command argv" in result.stdout
 
 
 def test_cli_refactor_candidates_json():
@@ -4125,6 +4219,12 @@ def test_cli_module_duplicates_missing_path_exits_nonzero():
 
 def test_cli_module_files_missing_path_exits_nonzero():
     result = _run_cli("module-files", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
+def test_cli_module_spans_missing_path_exits_nonzero():
+    result = _run_cli("module-spans", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
     assert "does not exist" in result.stderr
 


### PR DESCRIPTION
## Summary
- add a read-only `module-spans` CLI report for scanner-detected module declaration span review
- rank complete module declarations and block incomplete boundaries before refactor planning
- document the pre-stable boundary and add focused tests plus CI smoke coverage

Refs #8

## Validation
- `python3 -m py_compile src/pccx_ide_cli/module_organization.py src/pccx_ide_cli/cli.py tests/test_module_organization.py`
- `python3 -m pytest tests/test_module_organization.py`
- `python3 -m pytest -q`
- `python3 scripts/check-source-headers.py`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `PYTHONPATH=src python3 -m pccx_ide_cli module-spans fixtures/organization/hierarchy_top.sv --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli module-spans fixtures/organization/hierarchy_top.sv --format text`
- local forbidden-claim scan
- `git diff --check`
- `git diff --cached --check`