### PR TITLE
Block conflicting rename proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,10 +288,10 @@ pre-stable and documented in
 
 `refactor-plan` emits proposal-only rename-module, extract-port, and
 move-module planning envelopes over scanner-detected module boundaries.
-It records requested inputs, a bounded preflight status, and planned
-review steps, but it does not write files, apply patches, run validation,
-invoke `pccx-lab` or the launcher, call providers, touch hardware, or
-perform automatic repository actions.
+It records requested inputs, a bounded preflight status including existing
+rename-target conflicts, and planned review steps, but it does not write
+files, apply patches, run validation, invoke `pccx-lab` or the launcher, call
+providers, touch hardware, or perform automatic repository actions.
 `validation-plan`, `refactor-review`, `refactor-approval`,
 `refactor-application`, `refactor-result`, `refactor-handoff`,
 `refactor-checklist`, and `refactor-session` extend that reviewed flow with

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -1297,8 +1297,8 @@ review steps, and safety flags. Example shape:
 
 Blocked proposals still return JSON so editor consumers can display why a
 request is not ready for review. For example, a missing module, missing
-required input, absolute destination path, or invalid identifier produces
-`preflight.status: "blocked"` with reasons.
+required input, existing rename target, absolute destination path, or invalid
+identifier produces `preflight.status: "blocked"` with reasons.
 
 This boundary is intentionally limited to proposal metadata. It does not
 rewrite symbols, edit ports, move files, generate patches, run validation,

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -5081,6 +5081,7 @@ def _preflight(
     module_name: str,
     matches: list[dict[str, Any]],
     requested: dict[str, Any],
+    modules: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     reasons: list[str] = []
     required = _REFACTOR_REQUIRED_FIELDS[action]
@@ -5100,6 +5101,14 @@ def _preflight(
             reasons.append("new-name must be a SystemVerilog-style identifier")
         if requested["new_name"] == module_name:
             reasons.append("new-name matches the current module name")
+        elif any(
+            module["name"] == requested["new_name"]
+            for module in modules or []
+        ):
+            reasons.append(
+                "new-name already exists in scanned modules: "
+                f"{requested['new_name']}"
+            )
 
     if action == "extract-port" and requested["port_name"]:
         if not _safe_identifier(requested["port_name"]):
@@ -5145,7 +5154,13 @@ def build_refactor_proposal(
         width=width,
         destination=destination,
     )
-    preflight = _preflight(action, module_name, matches, requested)
+    preflight = _preflight(
+        action,
+        module_name,
+        matches,
+        requested,
+        organization["modules"],
+    )
     selected_module = matches[0] if len(matches) == 1 else None
 
     return {

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -1970,6 +1970,25 @@ def test_build_refactor_proposal_rename_is_review_only():
     assert proposal["safety"]["invokes_launcher"] is False
 
 
+def test_build_refactor_proposal_blocks_existing_new_name():
+    proposal = build_refactor_proposal(
+        str(FIXTURE),
+        FIXTURE,
+        "rename-module",
+        "top_mod",
+        new_name="leaf_mod",
+    )
+
+    assert proposal["proposal_state"] == "proposal-only"
+    assert proposal["writes_files"] is False
+    assert proposal["preflight"]["status"] == "blocked"
+    assert proposal["preflight"]["reasons"] == [
+        "new-name already exists in scanned modules: leaf_mod"
+    ]
+    assert proposal["safety"]["applies_patch"] is False
+    assert proposal["safety"]["runs_validation"] is False
+
+
 def test_build_refactor_proposal_blocks_missing_module():
     proposal = build_refactor_proposal(
         str(FIXTURE),
@@ -3767,6 +3786,28 @@ def test_cli_refactor_plan_json():
     assert payload["kind"] == "module-refactor-proposal"
     assert payload["action"] == "rename-module"
     assert payload["preflight"]["status"] == "ready-for-review"
+    assert payload["writes_files"] is False
+
+
+def test_cli_refactor_plan_blocks_existing_rename_target():
+    result = _run_cli(
+        "refactor-plan",
+        str(FIXTURE),
+        "--action",
+        "rename-module",
+        "--module",
+        "top_mod",
+        "--new-name",
+        "leaf_mod",
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["preflight"]["status"] == "blocked"
+    assert payload["preflight"]["reasons"] == [
+        "new-name already exists in scanned modules: leaf_mod"
+    ]
     assert payload["writes_files"] is False
 
 


### PR DESCRIPTION
## Summary
- block proposal-only `rename-module` requests when the requested new name already exists in the scanned module set
- keep blocked proposals JSON-visible for editor review without applying edits or running validation
- document the preflight reason and cover builder plus CLI behavior

Refs #8

## Validation
- `python3 -m py_compile src/pccx_ide_cli/module_organization.py tests/test_module_organization.py`
- `python3 -m pytest tests/test_module_organization.py`
- `python3 -m pytest -q`
- `python3 scripts/check-source-headers.py`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `PYTHONPATH=src python3 -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name leaf_mod --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name leaf_mod --format text`
- local forbidden-claim scan
- `git diff --check`
- `git diff --cached --check`