### PR TITLE
Block conflicting extract port proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,9 +289,10 @@ pre-stable and documented in
 `refactor-plan` emits proposal-only rename-module, extract-port, and
 move-module planning envelopes over scanner-detected module boundaries.
 It records requested inputs, a bounded preflight status including existing
-rename-target conflicts, and planned review steps, but it does not write
-files, apply patches, run validation, invoke `pccx-lab` or the launcher, call
-providers, touch hardware, or perform automatic repository actions.
+rename-target and target-port conflicts, and planned review steps, but it does
+not write files, apply patches, run validation, invoke `pccx-lab` or the
+launcher, call providers, touch hardware, or perform automatic repository
+actions.
 `validation-plan`, `refactor-review`, `refactor-approval`,
 `refactor-application`, `refactor-result`, `refactor-handoff`,
 `refactor-checklist`, and `refactor-session` extend that reviewed flow with

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -1297,8 +1297,9 @@ review steps, and safety flags. Example shape:
 
 Blocked proposals still return JSON so editor consumers can display why a
 request is not ready for review. For example, a missing module, missing
-required input, existing rename target, absolute destination path, or invalid
-identifier produces `preflight.status: "blocked"` with reasons.
+required input, existing rename target, existing target port name, absolute
+destination path, or invalid identifier produces `preflight.status: "blocked"`
+with reasons.
 
 This boundary is intentionally limited to proposal metadata. It does not
 rewrite symbols, edit ports, move files, generate patches, run validation,

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -5082,6 +5082,7 @@ def _preflight(
     matches: list[dict[str, Any]],
     requested: dict[str, Any],
     modules: list[dict[str, Any]] | None = None,
+    existing_port_names: list[str] | None = None,
 ) -> dict[str, Any]:
     reasons: list[str] = []
     required = _REFACTOR_REQUIRED_FIELDS[action]
@@ -5113,6 +5114,11 @@ def _preflight(
     if action == "extract-port" and requested["port_name"]:
         if not _safe_identifier(requested["port_name"]):
             reasons.append("port-name must be a SystemVerilog-style identifier")
+        if requested["port_name"] in (existing_port_names or []):
+            reasons.append(
+                "port-name already exists in scanned module header: "
+                f"{requested['port_name']}"
+            )
 
     if action == "move-module" and requested["destination"]:
         destination = str(requested["destination"])
@@ -5154,14 +5160,28 @@ def build_refactor_proposal(
         width=width,
         destination=destination,
     )
+    selected_module = matches[0] if len(matches) == 1 else None
+    existing_port_names: list[str] = []
+    if (
+        action == "extract-port"
+        and requested["port_name"]
+        and selected_module is not None
+    ):
+        visible_lines = _visible_lines(Path(selected_module["file"]))
+        header = _module_header(selected_module, visible_lines)
+        existing_port_names = [
+            port["name"]
+            for port in _scan_header_ports(selected_module, header["lines"])
+        ]
+
     preflight = _preflight(
         action,
         module_name,
         matches,
         requested,
         organization["modules"],
+        existing_port_names,
     )
-    selected_module = matches[0] if len(matches) == 1 else None
 
     return {
         "action": action,

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -2018,6 +2018,26 @@ def test_build_refactor_proposal_extract_port_requires_direction():
     assert proposal["safety"]["writes_files"] is False
 
 
+def test_build_refactor_proposal_blocks_existing_port_name():
+    proposal = build_refactor_proposal(
+        str(FIXTURE),
+        FIXTURE,
+        "extract-port",
+        "top_mod",
+        port_name="clk",
+        direction="output",
+    )
+
+    assert proposal["proposal_state"] == "proposal-only"
+    assert proposal["writes_files"] is False
+    assert proposal["preflight"]["status"] == "blocked"
+    assert proposal["preflight"]["reasons"] == [
+        "port-name already exists in scanned module header: clk"
+    ]
+    assert proposal["safety"]["applies_patch"] is False
+    assert proposal["safety"]["runs_validation"] is False
+
+
 def test_build_refactor_validation_plan_is_proposal_only():
     plan = build_refactor_validation_plan(
         str(FIXTURE),
@@ -3807,6 +3827,30 @@ def test_cli_refactor_plan_blocks_existing_rename_target():
     assert payload["preflight"]["status"] == "blocked"
     assert payload["preflight"]["reasons"] == [
         "new-name already exists in scanned modules: leaf_mod"
+    ]
+    assert payload["writes_files"] is False
+
+
+def test_cli_refactor_plan_blocks_existing_port_name():
+    result = _run_cli(
+        "refactor-plan",
+        str(FIXTURE),
+        "--action",
+        "extract-port",
+        "--module",
+        "top_mod",
+        "--port-name",
+        "clk",
+        "--direction",
+        "output",
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["preflight"]["status"] == "blocked"
+    assert payload["preflight"]["reasons"] == [
+        "port-name already exists in scanned module header: clk"
     ]
     assert payload["writes_files"] is False
 


### PR DESCRIPTION
## Summary
- block proposal-only `extract-port` requests when the requested port name already exists in the scanned target module header
- keep blocked proposals JSON-visible for editor review without applying edits or running validation
- document the preflight reason and cover builder plus CLI behavior

Refs #8

## Validation
- `python3 -m py_compile src/pccx_ide_cli/module_organization.py tests/test_module_organization.py`
- `python3 -m pytest tests/test_module_organization.py`
- `python3 -m pytest -q`
- `python3 scripts/check-source-headers.py`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `PYTHONPATH=src python3 -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action extract-port --module top_mod --port-name clk --direction output --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action extract-port --module top_mod --port-name clk --direction output --format text`
- local forbidden-claim scan
- `git diff --check`
- `git diff --cached --check`