### PR TITLE
Block same-file move module proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,10 +289,10 @@ pre-stable and documented in
 `refactor-plan` emits proposal-only rename-module, extract-port, and
 move-module planning envelopes over scanner-detected module boundaries.
 It records requested inputs, a bounded preflight status including existing
-rename-target and target-port conflicts, and planned review steps, but it does
-not write files, apply patches, run validation, invoke `pccx-lab` or the
-launcher, call providers, touch hardware, or perform automatic repository
-actions.
+rename-target conflicts, target-port conflicts, and same-file move destinations,
+and planned review steps, but it does not write files, apply patches, run
+validation, invoke `pccx-lab` or the launcher, call providers, touch hardware,
+or perform automatic repository actions.
 `validation-plan`, `refactor-review`, `refactor-approval`,
 `refactor-application`, `refactor-result`, `refactor-handoff`,
 `refactor-checklist`, and `refactor-session` extend that reviewed flow with

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -1298,8 +1298,8 @@ review steps, and safety flags. Example shape:
 Blocked proposals still return JSON so editor consumers can display why a
 request is not ready for review. For example, a missing module, missing
 required input, existing rename target, existing target port name, absolute
-destination path, or invalid identifier produces `preflight.status: "blocked"`
-with reasons.
+destination path, destination that matches the current module source file, or
+invalid identifier produces `preflight.status: "blocked"` with reasons.
 
 This boundary is intentionally limited to proposal metadata. It does not
 rewrite symbols, edit ports, move files, generate patches, run validation,

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -5083,6 +5083,7 @@ def _preflight(
     requested: dict[str, Any],
     modules: list[dict[str, Any]] | None = None,
     existing_port_names: list[str] | None = None,
+    source_file: str | None = None,
 ) -> dict[str, Any]:
     reasons: list[str] = []
     required = _REFACTOR_REQUIRED_FIELDS[action]
@@ -5126,12 +5127,25 @@ def _preflight(
             reasons.append("destination must be a relative path inside the workspace")
         if not destination.endswith((".sv", ".v")):
             reasons.append("destination should end with .sv or .v")
+        if source_file and _same_path(destination, source_file):
+            reasons.append("destination matches the current module source file")
 
     return {
         "reasons": reasons,
         "requires_approval_before_write": True,
         "status": "blocked" if reasons else "ready-for-review",
     }
+
+
+def _same_path(left: str, right: str) -> bool:
+    left_path = Path(left)
+    right_path = Path(right)
+    if left_path.as_posix() == right_path.as_posix():
+        return True
+    try:
+        return left_path.resolve(strict=False) == right_path.resolve(strict=False)
+    except OSError:
+        return False
 
 
 def build_refactor_proposal(
@@ -5181,6 +5195,7 @@ def build_refactor_proposal(
         requested,
         organization["modules"],
         existing_port_names,
+        str(selected_module["file"]) if selected_module is not None else None,
     )
 
     return {

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -2004,6 +2004,26 @@ def test_build_refactor_proposal_blocks_missing_module():
     assert proposal["planned_steps"] == []
 
 
+def test_build_refactor_proposal_blocks_move_to_same_source_file():
+    relative_fixture = Path("fixtures") / "organization" / "hierarchy_top.sv"
+    proposal = build_refactor_proposal(
+        str(relative_fixture),
+        relative_fixture,
+        "move-module",
+        "leaf_mod",
+        destination=str(relative_fixture),
+    )
+
+    assert proposal["proposal_state"] == "proposal-only"
+    assert proposal["writes_files"] is False
+    assert proposal["preflight"]["status"] == "blocked"
+    assert proposal["preflight"]["reasons"] == [
+        "destination matches the current module source file"
+    ]
+    assert proposal["safety"]["moves_files"] is False
+    assert proposal["safety"]["runs_validation"] is False
+
+
 def test_build_refactor_proposal_extract_port_requires_direction():
     proposal = build_refactor_proposal(
         str(FIXTURE),
@@ -3853,6 +3873,30 @@ def test_cli_refactor_plan_blocks_existing_port_name():
         "port-name already exists in scanned module header: clk"
     ]
     assert payload["writes_files"] is False
+
+
+def test_cli_refactor_plan_blocks_move_to_same_source_file():
+    relative_fixture = Path("fixtures") / "organization" / "hierarchy_top.sv"
+    result = _run_cli(
+        "refactor-plan",
+        str(relative_fixture),
+        "--action",
+        "move-module",
+        "--module",
+        "leaf_mod",
+        "--destination",
+        str(relative_fixture),
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["preflight"]["status"] == "blocked"
+    assert payload["preflight"]["reasons"] == [
+        "destination matches the current module source file"
+    ]
+    assert payload["writes_files"] is False
+    assert payload["safety"]["moves_files"] is False
 
 
 def test_cli_refactor_plan_text():


### PR DESCRIPTION
## Summary
- Block proposal-only move-module requests when the destination resolves to the current module source file.
- Keep blocked proposals visible in JSON/text output with write and move execution disabled.
- Document the preflight blocker and add focused builder/CLI coverage.

Refs #8.

## Validation
- `python3 -m py_compile src/pccx_ide_cli/module_organization.py tests/test_module_organization.py`
- `python3 -m pytest tests/test_module_organization.py` (224 passed)
- `python3 -m pytest -q` (392 passed)
- `python3 scripts/check-source-headers.py`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `find scripts -type f -name '*.sh' -exec bash -n {} +`
- `PYTHONPATH=src python3 -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action move-module --module leaf_mod --destination fixtures/organization/hierarchy_top.sv --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action move-module --module leaf_mod --destination fixtures/organization/hierarchy_top.sv --format text`
- local forbidden-claim scan matching CI: clean
- `git diff --check`
- `git diff --cached --check`