### PR TITLE
Block invalid extract port widths

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,10 +289,11 @@ pre-stable and documented in
 `refactor-plan` emits proposal-only rename-module, extract-port, and
 move-module planning envelopes over scanner-detected module boundaries.
 It records requested inputs, a bounded preflight status including existing
-rename-target conflicts, target-port conflicts, and same-file move destinations,
-and planned review steps, but it does not write files, apply patches, run
-validation, invoke `pccx-lab` or the launcher, call providers, touch hardware,
-or perform automatic repository actions.
+rename-target conflicts, target-port conflicts, invalid extract-port width
+syntax, and same-file move destinations, and planned review steps, but it does
+not write files, apply patches, run validation, invoke `pccx-lab` or the
+launcher, call providers, touch hardware, or perform automatic repository
+actions.
 `validation-plan`, `refactor-review`, `refactor-approval`,
 `refactor-application`, `refactor-result`, `refactor-handoff`,
 `refactor-checklist`, and `refactor-session` extend that reviewed flow with

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -1298,8 +1298,9 @@ review steps, and safety flags. Example shape:
 Blocked proposals still return JSON so editor consumers can display why a
 request is not ready for review. For example, a missing module, missing
 required input, existing rename target, existing target port name, absolute
-destination path, destination that matches the current module source file, or
-invalid identifier produces `preflight.status: "blocked"` with reasons.
+destination path, destination that matches the current module source file,
+invalid extract-port width, or invalid identifier produces
+`preflight.status: "blocked"` with reasons.
 
 This boundary is intentionally limited to proposal metadata. It does not
 rewrite symbols, edit ports, move files, generate patches, run validation,

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -16,6 +16,7 @@ _INSTANCE_RE = re.compile(
 _IDENT_RE = re.compile(r"\b[A-Za-z_]\w*\b")
 _PORT_DIRECTION_RE = re.compile(r"\b(input|output|inout)\b")
 _PORT_WIDTH_RE = re.compile(r"(\[[^\]]+\])")
+_PORT_WIDTH_LITERAL_RE = re.compile(r"(?:\[[^\[\]\r\n]+\])+")
 _PORT_NAMED_CONNECTION_RE = re.compile(r"\.\s*([A-Za-z_]\w*)\s*\(")
 _PORT_WILDCARD_CONNECTION_RE = re.compile(r"\.\s*\*")
 _PORT_CONNECTION_SCAN_LINE_LIMIT = 40
@@ -464,6 +465,10 @@ _REFACTOR_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
 
 def _safe_identifier(value: str | None) -> bool:
     return bool(value and re.fullmatch(r"[A-Za-z_]\w*", value))
+
+
+def _safe_port_width(value: str | None) -> bool:
+    return bool(value and _PORT_WIDTH_LITERAL_RE.fullmatch(value.strip()))
 
 
 def _refactor_safety_flags() -> dict[str, bool]:
@@ -5120,6 +5125,8 @@ def _preflight(
                 "port-name already exists in scanned module header: "
                 f"{requested['port_name']}"
             )
+        if requested["width"] and not _safe_port_width(str(requested["width"])):
+            reasons.append("width must be a bracketed SystemVerilog-style range")
 
     if action == "move-module" and requested["destination"]:
         destination = str(requested["destination"])

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -2058,6 +2058,27 @@ def test_build_refactor_proposal_blocks_existing_port_name():
     assert proposal["safety"]["runs_validation"] is False
 
 
+def test_build_refactor_proposal_blocks_unbracketed_port_width():
+    proposal = build_refactor_proposal(
+        str(FIXTURE),
+        FIXTURE,
+        "extract-port",
+        "top_mod",
+        port_name="valid_i",
+        direction="input",
+        width="7:0",
+    )
+
+    assert proposal["proposal_state"] == "proposal-only"
+    assert proposal["writes_files"] is False
+    assert proposal["preflight"]["status"] == "blocked"
+    assert proposal["preflight"]["reasons"] == [
+        "width must be a bracketed SystemVerilog-style range"
+    ]
+    assert proposal["safety"]["applies_patch"] is False
+    assert proposal["safety"]["runs_validation"] is False
+
+
 def test_build_refactor_validation_plan_is_proposal_only():
     plan = build_refactor_validation_plan(
         str(FIXTURE),
@@ -3897,6 +3918,32 @@ def test_cli_refactor_plan_blocks_move_to_same_source_file():
     ]
     assert payload["writes_files"] is False
     assert payload["safety"]["moves_files"] is False
+
+
+def test_cli_refactor_plan_blocks_unbracketed_port_width():
+    result = _run_cli(
+        "refactor-plan",
+        str(FIXTURE),
+        "--action",
+        "extract-port",
+        "--module",
+        "top_mod",
+        "--port-name",
+        "valid_i",
+        "--direction",
+        "input",
+        "--width",
+        "7:0",
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["preflight"]["status"] == "blocked"
+    assert payload["preflight"]["reasons"] == [
+        "width must be a bracketed SystemVerilog-style range"
+    ]
+    assert payload["writes_files"] is False
 
 
 def test_cli_refactor_plan_text():


### PR DESCRIPTION
## Summary
- Block proposal-only extract-port requests when an optional width is not bracketed range text.
- Keep blocked proposals visible in JSON/text output with write and validation execution disabled.
- Document the preflight blocker and add focused builder/CLI coverage.

Refs #8.

## Validation
- `python3 -m py_compile src/pccx_ide_cli/module_organization.py tests/test_module_organization.py`
- `python3 -m pytest tests/test_module_organization.py` (226 passed)
- `python3 -m pytest -q` (394 passed)
- `python3 scripts/check-source-headers.py`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `find scripts -type f -name '*.sh' -exec bash -n {} +`
- `PYTHONPATH=src python3 -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action extract-port --module top_mod --port-name valid_i --direction input --width 7:0 --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action extract-port --module top_mod --port-name valid_i --direction input --width 7:0 --format text`
- `PYTHONPATH=src python3 -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action extract-port --module top_mod --port-name valid_i --direction input --width '[7:0]' --format json`
- local forbidden-claim scan matching CI: clean
- `git diff --check`
- `git diff --cached --check`