### PR TITLE
Block invalid extract port directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,10 +290,10 @@ pre-stable and documented in
 move-module planning envelopes over scanner-detected module boundaries.
 It records requested inputs, a bounded preflight status including existing
 rename-target conflicts, target-port conflicts, invalid extract-port width
-syntax, and same-file move destinations, and planned review steps, but it does
-not write files, apply patches, run validation, invoke `pccx-lab` or the
-launcher, call providers, touch hardware, or perform automatic repository
-actions.
+syntax, invalid extract-port direction, and same-file move destinations, and
+planned review steps, but it does not write files, apply patches, run
+validation, invoke `pccx-lab` or the launcher, call providers, touch hardware,
+or perform automatic repository actions.
 `validation-plan`, `refactor-review`, `refactor-approval`,
 `refactor-application`, `refactor-result`, `refactor-handoff`,
 `refactor-checklist`, and `refactor-session` extend that reviewed flow with

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -1299,7 +1299,8 @@ Blocked proposals still return JSON so editor consumers can display why a
 request is not ready for review. For example, a missing module, missing
 required input, existing rename target, existing target port name, absolute
 destination path, destination that matches the current module source file,
-invalid extract-port width, or invalid identifier produces
+invalid extract-port width, invalid extract-port direction, or invalid
+identifier produces
 `preflight.status: "blocked"` with reasons.
 
 This boundary is intentionally limited to proposal metadata. It does not

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -461,6 +461,7 @@ _REFACTOR_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
     "extract-port": ("port_name", "direction"),
     "move-module": ("destination",),
 }
+_REFACTOR_PORT_DIRECTIONS = ("input", "output", "inout")
 
 
 def _safe_identifier(value: str | None) -> bool:
@@ -469,6 +470,10 @@ def _safe_identifier(value: str | None) -> bool:
 
 def _safe_port_width(value: str | None) -> bool:
     return bool(value and _PORT_WIDTH_LITERAL_RE.fullmatch(value.strip()))
+
+
+def _safe_port_direction(value: str | None) -> bool:
+    return value in _REFACTOR_PORT_DIRECTIONS
 
 
 def _refactor_safety_flags() -> dict[str, bool]:
@@ -5125,6 +5130,10 @@ def _preflight(
                 "port-name already exists in scanned module header: "
                 f"{requested['port_name']}"
             )
+        if requested["direction"] and not _safe_port_direction(
+            str(requested["direction"])
+        ):
+            reasons.append("direction must be input, output, or inout")
         if requested["width"] and not _safe_port_width(str(requested["width"])):
             reasons.append("width must be a bracketed SystemVerilog-style range")
 

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -2038,6 +2038,26 @@ def test_build_refactor_proposal_extract_port_requires_direction():
     assert proposal["safety"]["writes_files"] is False
 
 
+def test_build_refactor_proposal_blocks_invalid_port_direction():
+    proposal = build_refactor_proposal(
+        str(FIXTURE),
+        FIXTURE,
+        "extract-port",
+        "top_mod",
+        port_name="enable_i",
+        direction="wire",
+    )
+
+    assert proposal["proposal_state"] == "proposal-only"
+    assert proposal["writes_files"] is False
+    assert proposal["preflight"]["status"] == "blocked"
+    assert proposal["preflight"]["reasons"] == [
+        "direction must be input, output, or inout"
+    ]
+    assert proposal["safety"]["applies_patch"] is False
+    assert proposal["safety"]["runs_validation"] is False
+
+
 def test_build_refactor_proposal_blocks_existing_port_name():
     proposal = build_refactor_proposal(
         str(FIXTURE),
@@ -2140,6 +2160,28 @@ def test_build_refactor_validation_plan_blocks_post_change_commands():
     assert groups["post-change-local-validation"]["commands"] == []
     assert groups["post-change-local-validation"]["blocked_by"] == [
         "missing required direction"
+    ]
+
+
+def test_build_refactor_validation_plan_blocks_invalid_port_direction():
+    plan = build_refactor_validation_plan(
+        str(FIXTURE),
+        FIXTURE,
+        "extract-port",
+        "top_mod",
+        port_name="valid_i",
+        direction="wire",
+    )
+
+    assert plan["validation_state"] == "blocked"
+    assert plan["preflight"]["reasons"] == [
+        "direction must be input, output, or inout"
+    ]
+    groups = {group["phase"]: group for group in plan["validation_groups"]}
+    assert groups["post-change-local-validation"]["status"] == "blocked"
+    assert groups["post-change-local-validation"]["commands"] == []
+    assert groups["post-change-local-validation"]["blocked_by"] == [
+        "direction must be input, output, or inout"
     ]
 
 


### PR DESCRIPTION
## Summary
- reject extract-port directions outside `input`, `output`, and `inout` in the refactor proposal preflight
- propagate the blocked preflight through validation-plan command grouping
- document invalid extract-port direction as a blocked proposal reason

Refs #8.

## Validation
- `pytest -q tests/test_module_organization.py -k "invalid_port_direction or extract_port_requires_direction or blocks_existing_port_name or blocks_unbracketed_port_width or validation_plan_blocks"`
- `pytest -q`
- `python3 -m compileall src tests`
- `git diff --check`
- workflow claim-scan logic
- workflow link-sanity checks
- scaffold-smoke CLI checks from `.github/workflows/ci.yml`
- `python3 scripts/check-source-headers.py`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `find scripts -type f -name '*.sh' -exec bash -n {} +`
