### PR TITLE
Block unused refactor proposal inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,10 +290,10 @@ pre-stable and documented in
 move-module planning envelopes over scanner-detected module boundaries.
 It records requested inputs, a bounded preflight status including existing
 rename-target conflicts, target-port conflicts, invalid extract-port width
-syntax, invalid extract-port direction, and same-file move destinations, and
-planned review steps, but it does not write files, apply patches, run
-validation, invoke `pccx-lab` or the launcher, call providers, touch hardware,
-or perform automatic repository actions.
+syntax, invalid extract-port direction, unused action inputs, and same-file
+move destinations, and planned review steps, but it does not write files,
+apply patches, run validation, invoke `pccx-lab` or the launcher, call
+providers, touch hardware, or perform automatic repository actions.
 `validation-plan`, `refactor-review`, `refactor-approval`,
 `refactor-application`, `refactor-result`, `refactor-handoff`,
 `refactor-checklist`, and `refactor-session` extend that reviewed flow with

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -1300,7 +1300,7 @@ request is not ready for review. For example, a missing module, missing
 required input, existing rename target, existing target port name, absolute
 destination path, destination that matches the current module source file,
 invalid extract-port width, invalid extract-port direction, or invalid
-identifier produces
+identifier, or an input that does not belong to the selected action produces
 `preflight.status: "blocked"` with reasons.
 
 This boundary is intentionally limited to proposal metadata. It does not

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -461,6 +461,18 @@ _REFACTOR_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
     "extract-port": ("port_name", "direction"),
     "move-module": ("destination",),
 }
+_REFACTOR_INPUT_FIELDS = (
+    "new_name",
+    "port_name",
+    "direction",
+    "width",
+    "destination",
+)
+_REFACTOR_ALLOWED_FIELDS: dict[str, tuple[str, ...]] = {
+    "rename-module": ("new_name",),
+    "extract-port": ("port_name", "direction", "width"),
+    "move-module": ("destination",),
+}
 _REFACTOR_PORT_DIRECTIONS = ("input", "output", "inout")
 
 
@@ -474,6 +486,10 @@ def _safe_port_width(value: str | None) -> bool:
 
 def _safe_port_direction(value: str | None) -> bool:
     return value in _REFACTOR_PORT_DIRECTIONS
+
+
+def _field_label(field: str) -> str:
+    return field.replace("_", "-")
 
 
 def _refactor_safety_flags() -> dict[str, bool]:
@@ -5097,9 +5113,14 @@ def _preflight(
 ) -> dict[str, Any]:
     reasons: list[str] = []
     required = _REFACTOR_REQUIRED_FIELDS[action]
+    allowed = _REFACTOR_ALLOWED_FIELDS[action]
     for field in required:
         if not requested[field]:
-            reasons.append(f"missing required {field.replace('_', '-')}")
+            reasons.append(f"missing required {_field_label(field)}")
+
+    for field in _REFACTOR_INPUT_FIELDS:
+        if field not in allowed and requested[field]:
+            reasons.append(f"{_field_label(field)} is not used by {action} proposals")
 
     if len(matches) == 0:
         reasons.append(f"module not found: {module_name}")

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -2058,6 +2058,47 @@ def test_build_refactor_proposal_blocks_invalid_port_direction():
     assert proposal["safety"]["runs_validation"] is False
 
 
+def test_build_refactor_proposal_blocks_unused_rename_input():
+    proposal = build_refactor_proposal(
+        str(FIXTURE),
+        FIXTURE,
+        "rename-module",
+        "top_mod",
+        new_name="top_mod_next",
+        port_name="valid_i",
+    )
+
+    assert proposal["proposal_state"] == "proposal-only"
+    assert proposal["writes_files"] is False
+    assert proposal["preflight"]["status"] == "blocked"
+    assert proposal["preflight"]["reasons"] == [
+        "port-name is not used by rename-module proposals"
+    ]
+    assert proposal["safety"]["applies_patch"] is False
+    assert proposal["safety"]["runs_validation"] is False
+
+
+def test_build_refactor_proposal_blocks_unused_extract_destination():
+    proposal = build_refactor_proposal(
+        str(FIXTURE),
+        FIXTURE,
+        "extract-port",
+        "top_mod",
+        port_name="valid_i",
+        direction="input",
+        destination="rtl/top_mod.sv",
+    )
+
+    assert proposal["proposal_state"] == "proposal-only"
+    assert proposal["writes_files"] is False
+    assert proposal["preflight"]["status"] == "blocked"
+    assert proposal["preflight"]["reasons"] == [
+        "destination is not used by extract-port proposals"
+    ]
+    assert proposal["safety"]["applies_patch"] is False
+    assert proposal["safety"]["runs_validation"] is False
+
+
 def test_build_refactor_proposal_blocks_existing_port_name():
     proposal = build_refactor_proposal(
         str(FIXTURE),
@@ -3986,6 +4027,27 @@ def test_cli_refactor_plan_blocks_unbracketed_port_width():
         "width must be a bracketed SystemVerilog-style range"
     ]
     assert payload["writes_files"] is False
+
+
+def test_cli_refactor_plan_text_blocks_unused_move_input():
+    result = _run_cli(
+        "refactor-plan",
+        str(FIXTURE),
+        "--action",
+        "move-module",
+        "--module",
+        "leaf_mod",
+        "--destination",
+        "rtl/leaf_mod.sv",
+        "--new-name",
+        "leaf_mod_next",
+        "--format",
+        "text",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "preflight: blocked" in result.stdout
+    assert "blocked: new-name is not used by move-module proposals" in result.stdout
+    assert "writes files: no" in result.stdout
 
 
 def test_cli_refactor_plan_text():


### PR DESCRIPTION
## Summary
- block refactor-plan inputs that do not belong to the selected action
- keep unused-input failures in proposal-only preflight output for JSON/text consumers
- document unused action inputs as a blocked proposal reason

Refs #8.

## Validation
- `pytest -q tests/test_module_organization.py -k "unused_rename_input or unused_extract_destination or unused_move_input or invalid_port_direction or validation_plan_blocks"`
- `PYTHONPATH=src python3 -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --port-name valid_i --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action move-module --module leaf_mod --destination rtl/leaf_mod.sv --new-name leaf_mod_next --format text`
- `PYTHONPATH=src python3 -m pccx_ide_cli refactor-plan fixtures/organization/hierarchy_top.sv --action extract-port --module top_mod --port-name valid_i --direction input --format json`
- `PYTHONPATH=src python3 -m pccx_ide_cli validation-plan fixtures/organization/hierarchy_top.sv --action rename-module --module top_mod --new-name top_mod_next --destination rtl/top_mod.sv --format json`
- `pytest -q`
- `python3 -m compileall src tests`
- `git diff --check`
- workflow claim-scan logic
- workflow link-sanity checks
- scaffold-smoke CLI checks from `.github/workflows/ci.yml`
- `python3 scripts/check-source-headers.py`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `find scripts -type f -name '*.sh' -exec bash -n {} +`
