### PR TITLE
Add refactor identifier preflight coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,11 +289,12 @@ pre-stable and documented in
 `refactor-plan` emits proposal-only rename-module, extract-port, and
 move-module planning envelopes over scanner-detected module boundaries.
 It records requested inputs, a bounded preflight status including existing
-rename-target conflicts, target-port conflicts, invalid extract-port width
-syntax, invalid extract-port direction, unused action inputs, and same-file
-move destinations, and planned review steps, but it does not write files,
-apply patches, run validation, invoke `pccx-lab` or the launcher, call
-providers, touch hardware, or perform automatic repository actions.
+rename-target conflicts, target-port conflicts, invalid rename or port
+identifier syntax, invalid extract-port width syntax, invalid extract-port
+direction, unused action inputs, and same-file move destinations, and planned
+review steps, but it does not write files, apply patches, run validation,
+invoke `pccx-lab` or the launcher, call providers, touch hardware, or perform
+automatic repository actions.
 `validation-plan`, `refactor-review`, `refactor-approval`,
 `refactor-application`, `refactor-result`, `refactor-handoff`,
 `refactor-checklist`, and `refactor-session` extend that reviewed flow with

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -1989,6 +1989,25 @@ def test_build_refactor_proposal_blocks_existing_new_name():
     assert proposal["safety"]["runs_validation"] is False
 
 
+def test_build_refactor_proposal_blocks_invalid_new_name():
+    proposal = build_refactor_proposal(
+        str(FIXTURE),
+        FIXTURE,
+        "rename-module",
+        "top_mod",
+        new_name="2bad",
+    )
+
+    assert proposal["proposal_state"] == "proposal-only"
+    assert proposal["writes_files"] is False
+    assert proposal["preflight"]["status"] == "blocked"
+    assert proposal["preflight"]["reasons"] == [
+        "new-name must be a SystemVerilog-style identifier"
+    ]
+    assert proposal["safety"]["applies_patch"] is False
+    assert proposal["safety"]["runs_validation"] is False
+
+
 def test_build_refactor_proposal_blocks_missing_module():
     proposal = build_refactor_proposal(
         str(FIXTURE),
@@ -2053,6 +2072,26 @@ def test_build_refactor_proposal_blocks_invalid_port_direction():
     assert proposal["preflight"]["status"] == "blocked"
     assert proposal["preflight"]["reasons"] == [
         "direction must be input, output, or inout"
+    ]
+    assert proposal["safety"]["applies_patch"] is False
+    assert proposal["safety"]["runs_validation"] is False
+
+
+def test_build_refactor_proposal_blocks_invalid_port_name():
+    proposal = build_refactor_proposal(
+        str(FIXTURE),
+        FIXTURE,
+        "extract-port",
+        "top_mod",
+        port_name="bad-port",
+        direction="input",
+    )
+
+    assert proposal["proposal_state"] == "proposal-only"
+    assert proposal["writes_files"] is False
+    assert proposal["preflight"]["status"] == "blocked"
+    assert proposal["preflight"]["reasons"] == [
+        "port-name must be a SystemVerilog-style identifier"
     ]
     assert proposal["safety"]["applies_patch"] is False
     assert proposal["safety"]["runs_validation"] is False
@@ -3951,6 +3990,28 @@ def test_cli_refactor_plan_blocks_existing_rename_target():
     assert payload["preflight"]["status"] == "blocked"
     assert payload["preflight"]["reasons"] == [
         "new-name already exists in scanned modules: leaf_mod"
+    ]
+    assert payload["writes_files"] is False
+
+
+def test_cli_refactor_plan_blocks_invalid_identifier():
+    result = _run_cli(
+        "refactor-plan",
+        str(FIXTURE),
+        "--action",
+        "rename-module",
+        "--module",
+        "top_mod",
+        "--new-name",
+        "2bad",
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["preflight"]["status"] == "blocked"
+    assert payload["preflight"]["reasons"] == [
+        "new-name must be a SystemVerilog-style identifier"
     ]
     assert payload["writes_files"] is False
 


### PR DESCRIPTION
## Summary
- Add unit and CLI coverage for invalid rename-module and extract-port identifier inputs in refactor-plan preflight metadata.
- Update the README preflight list to mention invalid rename or port identifier syntax.
- Keep the refactor surface proposal-only: no file writes, refactor application, validation execution, lab/launcher invocation, provider calls, or hardware access.

Refs #8.

## Validation
- `PYTHONPATH=src python3 -m pytest -q tests/test_module_organization.py -k 'invalid_identifier or invalid_new_name or invalid_port_name'` (3 passed)
- `PYTHONPATH=src python3 -m pytest -q` (402 passed)
- `python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `find scripts -type f -name '*.sh' -exec bash -n {} +`
- `python3 scripts/check-source-headers.py`
- `git diff --check`
- workflow claim-scan logic (clean)
- README sibling-repo link sanity (clean)
- invalid identifier refactor-plan CLI JSON checks for rename-module and extract-port
