### PR TITLE
Block unsafe move module destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,10 +291,11 @@ move-module planning envelopes over scanner-detected module boundaries.
 It records requested inputs, a bounded preflight status including existing
 rename-target conflicts, target-port conflicts, invalid rename or port
 identifier syntax, invalid extract-port width syntax, invalid extract-port
-direction, unused action inputs, and same-file move destinations, and planned
-review steps, but it does not write files, apply patches, run validation,
-invoke `pccx-lab` or the launcher, call providers, touch hardware, or perform
-automatic repository actions.
+direction, unused action inputs, and unsafe move destinations such as
+absolute paths, parent traversal, unsupported extensions, or same-file moves,
+and planned review steps, but it does not write files, apply patches, run
+validation, invoke `pccx-lab` or the launcher, call providers, touch hardware,
+or perform automatic repository actions.
 `validation-plan`, `refactor-review`, `refactor-approval`,
 `refactor-application`, `refactor-result`, `refactor-handoff`,
 `refactor-checklist`, and `refactor-session` extend that reviewed flow with

--- a/docs/MODULE_ORGANIZATION_WORKFLOW.md
+++ b/docs/MODULE_ORGANIZATION_WORKFLOW.md
@@ -1298,9 +1298,10 @@ review steps, and safety flags. Example shape:
 Blocked proposals still return JSON so editor consumers can display why a
 request is not ready for review. For example, a missing module, missing
 required input, existing rename target, existing target port name, absolute
-destination path, destination that matches the current module source file,
-invalid extract-port width, invalid extract-port direction, or invalid
-identifier, or an input that does not belong to the selected action produces
+destination path, parent-directory traversal, unsupported destination
+extension, destination that matches the current module source file, invalid
+extract-port width, invalid extract-port direction, or invalid identifier, or
+an input that does not belong to the selected action produces
 `preflight.status: "blocked"` with reasons.
 
 This boundary is intentionally limited to proposal metadata. It does not

--- a/src/pccx_ide_cli/module_organization.py
+++ b/src/pccx_ide_cli/module_organization.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import re
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any
 
 from .module_index import _strip_block_comments, scan_path
@@ -486,6 +486,19 @@ def _safe_port_width(value: str | None) -> bool:
 
 def _safe_port_direction(value: str | None) -> bool:
     return value in _REFACTOR_PORT_DIRECTIONS
+
+
+def _safe_workspace_relative_path(value: str) -> bool:
+    path = Path(value)
+    windows_path = PureWindowsPath(value)
+    return (
+        not path.is_absolute()
+        and not windows_path.is_absolute()
+        and not windows_path.drive
+        and not windows_path.root
+        and ".." not in path.parts
+        and ".." not in windows_path.parts
+    )
 
 
 def _field_label(field: str) -> str:
@@ -5160,7 +5173,7 @@ def _preflight(
 
     if action == "move-module" and requested["destination"]:
         destination = str(requested["destination"])
-        if destination.startswith("/") or ".." in Path(destination).parts:
+        if not _safe_workspace_relative_path(destination):
             reasons.append("destination must be a relative path inside the workspace")
         if not destination.endswith((".sv", ".v")):
             reasons.append("destination should end with .sv or .v")

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -2043,6 +2043,25 @@ def test_build_refactor_proposal_blocks_move_to_same_source_file():
     assert proposal["safety"]["runs_validation"] is False
 
 
+def test_build_refactor_proposal_blocks_windows_absolute_move_destination():
+    proposal = build_refactor_proposal(
+        str(FIXTURE),
+        FIXTURE,
+        "move-module",
+        "leaf_mod",
+        destination=r"C:\tmp\leaf_mod.sv",
+    )
+
+    assert proposal["proposal_state"] == "proposal-only"
+    assert proposal["writes_files"] is False
+    assert proposal["preflight"]["status"] == "blocked"
+    assert proposal["preflight"]["reasons"] == [
+        "destination must be a relative path inside the workspace"
+    ]
+    assert proposal["safety"]["moves_files"] is False
+    assert proposal["safety"]["runs_validation"] is False
+
+
 def test_build_refactor_proposal_extract_port_requires_direction():
     proposal = build_refactor_proposal(
         str(FIXTURE),
@@ -4059,6 +4078,29 @@ def test_cli_refactor_plan_blocks_move_to_same_source_file():
     assert payload["preflight"]["status"] == "blocked"
     assert payload["preflight"]["reasons"] == [
         "destination matches the current module source file"
+    ]
+    assert payload["writes_files"] is False
+    assert payload["safety"]["moves_files"] is False
+
+
+def test_cli_refactor_plan_blocks_move_parent_traversal_destination():
+    result = _run_cli(
+        "refactor-plan",
+        str(FIXTURE),
+        "--action",
+        "move-module",
+        "--module",
+        "leaf_mod",
+        "--destination",
+        r"rtl\..\leaf_mod.sv",
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["preflight"]["status"] == "blocked"
+    assert payload["preflight"]["reasons"] == [
+        "destination must be a relative path inside the workspace"
     ]
     assert payload["writes_files"] is False
     assert payload["safety"]["moves_files"] is False


### PR DESCRIPTION
## Summary
- Block Windows-style absolute/rooted move-module destinations and Windows-style parent traversal in proposal-only refactor preflight metadata.
- Keep move-module planning review-only with no file moves, writes, validation execution, or shell execution.
- Update README and module organization workflow docs to list unsafe move destination blockers.

Refs #8.

## Validation
- `PYTHONPATH=src python3 -m pytest -q tests/test_module_organization.py -k 'windows_absolute_move_destination or parent_traversal_destination'` (2 passed)
- `PYTHONPATH=src python3 -m pytest -q` (404 passed)
- `python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `find scripts -type f -name '*.sh' -exec bash -n {} +`
- `python3 scripts/check-source-headers.py`
- `git diff --check`
- workflow claim-scan logic (clean)
- README sibling-repo link sanity (clean)
- move-module destination CLI JSON checks for Windows absolute path and parent traversal
