### PR TITLE
docs(readme): list pccx-LLM-v003 and pccx-vision-v001 as related tracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,9 @@ formal enough to bind to.
 
 - [pccxai/pccx][pccx] — spec / docs / roadmap / release coordination
 - [pccxai/pccx-lab][pccx-lab] — verification lab + CLI / core boundary
-- [pccxai/pccx-FPGA-NPU-LLM-kv260][pccx-fpga] — RTL / KV260 / hardware evidence
+- [pccxai/pccx-FPGA-NPU-LLM-kv260][pccx-fpga] — RTL / KV260 / hardware evidence (v002 LLM line)
+- [pccxai/pccx-LLM-v003][pccx-llm-v003] — active LLM RTL track in a separate repository
+- [pccxai/pccx-vision-v001][pccx-vision-v001] — active vision track for related KV260-oriented work
 - [pccxai/pccx-llm-launcher][pccx-launcher] — user-facing local LLM launcher
 
 ## License
@@ -451,3 +453,5 @@ Apache License 2.0 — see [LICENSE](./LICENSE).
 [pccx-lab]: https://github.com/pccxai/pccx-lab
 [pccx-fpga]: https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260
 [pccx-launcher]: https://github.com/pccxai/pccx-llm-launcher
+[pccx-llm-v003]: https://github.com/pccxai/pccx-LLM-v003
+[pccx-vision-v001]: https://github.com/pccxai/pccx-vision-v001


### PR DESCRIPTION
## Summary

Adds README related links for:

- [`pccx-LLM-v003`](https://github.com/pccxai/pccx-LLM-v003) — active LLM RTL track in a separate repository.
- [`pccx-vision-v001`](https://github.com/pccxai/pccx-vision-v001) — active vision track for related KV260-oriented work.

The `pccx-FPGA-NPU-LLM-kv260` line is annotated as the v002 LLM line for clarity.

## Scope

This is a README related-links update only. It does not claim runtime readiness, hardware readiness, inference success, timing closure, bitstream availability, or release status.

## Test plan

- [x] README link/style check.
- [x] Local claim wording scan.