### PR TITLE
Add module health incomplete-boundary coverage

### DIFF
--- a/scripts/editor-bridge-smoke.sh
+++ b/scripts/editor-bridge-smoke.sh
@@ -24,6 +24,11 @@ run_json() {
     | "$PY" -c "import json,sys; d=json.load(sys.stdin); assert d.get('kind') == '$expected_kind', d"
 }
 
+run_blocked_module_health() {
+  "$PY" -m pccx_ide_cli module-health fixtures/missing_endmodule.sv --format json \
+    | "$PY" -c "import json,sys; d=json.load(sys.stdin); assert d.get('kind') == 'module-graph-health-summary', d; assert d.get('health_state') == 'blocked', d; assert d.get('incomplete_module_count') == 1, d; assert d.get('safety', {}).get('writes_files') is False, d"
+}
+
 run_json editor-problems problems from-check fixtures/ok_module.sv --format json
 run_json editor-problems problems from-check fixtures/missing_endmodule.sv --format json
 run_json editor-problems problems from-xsim-log fixtures/xsim/mixed.log --format json
@@ -40,6 +45,8 @@ run_json module-path-report module-paths fixtures/organization/fanout_hierarchy.
 run_json module-fanout-report module-fanout fixtures/organization/fanout_hierarchy.sv --format json
 run_json module-fanin-report module-fanin fixtures/organization/fanout_hierarchy.sv --format json
 run_json module-duplicate-report module-duplicates fixtures/organization/duplicate_modules.sv --format json
+run_json module-graph-health-summary module-health fixtures/organization/hierarchy_top.sv --format json
+run_blocked_module_health
 run_json module-summary-view module-summary fixtures/organization/hierarchy_top.sv --format json
 run_json module-refactor-candidate-list refactor-candidates fixtures/organization/hierarchy_top.sv --format json
 run_json module-refactor-readiness-summary refactor-readiness fixtures/organization/hierarchy_top.sv --format json

--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -1665,6 +1665,37 @@ def test_build_module_graph_health_summary_blocks_unresolved_and_duplicates():
     assert "ambiguous module name: dup_mod" in duplicates["blocked_reasons"]
 
 
+def test_build_module_graph_health_summary_blocks_incomplete_boundaries():
+    report = build_module_graph_health_summary(
+        str(INCOMPLETE_FIXTURE),
+        INCOMPLETE_FIXTURE,
+    )
+
+    assert report["health_state"] == "blocked"
+    assert report["ready_for_review"] is False
+    assert report["module_count"] == 1
+    assert report["complete_module_count"] == 0
+    assert report["incomplete_module_count"] == 1
+    assert report["blocked_reasons"] == [
+        "module boundary is incomplete: bad_module"
+    ]
+    assert report["next_required_action"] == (
+        "resolve scanner-detected module graph blockers before refactor planning"
+    )
+    cards = {card["card_id"]: card for card in report["health_cards"]}
+    assert cards["boundary-completeness"]["status"] == "blocked"
+    assert cards["boundary-completeness"]["complete_module_count"] == 0
+    assert cards["boundary-completeness"]["incomplete_module_count"] == 1
+    assert report["root_names"] == ["bad_module"]
+    assert report["leaf_names"] == ["bad_module"]
+    assert report["safety"]["read_only"] is True
+    assert report["safety"]["graph_health_summary_only"] is True
+    assert report["safety"]["writes_files"] is False
+    assert report["safety"]["emits_command_descriptors"] is False
+    assert report["writes_files"] is False
+    assert '"argv"' not in json.dumps(report)
+
+
 def test_build_module_summary_view_reports_ports_and_safety():
     view = build_module_summary_view(str(FIXTURE), FIXTURE)
 
@@ -3814,6 +3845,31 @@ def test_cli_module_health_text():
     assert result.returncode == 0, result.stderr
     assert "module graph health: ready-for-review" in result.stdout
     assert "status: duplicate-modules (no-duplicates-detected)" in result.stdout
+    assert "read-only graph health summary: no command argv" in result.stdout
+
+
+def test_cli_module_health_blocks_incomplete_boundary_json():
+    result = _run_cli("module-health", str(INCOMPLETE_FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "module-graph-health-summary"
+    assert payload["health_state"] == "blocked"
+    assert payload["ready_for_review"] is False
+    assert payload["incomplete_module_count"] == 1
+    assert payload["blocked_reasons"] == [
+        "module boundary is incomplete: bad_module"
+    ]
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["emits_command_descriptors"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_module_health_blocks_incomplete_boundary_text():
+    result = _run_cli("module-health", str(INCOMPLETE_FIXTURE), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "module graph health: blocked" in result.stdout
+    assert "status: boundary-completeness (blocked)" in result.stdout
+    assert "blocked: module boundary is incomplete: bad_module" in result.stdout
     assert "read-only graph health summary: no command argv" in result.stdout
 
 


### PR DESCRIPTION
## Summary
- Add focused module-health unit coverage for incomplete module boundaries using the existing malformed fixture.
- Add CLI JSON/text assertions that the graph-health surface stays blocked, read-only, and does not emit command descriptors for incomplete boundaries.
- Extend the editor bridge smoke script to cover ready and blocked module-health JSON paths.

Refs #8.

## Validation
- `PYTHONPATH=src python3 -m pytest -q tests/test_module_organization.py`
- `python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py`
- `bash scripts/editor-bridge-smoke.sh`
- `find scripts -type f -name '*.sh' -exec bash -n {} +`
- `PYTHONPATH=src python3 -m pytest -q`
- `bash scripts/check-editor-bridge-examples.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `python3 scripts/check-source-headers.py`
- workflow claim-scan command from `.github/workflows/ci.yml`
- README sibling-link sanity check
- `git diff --check`
- `git diff --cached --check`
