### PR TITLE
Add module health CLI blocker coverage

### DIFF
--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -3873,6 +3873,41 @@ def test_cli_module_health_blocks_incomplete_boundary_text():
     assert "read-only graph health summary: no command argv" in result.stdout
 
 
+def test_cli_module_health_blocks_duplicate_modules_json():
+    result = _run_cli("module-health", str(DUPLICATE_FIXTURE), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+
+    assert payload["kind"] == "module-graph-health-summary"
+    assert payload["health_state"] == "blocked"
+    assert payload["ready_for_review"] is False
+    assert payload["duplicate_name_count"] == 1
+    assert payload["duplicate_names"] == ["dup_mod"]
+    assert payload["blocked_reasons"] == ["ambiguous module name: dup_mod"]
+    cards = {card["card_id"]: card for card in payload["health_cards"]}
+    assert cards["duplicate-modules"]["status"] == "duplicates-detected"
+    assert payload["safety"]["writes_files"] is False
+    assert payload["safety"]["emits_command_descriptors"] is False
+    assert '"argv"' not in result.stdout
+
+
+def test_cli_module_health_blocks_unresolved_instances_text():
+    result = _run_cli("module-health", str(UNRESOLVED_FIXTURE), "--format", "text")
+    assert result.returncode == 0, result.stderr
+    assert "module graph health: blocked" in result.stdout
+    assert "status: unresolved-instances (unresolved-instances-detected)" in (
+        result.stdout
+    )
+    assert (
+        "blocked: unresolved module instantiation: missing_child as u_missing "
+        "in unresolved_top"
+    ) in result.stdout
+    assert "blocked: unresolved dependencies for depth report: missing_child" in (
+        result.stdout
+    )
+    assert "read-only graph health summary: no command argv" in result.stdout
+
+
 def test_cli_module_summary_json():
     result = _run_cli("module-summary", str(FIXTURE), "--format", "json")
     assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Add CLI coverage for `module-health` duplicate-module blockers in JSON output.
- Add CLI coverage for `module-health` unresolved-instance blockers in text output.
- Keep this test-only: no scanner behavior, write-capable refactor behavior, command execution path, command argv emission, validation runner, file write, patch generation, lab/launcher/vendor/provider/hardware invocation, LSP claim, marketplace claim, or stable API/ABI claim changes.
- Refs #8.

## Validation
- `python3 -m pytest tests/test_module_organization.py -k "module_health_blocks_duplicate_modules_json or module_health_blocks_unresolved_instances_text"`
- `python3 -m pytest -q`
- `python3 -m compileall -q src tests`
- `bash scripts/editor-bridge-smoke.sh`
- `bash scripts/vscode-adapter-smoke.sh`
- `python3 scripts/check-source-headers.py`
- `find scripts -type f -name "*.sh" -exec bash -n {} +`
- workflow-equivalent claim scan
- README sibling-link sanity check
- CLI ok/missing/empty/schema smoke checks
- `git diff --check`
- `git diff --cached --check`