### PR TITLE
Add refactor status missing-path CLI coverage

### DIFF
--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -4975,6 +4975,18 @@ def test_cli_module_spans_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_refactor_candidates_missing_path_exits_nonzero():
+    result = _run_cli("refactor-candidates", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
+def test_cli_refactor_readiness_missing_path_exits_nonzero():
+    result = _run_cli("refactor-readiness", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_cli_hierarchy_missing_path_exits_nonzero():
     result = _run_cli("hierarchy", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0


### PR DESCRIPTION
Refs #8

## Summary
- Add CLI missing-path coverage for the existing refactor-candidates and refactor-readiness guards.
- Keep the change test-only; no scanner behavior or refactor output behavior changes.

## Validation
- PYTHONPATH=src python3 -m pytest -q tests/test_module_organization.py -k 'refactor_candidates_missing_path or refactor_readiness_missing_path'
- PYTHONPATH=src python3 -m pytest -q tests/test_module_organization.py
- python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py
- PYTHONPATH=src python3 -m pytest -q
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- bash scripts/vscode-adapter-smoke.sh
- find scripts -type f -name '*.sh' -exec bash -n {} +
- python3 scripts/check-source-headers.py
- git diff --check
- claim-scan clean
- required files and sibling links present
- PYTHONPATH=src python3 -m pccx_ide_cli check fixtures/ok_module.sv
- broken fixture exits non-zero

## Scope notes
No scanner behavior, write-capable refactor behavior, command argv emission, validation runner, file write, patch generation, lab/launcher/vendor/provider/hardware invocation, LSP claim, marketplace claim, or stable API/ABI claim.