### PR TITLE
Add module graph status missing-path CLI coverage

### DIFF
--- a/tests/test_module_organization.py
+++ b/tests/test_module_organization.py
@@ -5017,8 +5017,20 @@ def test_cli_module_roots_missing_path_exits_nonzero():
     assert "does not exist" in result.stderr
 
 
+def test_cli_module_leaves_missing_path_exits_nonzero():
+    result = _run_cli("module-leaves", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
 def test_cli_module_orphans_missing_path_exits_nonzero():
     result = _run_cli("module-orphans", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
+def test_cli_module_depths_missing_path_exits_nonzero():
+    result = _run_cli("module-depths", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
     assert "does not exist" in result.stderr
 
@@ -5061,6 +5073,12 @@ def test_cli_module_fanin_missing_path_exits_nonzero():
 
 def test_cli_module_summary_missing_path_exits_nonzero():
     result = _run_cli("module-summary", str(FIXTURE.parent / "missing.sv"))
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
+def test_cli_module_health_missing_path_exits_nonzero():
+    result = _run_cli("module-health", str(FIXTURE.parent / "missing.sv"))
     assert result.returncode != 0
     assert "does not exist" in result.stderr
 


### PR DESCRIPTION
Refs #8

## Summary
- Add CLI missing-path coverage for the existing module-leaves, module-depths, and module-health guards.
- Keep the change test-only; no scanner behavior or output behavior changes.

## Validation
- PYTHONPATH=src python3 -m pytest -q tests/test_module_organization.py -k 'module_leaves_missing_path or module_depths_missing_path or module_health_missing_path'
- PYTHONPATH=src python3 -m pytest -q tests/test_module_organization.py
- python3 -m py_compile src/pccx_ide_cli/*.py tests/*.py
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- bash scripts/vscode-adapter-smoke.sh
- find scripts -type f -name '*.sh' -exec bash -n {} +
- python3 scripts/check-source-headers.py
- PYTHONPATH=src python3 -m pytest -q
- git diff --check
- git diff --cached --check
- claim-scan clean

## Scope notes
No scanner behavior, write-capable refactor behavior, production command execution path, command argv emission, validation runner, file write, patch generation, lab/launcher/vendor/provider/hardware invocation, LSP claim, marketplace claim, or stable API/ABI claim.