### PR TITLE
feat(kv260): add read-only status surface for IDE

### DIFF
--- a/docs/EDITOR_BRIDGE_CONTRACT.md
+++ b/docs/EDITOR_BRIDGE_CONTRACT.md
@@ -332,3 +332,10 @@ xsim path, and text surface sketches is documented in
 - No MCP server implementation in this repo today.
 - No pccx-llm-launcher runtime call yet; future integration requires an
   explicit reviewed contract.
+- The KV260 status surface is a read-only local display over launcher NPU
+  status data and pccx-lab trace manifest JSON. The VS Code prototype command
+  `pccxSystemVerilog.showKv260StatusPanel` and CLI command `sv-ide
+  kv260-status` render fixture or explicitly supplied local JSON data only;
+  they do not invoke the launcher, invoke pccx-lab, run shell commands, open
+  SSH, control KV260 hardware, or write back status. The surface is documented
+  in [`KV260_READ_ONLY_STATUS_SURFACE.md`](./KV260_READ_ONLY_STATUS_SURFACE.md).

--- a/docs/KV260_READ_ONLY_STATUS_SURFACE.md
+++ b/docs/KV260_READ_ONLY_STATUS_SURFACE.md
@@ -1,0 +1,40 @@
+# KV260 Read-Only Status Surface
+
+This page documents the local IDE status surface for KV260 data. The surface
+parses existing JSON data and renders a checklist before a future run path is
+considered. It does not open SSH, run board commands, invoke the launcher,
+invoke pccx-lab, load a bitstream, access AXI, scan networks, mutate files, or
+write back status.
+
+## Inputs
+
+- `LauncherStatusReader` consumes the launcher `NPUStatus` shape from
+  `pccxai/pccx-llm-launcher#70`: `bitstream_loaded`, `bitstream_uuid`,
+  `axi_base_addr`, `axi_stat_register_value`, and `last_error`.
+- `LabTraceReader` parses the lab `TraceManifest` JSON shape from
+  `pccxai/pccx-lab#160` for file-replay trace manifests.
+
+The launcher type is mirrored locally because this repository does not import
+the launcher contract package.
+
+## Rendered Surface
+
+`Kv260StatusPanel` renders launcher status, lab manifest metadata, and a
+`PreflightProposal` checklist:
+
+- bitstream loaded
+- AXI reachable
+- manifest available
+
+The checklist is display-only. A blocked item is evidence that the IDE should
+keep any future KV260 run path gated until lower layers provide reviewed data.
+
+## CLI
+
+```bash
+sv-ide kv260-status
+```
+
+The command reads the bundled tiny fixtures by default and prints the same
+status panel as text. Optional local JSON paths can be supplied with
+`--launcher-status` and `--trace-manifest`.

--- a/docs/examples/kv260-status/lab-trace-manifest.example.json
+++ b/docs/examples/kv260-status/lab-trace-manifest.example.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "pccx.lab.kv260.trace-manifest.v0",
+  "bitstream_uuid": "00000000-0000-0000-0000-000000000160",
+  "axi_base": "0x00000000a0000000",
+  "isa_version": "pccx_v002",
+  "frame_count": 1,
+  "checksums": [
+    {
+      "algorithm": "sha256",
+      "value": "fixture-only-not-a-hardware-capture",
+      "frame_idx": null
+    }
+  ],
+  "runbook_ref": "pccxai/pccx-lab#160",
+  "source_kind": "file_replay",
+  "frames": [
+    {
+      "frame_idx": 0,
+      "axi_stat_register_value": 1,
+      "engine_completion_mask": 3,
+      "cycle_count": 128,
+      "result_payload": "a55a0001"
+    }
+  ]
+}

--- a/docs/examples/kv260-status/launcher-npu-status.example.json
+++ b/docs/examples/kv260-status/launcher-npu-status.example.json
@@ -1,0 +1,7 @@
+{
+  "bitstream_loaded": false,
+  "bitstream_uuid": null,
+  "axi_base_addr": null,
+  "axi_stat_register_value": null,
+  "last_error": "fixture only; lower-layer evidence not supplied"
+}

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -147,6 +147,7 @@ The contributed commands are:
 - `pccxSystemVerilog.showContextBundleAudit`
 - `pccxSystemVerilog.showPccxLabBackendStatus`
 - `pccxSystemVerilog.showDiagnosticsHandoffSummary`
+- `pccxSystemVerilog.showKv260StatusPanel`
 
 The prototype-only settings are:
 
@@ -559,6 +560,7 @@ node editors/vscode-prototype/test/runtime-readiness-consumer.test.mjs
 node editors/vscode-prototype/test/runtime-readiness-status-surface.test.mjs
 node editors/vscode-prototype/test/device-session-status-consumer.test.mjs
 node editors/vscode-prototype/test/device-session-status-surface.test.mjs
+node editors/vscode-prototype/test/kv260-status-panel.test.mjs
 node editors/vscode-prototype/test/local-workflow-status.test.mjs
 node editors/vscode-prototype/test/context-bundle-audit.test.mjs
 node editors/vscode-prototype/test/validation-result-summary.test.mjs
@@ -597,3 +599,8 @@ node editors/vscode-prototype/src/adapter.mjs diagnostics \
 node editors/vscode-prototype/src/adapter.mjs navigation \
   docs/examples/editor-bridge/declarations.example.json
 ```
+
+The KV260 status surface is a read-only panel over local launcher NPU status
+and pccx-lab trace manifest data. `pccxSystemVerilog.showKv260StatusPanel`
+renders the bundled tiny fixture data and does not invoke the launcher,
+pccx-lab, shell, SSH, or hardware paths.

--- a/editors/vscode-prototype/package.json
+++ b/editors/vscode-prototype/package.json
@@ -34,7 +34,8 @@
     "onCommand:pccxSystemVerilog.showLocalWorkflowStatus",
     "onCommand:pccxSystemVerilog.showContextBundleAudit",
     "onCommand:pccxSystemVerilog.showPccxLabBackendStatus",
-    "onCommand:pccxSystemVerilog.showDiagnosticsHandoffSummary"
+    "onCommand:pccxSystemVerilog.showDiagnosticsHandoffSummary",
+    "onCommand:pccxSystemVerilog.showKv260StatusPanel"
   ],
   "contributes": {
     "commands": [
@@ -125,6 +126,10 @@
       {
         "command": "pccxSystemVerilog.showDiagnosticsHandoffSummary",
         "title": "PCCX SystemVerilog: Show Diagnostics Handoff Summary (Experimental)"
+      },
+      {
+        "command": "pccxSystemVerilog.showKv260StatusPanel",
+        "title": "PCCX SystemVerilog: Show KV260 Status Panel (Experimental)"
       }
     ],
     "configuration": {

--- a/editors/vscode-prototype/src/config.mjs
+++ b/editors/vscode-prototype/src/config.mjs
@@ -56,11 +56,16 @@ export const DIAGNOSTICS_HANDOFF_COMMAND_IDS = Object.freeze([
   "pccxSystemVerilog.showDiagnosticsHandoffSummary",
 ]);
 
+export const KV260_STATUS_COMMAND_IDS = Object.freeze([
+  "pccxSystemVerilog.showKv260StatusPanel",
+]);
+
 export const COMMAND_IDS = Object.freeze([
   ...FACADE_COMMAND_IDS,
   ...WORKFLOW_COMMAND_IDS,
   ...PCCX_LAB_COMMAND_IDS,
   ...DIAGNOSTICS_HANDOFF_COMMAND_IDS,
+  ...KV260_STATUS_COMMAND_IDS,
 ]);
 
 export const MODES = Object.freeze(["checkedExample", "liveWorkspace"]);

--- a/editors/vscode-prototype/src/extension.mjs
+++ b/editors/vscode-prototype/src/extension.mjs
@@ -72,6 +72,10 @@ import {
   createDiagnosticsHandoffStatusSurface,
   formatDiagnosticsHandoffStatusSurface,
 } from "./diagnostics-handoff-status-surface.mjs";
+import {
+  createKv260StatusPanel,
+  formatKv260StatusPanel,
+} from "./kv260-status-panel.mjs";
 
 const EXTENSION_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_DIAGNOSTIC_FILE_ROOT = resolve(EXTENSION_ROOT, "../..");
@@ -113,6 +117,8 @@ export const PCCX_LAB_BACKEND_STATUS_COMMAND =
   "pccxSystemVerilog.showPccxLabBackendStatus";
 export const SHOW_DIAGNOSTICS_HANDOFF_SUMMARY_COMMAND =
   "pccxSystemVerilog.showDiagnosticsHandoffSummary";
+export const SHOW_KV260_STATUS_PANEL_COMMAND =
+  "pccxSystemVerilog.showKv260StatusPanel";
 
 const NAVIGATION_LOCATION_COMMAND_IDS = Object.freeze([
   CHECKED_EXAMPLE_NAVIGATION_COMMAND,
@@ -427,6 +433,9 @@ function appendCommandOutput(outputChannel, commandId, result) {
   }
   if (result.kind === "diagnostics-handoff-status") {
     outputChannel.appendLine(formatDiagnosticsHandoffStatusSurface(result.surface));
+  }
+  if (result.kind === "kv260-status-panel") {
+    outputChannel.appendLine(formatKv260StatusPanel(result.panel));
   }
   if (result.status?.kind === "pccx-lab-backend-status") {
     outputChannel.appendLine(JSON.stringify(result.status, null, 2));
@@ -1096,6 +1105,28 @@ export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
         };
         vscodeApi?.window?.showInformationMessage?.(
           `Diagnostics handoff summary: ${surface.display.summary}.`,
+          result,
+        );
+      } catch (error) {
+        result = { ok: false, commandId, error: error.message };
+        vscodeApi?.window?.showWarningMessage?.(result.error, result);
+      }
+      appendCommandOutput(runtime.outputChannel, commandId, result);
+      return result;
+    }
+
+    if (commandId === SHOW_KV260_STATUS_PANEL_COMMAND) {
+      let result;
+      try {
+        const panel = createKv260StatusPanel(runtime.kv260StatusInputs);
+        result = {
+          ok: true,
+          commandId,
+          kind: "kv260-status-panel",
+          panel,
+        };
+        vscodeApi?.window?.showInformationMessage?.(
+          `KV260 status surface: ${panel.lab.frameCount} trace frame(s).`,
           result,
         );
       } catch (error) {

--- a/editors/vscode-prototype/src/kv260-status-panel.mjs
+++ b/editors/vscode-prototype/src/kv260-status-panel.mjs
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
+
+export const LAUNCHER_NPU_STATUS_MIRROR_VERSION =
+  "pccx.ide.launcher-npu-status.local-mirror.v0";
+export const TRACE_MANIFEST_SCHEMA_VERSION = "pccx.lab.kv260.trace-manifest.v0";
+export const KV260_STATUS_PANEL_VERSION = "pccx.ide.kv260-status-panel.v0";
+
+export const DEFAULT_LAUNCHER_NPU_STATUS = Object.freeze({
+  bitstream_loaded: false,
+  bitstream_uuid: null,
+  axi_base_addr: null,
+  axi_stat_register_value: null,
+  last_error: "fixture only; lower-layer evidence not supplied",
+});
+
+export const DEFAULT_TRACE_MANIFEST = Object.freeze({
+  schema_version: TRACE_MANIFEST_SCHEMA_VERSION,
+  bitstream_uuid: "00000000-0000-0000-0000-000000000160",
+  axi_base: "0x00000000a0000000",
+  isa_version: "pccx_v002",
+  frame_count: 1,
+  checksums: Object.freeze([
+    Object.freeze({
+      algorithm: "sha256",
+      value: "fixture-only-not-a-hardware-capture",
+      frame_idx: null,
+    }),
+  ]),
+  runbook_ref: "pccxai/pccx-lab#160",
+  source_kind: "file_replay",
+  frames: Object.freeze([
+    Object.freeze({
+      frame_idx: 0,
+      axi_stat_register_value: 1,
+      engine_completion_mask: 3,
+      cycle_count: 128,
+      result_payload: "a55a0001",
+    }),
+  ]),
+});
+
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|password|private[_-]?key|secret|token)\b\s*[:=]/i;
+const PRIVATE_PATH_PATTERN = /(?:\/home\/[^/\s]+|\/Users\/[^/\s]+|[A-Za-z]:\\Users\\)/;
+const MODEL_ARTIFACT_PATTERN =
+  /\.(?:gguf|safetensors|ckpt|pt|pth|onnx|xclbin|bit)(?:\s|$|["'])/i;
+const UNSUPPORTED_MARKER_PARTS = Object.freeze([
+  ["production", "ready"],
+  ["marketplace", "ready"],
+  ["stable", "api"],
+  ["stable", "abi"],
+  ["kv260 inference ", "works"],
+  ["gemma 3n e4b runs on ", "kv260"],
+  ["20 tok/s ", "achieved"],
+  ["timing ", "closed"],
+]);
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function isObject(value) {
+  return value && typeof value === "object" && !Array.isArray(value);
+}
+
+function addError(errors, path, message) {
+  errors.push(`${path}: ${message}`);
+}
+
+function assertSafeText(value, errors) {
+  let text = "";
+  try {
+    text = JSON.stringify(value ?? {});
+  } catch {
+    addError(errors, "input", "must be JSON-serializable");
+    return;
+  }
+  const lower = text.toLowerCase();
+  if (
+    SECRET_ASSIGNMENT_PATTERN.test(text) ||
+    PRIVATE_PATH_PATTERN.test(text) ||
+    MODEL_ARTIFACT_PATTERN.test(text)
+  ) {
+    addError(errors, "input", "must not include secrets, private paths, or model artifact paths");
+  }
+  for (const parts of UNSUPPORTED_MARKER_PARTS) {
+    if (lower.includes(parts.join(""))) {
+      addError(errors, "input", "must not include unsupported runtime or readiness claims");
+    }
+  }
+}
+
+function stringField(value, path, errors, maxCharacters = 500) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    addError(errors, path, "must be a non-empty string");
+    return "";
+  }
+  if (
+    value.length > maxCharacters ||
+    value.includes("\0") ||
+    value.includes("\n") ||
+    value.includes("\r")
+  ) {
+    addError(errors, path, `must be a single-line string up to ${maxCharacters} characters`);
+  }
+  return value;
+}
+
+function optionalStringField(value, path, errors, maxCharacters = 500) {
+  if (value == null) {
+    return null;
+  }
+  return stringField(value, path, errors, maxCharacters);
+}
+
+function boolField(value, path, errors) {
+  if (typeof value !== "boolean") {
+    addError(errors, path, "must be a boolean");
+    return false;
+  }
+  return value;
+}
+
+function optionalIntegerField(value, path, errors) {
+  if (value == null) {
+    return null;
+  }
+  if (!Number.isSafeInteger(value) || value < 0) {
+    addError(errors, path, "must be null or a non-negative integer");
+    return null;
+  }
+  return value;
+}
+
+function integerField(value, path, errors) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    addError(errors, path, "must be a non-negative integer");
+    return 0;
+  }
+  return value;
+}
+
+function arrayField(value, path, errors) {
+  if (!Array.isArray(value)) {
+    addError(errors, path, "must be an array");
+    return [];
+  }
+  return value;
+}
+
+function normalizeTraceFrame(value, index, errors) {
+  const frame = isObject(value) ? value : {};
+  if (!isObject(value)) {
+    addError(errors, `frames[${index}]`, "must be an object");
+  }
+  const resultPayload = frame.result_payload == null
+    ? null
+    : stringField(frame.result_payload, `frames[${index}].result_payload`, errors, 10000);
+  const error = frame.error == null ? null : frame.error;
+  if (error != null && !isObject(error)) {
+    addError(errors, `frames[${index}].error`, "must be null or an object");
+  }
+  return {
+    frame_idx: integerField(frame.frame_idx, `frames[${index}].frame_idx`, errors),
+    axi_stat_register_value: integerField(
+      frame.axi_stat_register_value,
+      `frames[${index}].axi_stat_register_value`,
+      errors,
+    ),
+    engine_completion_mask: integerField(
+      frame.engine_completion_mask,
+      `frames[${index}].engine_completion_mask`,
+      errors,
+    ),
+    cycle_count: integerField(frame.cycle_count, `frames[${index}].cycle_count`, errors),
+    result_payload: resultPayload,
+    error,
+  };
+}
+
+export class LauncherStatusReader {
+  static consume(status = DEFAULT_LAUNCHER_NPU_STATUS) {
+    const errors = [];
+    if (!isObject(status)) {
+      throw new Error("launcher NPU status must be an object");
+    }
+    assertSafeText(status, errors);
+    const normalized = {
+      bitstream_loaded: boolField(status.bitstream_loaded, "bitstream_loaded", errors),
+      bitstream_uuid: optionalStringField(status.bitstream_uuid, "bitstream_uuid", errors, 160),
+      axi_base_addr: optionalIntegerField(status.axi_base_addr, "axi_base_addr", errors),
+      axi_stat_register_value: optionalIntegerField(
+        status.axi_stat_register_value,
+        "axi_stat_register_value",
+        errors,
+      ),
+      last_error: optionalStringField(status.last_error, "last_error", errors, 500),
+    };
+    if (errors.length > 0) {
+      throw new Error(errors.join("; "));
+    }
+    return Object.freeze(normalized);
+  }
+}
+
+export class LabTraceReader {
+  static consume(manifest = DEFAULT_TRACE_MANIFEST) {
+    const errors = [];
+    if (!isObject(manifest)) {
+      throw new Error("trace manifest must be an object");
+    }
+    assertSafeText(manifest, errors);
+    const schemaVersion = stringField(manifest.schema_version, "schema_version", errors);
+    if (schemaVersion !== TRACE_MANIFEST_SCHEMA_VERSION) {
+      addError(errors, "schema_version", `must be ${TRACE_MANIFEST_SCHEMA_VERSION}`);
+    }
+    const sourceKind = stringField(manifest.source_kind, "source_kind", errors);
+    if (sourceKind !== "file_replay") {
+      addError(errors, "source_kind", "must be file_replay");
+    }
+    const frames = arrayField(manifest.frames, "frames", errors)
+      .map((frame, index) => normalizeTraceFrame(frame, index, errors));
+    const frameCount = integerField(manifest.frame_count, "frame_count", errors);
+    if (frameCount !== frames.length) {
+      addError(errors, "frame_count", "must match inline frames");
+    }
+    const normalized = {
+      schema_version: schemaVersion,
+      bitstream_uuid: stringField(manifest.bitstream_uuid, "bitstream_uuid", errors, 160),
+      axi_base: stringField(manifest.axi_base, "axi_base", errors, 80),
+      isa_version: stringField(manifest.isa_version, "isa_version", errors, 80),
+      frame_count: frameCount,
+      checksums: arrayField(manifest.checksums, "checksums", errors).map(clone),
+      runbook_ref: stringField(manifest.runbook_ref, "runbook_ref", errors, 240),
+      source_kind: sourceKind,
+      frames,
+    };
+    if (errors.length > 0) {
+      throw new Error(errors.join("; "));
+    }
+    return Object.freeze(normalized);
+  }
+}
+
+function hexOrUnavailable(value) {
+  return value == null ? "unavailable" : `0x${value.toString(16)}`;
+}
+
+function yesNo(value) {
+  return value ? "yes" : "no";
+}
+
+export function createPreflightProposal(launcherStatus, traceManifest) {
+  const axiPresent =
+    launcherStatus.axi_base_addr != null && launcherStatus.axi_stat_register_value != null;
+  return Object.freeze({
+    kind: "kv260-preflight-proposal",
+    items: Object.freeze([
+      Object.freeze({
+        itemId: "bitstream_loaded",
+        label: "bitstream loaded",
+        satisfied: launcherStatus.bitstream_loaded,
+        evidence: launcherStatus.bitstream_uuid || "launcher status reports no bitstream UUID",
+      }),
+      Object.freeze({
+        itemId: "axi_reachable",
+        label: "AXI reachable",
+        satisfied: axiPresent,
+        evidence: hexOrUnavailable(launcherStatus.axi_stat_register_value),
+      }),
+      Object.freeze({
+        itemId: "manifest_available",
+        label: "manifest available",
+        satisfied: traceManifest.frame_count >= 0,
+        evidence: `${traceManifest.schema_version}; ${traceManifest.frame_count} frame(s)`,
+      }),
+    ]),
+  });
+}
+
+export function createKv260StatusPanel(inputs = {}) {
+  const launcherStatus = LauncherStatusReader.consume(inputs.launcherStatus);
+  const traceManifest = LabTraceReader.consume(inputs.traceManifest);
+  return Object.freeze({
+    version: KV260_STATUS_PANEL_VERSION,
+    kind: "kv260-status-panel",
+    source: Object.freeze({
+      launcherTypeMirror: LAUNCHER_NPU_STATUS_MIRROR_VERSION,
+      labManifestParser: "real",
+      adapterOutput: true,
+      executesLauncher: false,
+      executesPccxLab: false,
+      rawManifestParsedByUi: false,
+    }),
+    launcher: Object.freeze(launcherStatus),
+    lab: Object.freeze({
+      schemaVersion: traceManifest.schema_version,
+      bitstreamUuid: traceManifest.bitstream_uuid,
+      axiBase: traceManifest.axi_base,
+      isaVersion: traceManifest.isa_version,
+      frameCount: traceManifest.frame_count,
+      sourceKind: traceManifest.source_kind,
+      runbookRef: traceManifest.runbook_ref,
+    }),
+    preflight: createPreflightProposal(launcherStatus, traceManifest),
+    safety: Object.freeze({
+      dataOnly: true,
+      readOnly: true,
+      localOnly: true,
+      launcherExecution: false,
+      pccxLabExecution: false,
+      shellExecution: false,
+      sshExecution: false,
+      kv260Control: false,
+      providerCalls: false,
+      networkCalls: false,
+      telemetry: false,
+      automaticUpload: false,
+      writeBack: false,
+    }),
+  });
+}
+
+export function kv260StatusPanelJson(inputs = {}) {
+  return `${JSON.stringify(createKv260StatusPanel(inputs), null, 2)}\n`;
+}
+
+export function formatKv260StatusPanel(panel = createKv260StatusPanel()) {
+  const lines = [
+    "KV260 Status Surface",
+    `version: ${panel.version}`,
+    `launcherMirror: ${panel.source.launcherTypeMirror}`,
+    `launcher.bitstreamLoaded: ${yesNo(panel.launcher.bitstream_loaded)}`,
+    `launcher.bitstreamUuid: ${panel.launcher.bitstream_uuid || "unavailable"}`,
+    `launcher.axiBaseAddr: ${hexOrUnavailable(panel.launcher.axi_base_addr)}`,
+    `launcher.axiStatus: ${hexOrUnavailable(panel.launcher.axi_stat_register_value)}`,
+    `launcher.lastError: ${panel.launcher.last_error || "none"}`,
+    `lab.schema: ${panel.lab.schemaVersion}`,
+    `lab.sourceKind: ${panel.lab.sourceKind}`,
+    `lab.frames: ${panel.lab.frameCount}`,
+    `lab.axiBase: ${panel.lab.axiBase}`,
+    `lab.isaVersion: ${panel.lab.isaVersion}`,
+    "preflight:",
+  ];
+  for (const item of panel.preflight.items) {
+    const state = item.satisfied ? "pass" : "blocked";
+    lines.push(`- ${item.label}: ${state} (${item.evidence})`);
+  }
+  lines.push("execution: no launcher, no pccx-lab, no shell, no SSH, no KV260 control");
+  lines.push("writeBack: no");
+  return `${lines.join("\n")}\n`;
+}

--- a/editors/vscode-prototype/test/extension-entrypoint.test.mjs
+++ b/editors/vscode-prototype/test/extension-entrypoint.test.mjs
@@ -17,6 +17,7 @@ import {
   PCCX_LAB_BACKEND_STATUS_COMMAND,
   SHOW_CONTEXT_BUNDLE_AUDIT_COMMAND,
   SHOW_DIAGNOSTICS_HANDOFF_SUMMARY_COMMAND,
+  SHOW_KV260_STATUS_PANEL_COMMAND,
   SHOW_LOCAL_WORKFLOW_STATUS_COMMAND,
   SHOW_PATCH_PROPOSAL_PREVIEW_COMMAND,
   SHOW_RECENT_VALIDATION_RESULTS_COMMAND,
@@ -1548,6 +1549,23 @@ async function testPccxLabBackendStatusCommandReturnsStatusOnly() {
   assert.ok(result.status.futureSafetyRequirements.includes("fixed args"));
 }
 
+async function testKv260StatusPanelCommandReturnsDataOnlySurface() {
+  const handler = createCommandHandler(SHOW_KV260_STATUS_PANEL_COMMAND, null, {});
+
+  const result = await handler();
+
+  assert.equal(result.ok, true);
+  assert.equal(result.commandId, SHOW_KV260_STATUS_PANEL_COMMAND);
+  assert.equal(result.kind, "kv260-status-panel");
+  assert.equal(result.panel.kind, "kv260-status-panel");
+  assert.equal(result.panel.source.launcherTypeMirror, "pccx.ide.launcher-npu-status.local-mirror.v0");
+  assert.equal(result.panel.source.labManifestParser, "real");
+  assert.equal(result.panel.safety.launcherExecution, false);
+  assert.equal(result.panel.safety.pccxLabExecution, false);
+  assert.equal(result.panel.safety.shellExecution, false);
+  assert.equal(result.panel.safety.sshExecution, false);
+}
+
 testKnownFacadeArgs();
 testUnknownCommandsRejected();
 testCheckedExampleDiagnosticsCommandStaysExampleMode();
@@ -1576,5 +1594,6 @@ await testLocalWorkflowStatusCommandReturnsFixtureOnlyBoundaryState();
 await testContextBundleAuditCommandReturnsBoundedAudit();
 await testDiagnosticsHandoffSummaryCommandReturnsDataOnlySurface();
 await testPccxLabBackendStatusCommandReturnsStatusOnly();
+await testKv260StatusPanelCommandReturnsDataOnlySurface();
 
 console.log("vscode extension entrypoint tests ok");

--- a/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
+++ b/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
@@ -81,6 +81,7 @@ async function run() {
     "pccxSystemVerilog.showContextBundleAudit",
     "pccxSystemVerilog.showPccxLabBackendStatus",
     "pccxSystemVerilog.showDiagnosticsHandoffSummary",
+    "pccxSystemVerilog.showKv260StatusPanel",
   ]);
 
   const manifest = readManifest();
@@ -594,6 +595,22 @@ async function run() {
   assert.equal(diagnosticsHandoffStatus.surface.safety.runtimeCalls, false);
   assert.equal(diagnosticsHandoffStatus.surface.safety.mcpCalls, false);
   assert.equal(diagnosticsHandoffStatus.surface.safety.lspImplemented, false);
+
+  const kv260Status = await vscode.commands.executeCommand(
+    "pccxSystemVerilog.showKv260StatusPanel",
+  );
+  assert.equal(kv260Status.ok, true);
+  assert.equal(kv260Status.kind, "kv260-status-panel");
+  assert.equal(kv260Status.panel.kind, "kv260-status-panel");
+  assert.equal(
+    kv260Status.panel.source.launcherTypeMirror,
+    "pccx.ide.launcher-npu-status.local-mirror.v0",
+  );
+  assert.equal(kv260Status.panel.source.labManifestParser, "real");
+  assert.equal(kv260Status.panel.safety.launcherExecution, false);
+  assert.equal(kv260Status.panel.safety.pccxLabExecution, false);
+  assert.equal(kv260Status.panel.safety.shellExecution, false);
+  assert.equal(kv260Status.panel.safety.sshExecution, false);
 
   const extensionModule = await importExtensionEntrypoint();
   assert.equal(typeof extensionModule.deactivate, "function");

--- a/editors/vscode-prototype/test/extension-manifest.test.mjs
+++ b/editors/vscode-prototype/test/extension-manifest.test.mjs
@@ -31,6 +31,7 @@ const COMMAND_IDS = [
   "pccxSystemVerilog.showContextBundleAudit",
   "pccxSystemVerilog.showPccxLabBackendStatus",
   "pccxSystemVerilog.showDiagnosticsHandoffSummary",
+  "pccxSystemVerilog.showKv260StatusPanel",
 ];
 
 async function readText(path) {
@@ -139,6 +140,7 @@ async function testDocsKeepExperimentalScope() {
   assert.match(combined, /allowlisted proposal IDs/i);
   assert.match(combined, /pccx-lab backend status/i);
   assert.match(combined, /showDiagnosticsHandoffSummary/);
+  assert.match(combined, /KV260 status surface/i);
   assert.match(combined, /no provider\/runtime calls/i);
   assert.match(combined, /no MCP server implementation/i);
 }

--- a/editors/vscode-prototype/test/kv260-status-panel.test.mjs
+++ b/editors/vscode-prototype/test/kv260-status-panel.test.mjs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  KV260_STATUS_PANEL_VERSION,
+  LAUNCHER_NPU_STATUS_MIRROR_VERSION,
+  LabTraceReader,
+  LauncherStatusReader,
+  createKv260StatusPanel,
+  formatKv260StatusPanel,
+  kv260StatusPanelJson,
+} from "../src/kv260-status-panel.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const LAUNCHER_FIXTURE = resolve(
+  ROOT,
+  "docs/examples/kv260-status/launcher-npu-status.example.json",
+);
+const TRACE_FIXTURE = resolve(
+  ROOT,
+  "docs/examples/kv260-status/lab-trace-manifest.example.json",
+);
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+async function testReadersParseFixtures() {
+  const launcher = LauncherStatusReader.consume(await readJson(LAUNCHER_FIXTURE));
+  const trace = LabTraceReader.consume(await readJson(TRACE_FIXTURE));
+
+  assert.equal(launcher.bitstream_loaded, false);
+  assert.equal(launcher.bitstream_uuid, null);
+  assert.equal(trace.schema_version, "pccx.lab.kv260.trace-manifest.v0");
+  assert.equal(trace.frame_count, 1);
+  assert.equal(trace.frames[0].result_payload, "a55a0001");
+}
+
+async function testPanelRendersPreflightAndSafety() {
+  const panel = createKv260StatusPanel({
+    launcherStatus: await readJson(LAUNCHER_FIXTURE),
+    traceManifest: await readJson(TRACE_FIXTURE),
+  });
+  const text = formatKv260StatusPanel(panel);
+  const jsonText = kv260StatusPanelJson({
+    launcherStatus: await readJson(LAUNCHER_FIXTURE),
+    traceManifest: await readJson(TRACE_FIXTURE),
+  });
+
+  assert.equal(panel.version, KV260_STATUS_PANEL_VERSION);
+  assert.equal(panel.source.launcherTypeMirror, LAUNCHER_NPU_STATUS_MIRROR_VERSION);
+  assert.equal(panel.source.labManifestParser, "real");
+  assert.equal(panel.safety.readOnly, true);
+  assert.equal(panel.safety.launcherExecution, false);
+  assert.equal(panel.safety.pccxLabExecution, false);
+  assert.equal(panel.safety.sshExecution, false);
+  assert.deepEqual(panel.preflight.items.map((item) => item.itemId), [
+    "bitstream_loaded",
+    "axi_reachable",
+    "manifest_available",
+  ]);
+  assert.match(text, /KV260 Status Surface/);
+  assert.match(text, /launcherMirror: pccx\.ide\.launcher-npu-status\.local-mirror\.v0/);
+  assert.match(text, /execution: no launcher, no pccx-lab, no shell, no SSH, no KV260 control/);
+  assert.equal(JSON.parse(jsonText).kind, "kv260-status-panel");
+}
+
+async function testRejectsInvalidOrUnsafeInputs() {
+  assert.throws(
+    () => LauncherStatusReader.consume({ bitstream_loaded: "false" }),
+    /bitstream_loaded/,
+  );
+
+  const invalid = await readJson(TRACE_FIXTURE);
+  invalid.source_kind = "ssh_log_tail";
+  assert.throws(
+    () => LabTraceReader.consume(invalid),
+    /source_kind: must be file_replay/,
+  );
+
+  const unsafe = await readJson(LAUNCHER_FIXTURE);
+  unsafe.last_error = "/home/user/private.log";
+  assert.throws(
+    () => LauncherStatusReader.consume(unsafe),
+    /private paths/,
+  );
+}
+
+async function testModuleSourceHasNoExecutionTerms() {
+  const source = await readFile(
+    resolve(ROOT, "editors/vscode-prototype/src/kv260-status-panel.mjs"),
+    "utf8",
+  );
+
+  assert.doesNotMatch(source, /node:child_process|\bexecFile\b|\bspawn\s*\(|\bexec\s*\(/);
+  assert.doesNotMatch(source, /node:fs|readFile\s*\(|readdir\s*\(|opendir\s*\(|stat\s*\(/);
+  assert.doesNotMatch(source, /\bwriteFile\s*\(|\bappendFile\s*\(|\bunlink\s*\(|\brm\s*\(/);
+  assert.doesNotMatch(source, /\bfetch\s*\(|XMLHttpRequest|WebSocket|node:https|node:http|node:net|node:tls/);
+  assert.doesNotMatch(source, /\b(?:openai|anthropic|gemini)\b/i);
+  assert.doesNotMatch(source, /modelcontextprotocol|McpServer|vscode-languageclient|LanguageClient/);
+}
+
+await testReadersParseFixtures();
+await testPanelRendersPreflightAndSafety();
+await testRejectsInvalidOrUnsafeInputs();
+await testModuleSourceHasNoExecutionTerms();
+
+console.log("vscode kv260 status panel tests ok");

--- a/editors/vscode-prototype/test/static-boundary.test.mjs
+++ b/editors/vscode-prototype/test/static-boundary.test.mjs
@@ -151,6 +151,7 @@ async function testProposalAndStatusModulesAreDataOnly() {
     resolve(EXTENSION_ROOT, "src/launcher-status-contract.mjs"),
     resolve(EXTENSION_ROOT, "src/diagnostics-handoff-consumer.mjs"),
     resolve(EXTENSION_ROOT, "src/diagnostics-handoff-status-surface.mjs"),
+    resolve(EXTENSION_ROOT, "src/kv260-status-panel.mjs"),
     resolve(EXTENSION_ROOT, "src/runtime-readiness-consumer.mjs"),
     resolve(EXTENSION_ROOT, "src/runtime-readiness-status-surface.mjs"),
     resolve(EXTENSION_ROOT, "src/local-workflow-status.mjs"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ test = ["pytest"]
 
 [project.scripts]
 pccx-ide = "pccx_ide_cli.__main__:main"
+sv-ide = "pccx_ide_cli.__main__:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/pccx_ide_cli"]

--- a/src/pccx_ide_cli/cli.py
+++ b/src/pccx_ide_cli/cli.py
@@ -1127,6 +1127,29 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output format (default: json).",
     )
 
+    kv260_status = sub.add_parser(
+        "kv260-status",
+        help="Render a read-only KV260 launcher/lab status surface.",
+    )
+    kv260_status.add_argument(
+        "--launcher-status",
+        type=Path,
+        default=None,
+        help="Path to launcher NPUStatus JSON; defaults to the bundled fixture.",
+    )
+    kv260_status.add_argument(
+        "--trace-manifest",
+        type=Path,
+        default=None,
+        help="Path to lab TraceManifest JSON; defaults to the bundled fixture.",
+    )
+    kv260_status.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format (default: text).",
+    )
+
     xsim_log = sub.add_parser(
         "xsim-log",
         help="Parse an existing xsim-style log file into diagnostics-like output.",
@@ -1201,6 +1224,35 @@ def main(argv: Sequence[str] | None = None) -> int:
         if not schema_path.exists():
             schema_path = Path(__file__).resolve().parent / "_schema_fallback.json"
         sys.stdout.write(schema_path.read_text(encoding="utf-8"))
+        return 0
+
+    if args.command == "kv260-status":
+        from .kv260_status import (
+            LabTraceReader,
+            LauncherStatusReader,
+            create_kv260_status_panel,
+            default_launcher_status_path,
+            default_trace_manifest_path,
+            format_kv260_status_panel,
+            panel_to_dict,
+        )
+
+        repo_root = Path(__file__).resolve().parent.parent.parent
+        launcher_path = args.launcher_status or default_launcher_status_path(repo_root)
+        trace_path = args.trace_manifest or default_trace_manifest_path(repo_root)
+        try:
+            launcher_status = LauncherStatusReader.from_json_file(launcher_path)
+            trace_manifest = LabTraceReader.from_json_file(trace_path)
+            panel = create_kv260_status_panel(launcher_status, trace_manifest)
+        except (OSError, ValueError, json.JSONDecodeError) as error:
+            sys.stderr.write(f"error: cannot render kv260 status: {error}\n")
+            return 2
+
+        if args.format == "json":
+            json.dump(panel_to_dict(panel), sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(format_kv260_status_panel(panel))
         return 0
 
     if args.command == "check":

--- a/src/pccx_ide_cli/kv260_status.py
+++ b/src/pccx_ide_cli/kv260_status.py
@@ -1,0 +1,331 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+
+LAUNCHER_NPU_STATUS_MIRROR_VERSION = "pccx.ide.launcher-npu-status.local-mirror.v0"
+TRACE_MANIFEST_SCHEMA_VERSION = "pccx.lab.kv260.trace-manifest.v0"
+KV260_STATUS_PANEL_VERSION = "pccx.ide.kv260-status-panel.v0"
+
+
+@dataclass(frozen=True)
+class NPUStatus:
+    bitstream_loaded: bool
+    bitstream_uuid: str | None
+    axi_base_addr: int | None
+    axi_stat_register_value: int | None
+    last_error: str | None
+
+
+@dataclass(frozen=True)
+class TraceFrame:
+    frame_idx: int
+    axi_stat_register_value: int
+    engine_completion_mask: int
+    cycle_count: int
+    result_payload: str | None
+    error: Mapping[str, Any] | None
+
+
+@dataclass(frozen=True)
+class TraceManifest:
+    schema_version: str
+    bitstream_uuid: str
+    axi_base: str
+    isa_version: str
+    frame_count: int
+    checksums: tuple[Mapping[str, Any], ...]
+    runbook_ref: str
+    source_kind: str
+    frames: tuple[TraceFrame, ...]
+
+
+@dataclass(frozen=True)
+class PreflightItem:
+    item_id: str
+    label: str
+    satisfied: bool
+    evidence: str
+
+
+@dataclass(frozen=True)
+class PreflightProposal:
+    kind: str
+    items: tuple[PreflightItem, ...]
+
+
+@dataclass(frozen=True)
+class Kv260StatusPanel:
+    version: str
+    launcher_status: NPUStatus
+    trace_manifest: TraceManifest
+    preflight: PreflightProposal
+
+
+class LauncherStatusReader:
+    """Read-only local mirror of launcher#70 `NPUStatus` type shape."""
+
+    @classmethod
+    def from_json_text(cls, text: str) -> NPUStatus:
+        return cls.from_object(json.loads(text))
+
+    @classmethod
+    def from_json_file(cls, path: Path) -> NPUStatus:
+        return cls.from_json_text(path.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def from_object(value: Mapping[str, Any]) -> NPUStatus:
+        if not isinstance(value, Mapping):
+            raise ValueError("launcher NPU status must be a JSON object")
+        bitstream_loaded = _bool_field(value, "bitstream_loaded")
+        bitstream_uuid = _optional_string_field(value, "bitstream_uuid")
+        axi_base_addr = _optional_int_field(value, "axi_base_addr")
+        axi_stat_register_value = _optional_int_field(value, "axi_stat_register_value")
+        last_error = _optional_string_field(value, "last_error")
+        return NPUStatus(
+            bitstream_loaded=bitstream_loaded,
+            bitstream_uuid=bitstream_uuid,
+            axi_base_addr=axi_base_addr,
+            axi_stat_register_value=axi_stat_register_value,
+            last_error=last_error,
+        )
+
+
+class LabTraceReader:
+    """Read-only parser for lab#160 `TraceManifest` JSON fixtures."""
+
+    @classmethod
+    def from_json_text(cls, text: str) -> TraceManifest:
+        return cls.from_object(json.loads(text))
+
+    @classmethod
+    def from_json_file(cls, path: Path) -> TraceManifest:
+        return cls.from_json_text(path.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def from_object(value: Mapping[str, Any]) -> TraceManifest:
+        if not isinstance(value, Mapping):
+            raise ValueError("trace manifest must be a JSON object")
+        schema_version = _string_field(value, "schema_version")
+        if schema_version != TRACE_MANIFEST_SCHEMA_VERSION:
+            raise ValueError(f"unsupported trace manifest schema_version: {schema_version}")
+        source_kind = _string_field(value, "source_kind")
+        if source_kind != "file_replay":
+            raise ValueError("only file_replay trace manifests are displayable")
+        frames = tuple(_trace_frame(frame, index) for index, frame in enumerate(_list_field(value, "frames")))
+        frame_count = _int_field(value, "frame_count")
+        if frame_count != len(frames):
+            raise ValueError("trace manifest frame_count must match inline frames")
+        return TraceManifest(
+            schema_version=schema_version,
+            bitstream_uuid=_string_field(value, "bitstream_uuid"),
+            axi_base=_string_field(value, "axi_base"),
+            isa_version=_string_field(value, "isa_version"),
+            frame_count=frame_count,
+            checksums=tuple(_mapping_item(item, "checksums", index) for index, item in enumerate(_list_field(value, "checksums"))),
+            runbook_ref=_string_field(value, "runbook_ref"),
+            source_kind=source_kind,
+            frames=frames,
+        )
+
+
+def create_preflight_proposal(status: NPUStatus, manifest: TraceManifest) -> PreflightProposal:
+    axi_present = status.axi_base_addr is not None and status.axi_stat_register_value is not None
+    return PreflightProposal(
+        kind="kv260-preflight-proposal",
+        items=(
+            PreflightItem(
+                item_id="bitstream_loaded",
+                label="bitstream loaded",
+                satisfied=status.bitstream_loaded,
+                evidence=status.bitstream_uuid or "launcher status reports no bitstream UUID",
+            ),
+            PreflightItem(
+                item_id="axi_reachable",
+                label="AXI reachable",
+                satisfied=axi_present,
+                evidence=_hex_or_unavailable(status.axi_stat_register_value),
+            ),
+            PreflightItem(
+                item_id="manifest_available",
+                label="manifest available",
+                satisfied=manifest.frame_count >= 0,
+                evidence=f"{manifest.schema_version}; {manifest.frame_count} frame(s)",
+            ),
+        ),
+    )
+
+
+def create_kv260_status_panel(status: NPUStatus, manifest: TraceManifest) -> Kv260StatusPanel:
+    return Kv260StatusPanel(
+        version=KV260_STATUS_PANEL_VERSION,
+        launcher_status=status,
+        trace_manifest=manifest,
+        preflight=create_preflight_proposal(status, manifest),
+    )
+
+
+def panel_to_dict(panel: Kv260StatusPanel) -> dict[str, Any]:
+    return {
+        "version": panel.version,
+        "kind": "kv260-status-panel",
+        "launcher": {
+            "mirror_version": LAUNCHER_NPU_STATUS_MIRROR_VERSION,
+            "bitstream_loaded": panel.launcher_status.bitstream_loaded,
+            "bitstream_uuid": panel.launcher_status.bitstream_uuid,
+            "axi_base_addr": panel.launcher_status.axi_base_addr,
+            "axi_stat_register_value": panel.launcher_status.axi_stat_register_value,
+            "last_error": panel.launcher_status.last_error,
+        },
+        "lab": {
+            "schema_version": panel.trace_manifest.schema_version,
+            "bitstream_uuid": panel.trace_manifest.bitstream_uuid,
+            "axi_base": panel.trace_manifest.axi_base,
+            "isa_version": panel.trace_manifest.isa_version,
+            "frame_count": panel.trace_manifest.frame_count,
+            "source_kind": panel.trace_manifest.source_kind,
+            "runbook_ref": panel.trace_manifest.runbook_ref,
+        },
+        "preflight": {
+            "kind": panel.preflight.kind,
+            "items": [
+                {
+                    "item_id": item.item_id,
+                    "label": item.label,
+                    "satisfied": item.satisfied,
+                    "evidence": item.evidence,
+                }
+                for item in panel.preflight.items
+            ],
+        },
+        "safety": {
+            "read_only": True,
+            "launcher_execution": False,
+            "pccx_lab_execution": False,
+            "shell_execution": False,
+            "ssh_execution": False,
+            "kv260_control": False,
+            "write_back": False,
+        },
+    }
+
+
+def format_kv260_status_panel(panel: Kv260StatusPanel) -> str:
+    status = panel.launcher_status
+    manifest = panel.trace_manifest
+    lines = [
+        "KV260 Status Surface",
+        f"version: {panel.version}",
+        f"launcherMirror: {LAUNCHER_NPU_STATUS_MIRROR_VERSION}",
+        f"launcher.bitstreamLoaded: {_yes_no(status.bitstream_loaded)}",
+        f"launcher.bitstreamUuid: {status.bitstream_uuid or 'unavailable'}",
+        f"launcher.axiBaseAddr: {_hex_or_unavailable(status.axi_base_addr)}",
+        f"launcher.axiStatus: {_hex_or_unavailable(status.axi_stat_register_value)}",
+        f"launcher.lastError: {status.last_error or 'none'}",
+        f"lab.schema: {manifest.schema_version}",
+        f"lab.sourceKind: {manifest.source_kind}",
+        f"lab.frames: {manifest.frame_count}",
+        f"lab.axiBase: {manifest.axi_base}",
+        f"lab.isaVersion: {manifest.isa_version}",
+        "preflight:",
+    ]
+    for item in panel.preflight.items:
+        state = "pass" if item.satisfied else "blocked"
+        lines.append(f"- {item.label}: {state} ({item.evidence})")
+    lines.extend([
+        "execution: no launcher, no pccx-lab, no shell, no SSH, no KV260 control",
+        "writeBack: no",
+    ])
+    return "\n".join(lines) + "\n"
+
+
+def default_launcher_status_path(repo_root: Path) -> Path:
+    return repo_root / "docs" / "examples" / "kv260-status" / "launcher-npu-status.example.json"
+
+
+def default_trace_manifest_path(repo_root: Path) -> Path:
+    return repo_root / "docs" / "examples" / "kv260-status" / "lab-trace-manifest.example.json"
+
+
+def _bool_field(value: Mapping[str, Any], key: str) -> bool:
+    field = value.get(key)
+    if not isinstance(field, bool):
+        raise ValueError(f"{key} must be a boolean")
+    return field
+
+
+def _int_field(value: Mapping[str, Any], key: str) -> int:
+    field = value.get(key)
+    if not isinstance(field, int) or isinstance(field, bool) or field < 0:
+        raise ValueError(f"{key} must be a non-negative integer")
+    return field
+
+
+def _optional_int_field(value: Mapping[str, Any], key: str) -> int | None:
+    field = value.get(key)
+    if field is None:
+        return None
+    if not isinstance(field, int) or isinstance(field, bool) or field < 0:
+        raise ValueError(f"{key} must be null or a non-negative integer")
+    return field
+
+
+def _string_field(value: Mapping[str, Any], key: str) -> str:
+    field = value.get(key)
+    if not isinstance(field, str) or not field.strip() or "\n" in field or "\r" in field:
+        raise ValueError(f"{key} must be a non-empty single-line string")
+    return field
+
+
+def _optional_string_field(value: Mapping[str, Any], key: str) -> str | None:
+    field = value.get(key)
+    if field is None:
+        return None
+    if not isinstance(field, str) or "\n" in field or "\r" in field:
+        raise ValueError(f"{key} must be null or a single-line string")
+    return field
+
+
+def _list_field(value: Mapping[str, Any], key: str) -> list[Any]:
+    field = value.get(key)
+    if not isinstance(field, list):
+        raise ValueError(f"{key} must be an array")
+    return field
+
+
+def _mapping_item(value: Any, key: str, index: int) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{key}[{index}] must be an object")
+    return value
+
+
+def _trace_frame(value: Any, index: int) -> TraceFrame:
+    item = _mapping_item(value, "frames", index)
+    result_payload = item.get("result_payload")
+    if result_payload is not None and not isinstance(result_payload, str):
+        raise ValueError(f"frames[{index}].result_payload must be null or a string")
+    error = item.get("error")
+    if error is not None and not isinstance(error, Mapping):
+        raise ValueError(f"frames[{index}].error must be null or an object")
+    return TraceFrame(
+        frame_idx=_int_field(item, "frame_idx"),
+        axi_stat_register_value=_int_field(item, "axi_stat_register_value"),
+        engine_completion_mask=_int_field(item, "engine_completion_mask"),
+        cycle_count=_int_field(item, "cycle_count"),
+        result_payload=result_payload,
+        error=error,
+    )
+
+
+def _hex_or_unavailable(value: int | None) -> str:
+    return "unavailable" if value is None else f"0x{value:x}"
+
+
+def _yes_no(value: bool) -> str:
+    return "yes" if value else "no"

--- a/tests/test_kv260_status.py
+++ b/tests/test_kv260_status.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 pccxai
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+sys.path.insert(0, str(SRC))
+
+from pccx_ide_cli.kv260_status import (
+    LabTraceReader,
+    LauncherStatusReader,
+    create_kv260_status_panel,
+    format_kv260_status_panel,
+    panel_to_dict,
+)
+
+
+LAUNCHER_FIXTURE = REPO_ROOT / "docs/examples/kv260-status/launcher-npu-status.example.json"
+TRACE_FIXTURE = REPO_ROOT / "docs/examples/kv260-status/lab-trace-manifest.example.json"
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess:
+    env = {
+        "PYTHONPATH": str(SRC),
+        "PATH": os.environ.get("PATH", ""),
+    }
+    return subprocess.run(
+        [sys.executable, "-m", "pccx_ide_cli", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_readers_parse_tiny_fixtures_as_data_only() -> None:
+    launcher = LauncherStatusReader.from_json_file(LAUNCHER_FIXTURE)
+    manifest = LabTraceReader.from_json_file(TRACE_FIXTURE)
+
+    assert launcher.bitstream_loaded is False
+    assert launcher.bitstream_uuid is None
+    assert manifest.schema_version == "pccx.lab.kv260.trace-manifest.v0"
+    assert manifest.frame_count == 1
+    assert manifest.frames[0].result_payload == "a55a0001"
+
+
+def test_status_panel_and_preflight_are_deterministic() -> None:
+    launcher = LauncherStatusReader.from_json_file(LAUNCHER_FIXTURE)
+    manifest = LabTraceReader.from_json_file(TRACE_FIXTURE)
+    panel = create_kv260_status_panel(launcher, manifest)
+    payload = panel_to_dict(panel)
+    text = format_kv260_status_panel(panel)
+
+    assert payload["kind"] == "kv260-status-panel"
+    assert payload["launcher"]["mirror_version"] == "pccx.ide.launcher-npu-status.local-mirror.v0"
+    assert payload["safety"]["launcher_execution"] is False
+    assert payload["safety"]["pccx_lab_execution"] is False
+    assert payload["safety"]["ssh_execution"] is False
+    assert [item["item_id"] for item in payload["preflight"]["items"]] == [
+        "bitstream_loaded",
+        "axi_reachable",
+        "manifest_available",
+    ]
+    assert "KV260 Status Surface" in text
+    assert "execution: no launcher, no pccx-lab, no shell, no SSH, no KV260 control" in text
+
+
+def test_cli_kv260_status_prints_text_and_json() -> None:
+    text_result = _run_cli("kv260-status")
+    assert text_result.returncode == 0, text_result.stderr
+    assert "KV260 Status Surface" in text_result.stdout
+    assert "launcherMirror: pccx.ide.launcher-npu-status.local-mirror.v0" in text_result.stdout
+    assert "preflight:" in text_result.stdout
+
+    json_result = _run_cli("kv260-status", "--format", "json")
+    assert json_result.returncode == 0, json_result.stderr
+    payload = json.loads(json_result.stdout)
+    assert payload["kind"] == "kv260-status-panel"
+    assert payload["lab"]["source_kind"] == "file_replay"
+
+
+def test_readers_reject_unsafe_or_invalid_shapes() -> None:
+    with pytest.raises(ValueError, match="bitstream_loaded"):
+        LauncherStatusReader.from_object({"bitstream_loaded": "false"})
+
+    invalid_manifest = json.loads(TRACE_FIXTURE.read_text(encoding="utf-8"))
+    invalid_manifest["source_kind"] = "ssh_log_tail"
+    with pytest.raises(ValueError, match="file_replay"):
+        LabTraceReader.from_object(invalid_manifest)
+
+
+def test_touched_sources_do_not_add_execution_paths() -> None:
+    source = (SRC / "pccx_ide_cli" / "kv260_status.py").read_text(encoding="utf-8")
+    combined = "\n".join([
+        source,
+        (REPO_ROOT / "docs/KV260_READ_ONLY_STATUS_SURFACE.md").read_text(encoding="utf-8"),
+    ])
+    forbidden_source_terms = [
+        "subprocess",
+        "os.system",
+        "popen",
+        "socket",
+        "paramiko",
+        "requests",
+        "urllib",
+        "write_text",
+        "open(",
+    ]
+    for term in forbidden_source_terms:
+        assert term not in source, term
+    assert "/home/" not in combined
+    assert "password:" not in combined.lower()


### PR DESCRIPTION
Refs pccxai/pccx-llm-launcher#70
Refs pccxai/pccx-lab#160

## Summary
- Add local read-only KV260 status readers for launcher `NPUStatus` and lab `TraceManifest` fixture JSON.
- Add a pure VS Code prototype `Kv260StatusPanel` with preflight checklist and a read-only display command.
- Add `sv-ide kv260-status` / `pccx-ide kv260-status` text+JSON CLI output, tiny fixtures, docs, and type-only tests.

## Evidence
- python3 -m compileall -q src tests
- PYTHONPATH=src python3 -m pytest -q
- for test in editors/vscode-prototype/test/*.test.mjs; do node "$test" || exit 1; done
- git diff --check
- python3 scripts/check-source-headers.py
- node editors/vscode-prototype/test/static-boundary.test.mjs
- PYTHONPATH=src python3 -m pccx_ide_cli kv260-status
- PYTHONPATH=src python3 -m pccx_ide_cli kv260-status --format json

## Notes
- Launcher `NPUStatus` is mirrored locally; no cross-repo import is configured in this repo.
- Lab manifest parser is real for the lab#160 file-replay JSON shape.
- No SSH, board command, launcher execution, pccx-lab execution, shell execution, KV260 control, allowlist expansion, provider call, telemetry, upload, or write-back is implemented.
- `shellcheck` is not installed in this environment; this slice is gated on Python, JavaScript, JSON fixture, docs, static-boundary, and hook claim checks.
