### PR TITLE
feat(theme): dark variant

### DIFF
--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -13,9 +13,9 @@ integration tests, and they run without npm install, Vivado, xsim, or
 hardware.  A limited opt-in Extension Host runtime smoke exists for local
 dependency-policy review; it is not a product claim.
 
-The package includes a copied pccx aperture-mark icon and a light
-`pccx SystemVerilog Light` color theme derived from the local
-`pccx-UI/Systemverilog-IDE` design-system package.  These assets are
+The package includes a copied pccx aperture-mark icon and
+`pccx SystemVerilog Light` / `pccx SystemVerilog Dark` color themes derived
+from the local `pccx-UI/Systemverilog-IDE` design-system package.  These assets are
 visual branding only; they do not replace the host-theme-first
 presentation boundary and do not make the theme surface complete.
 
@@ -154,9 +154,10 @@ The contributed commands are:
 - `pccxSystemVerilog.showPccxLabBackendStatus`
 - `pccxSystemVerilog.showDiagnosticsHandoffSummary`
 
-The contributed color theme is:
+The contributed color themes are:
 
 - `pccx SystemVerilog Light`
+- `pccx SystemVerilog Dark`
 
 The extension icon is `assets/logo/aperture-mark-128.png`, with source
 SVG logo assets retained under `assets/logo/`.  The copied-asset notice is

--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -159,6 +159,9 @@ The contributed color themes are:
 - `pccx SystemVerilog Light`
 - `pccx SystemVerilog Dark`
 
+Light/dark maintenance expectations are documented in
+[`docs/theme-consistency.md`](./docs/theme-consistency.md).
+
 The extension icon is `assets/logo/aperture-mark-128.png`, with source
 SVG logo assets retained under `assets/logo/`.  The copied-asset notice is
 tracked in `assets/PCCX_UI_NOTICE.md`.

--- a/editors/vscode-prototype/docs/theme-consistency.md
+++ b/editors/vscode-prototype/docs/theme-consistency.md
@@ -1,0 +1,97 @@
+# Theme Consistency Rules
+
+The VS Code prototype contributes paired local themes:
+`pccx SystemVerilog Light` and `pccx SystemVerilog Dark`.  The light theme
+comes from the pccx-UI integration work and the dark theme is its follow-up
+variant.  Keep them reviewed as one pair so the dark theme stays a contrast
+variant of the same SystemVerilog editor surface, not a separate design
+system.
+
+This document is a maintenance rule set for:
+
+- `../themes/pccx-systemverilog-light-color-theme.json`
+- `../themes/pccx-systemverilog-dark-color-theme.json`
+- the `contributes.themes` entries in `../package.json`
+
+It does not make the prototype marketplace-ready, LSP-backed, or a complete
+custom theme engine.  The presentation policy remains host-theme-first for
+runtime UI records and future webview-like surfaces.
+
+## Pairing Rules
+
+- Both theme files must keep `semanticHighlighting: true`.
+- Both theme files must keep the same top-level shape: `name`, `type`,
+  `semanticHighlighting`, `colors`, and `tokenColors`.
+- `package.json` must contribute both themes together.  The light entry uses
+  `uiTheme: "vs"` and the dark entry uses `uiTheme: "vs-dark"`.
+- The `colors` maps should keep the same VS Code color keys unless a key is
+  demonstrably unavailable or inappropriate for one theme.  Any exception
+  should be documented in this file or the adjacent review notes.
+- The `tokenColors` arrays must keep the same bucket names, bucket order, and
+  scope lists.  Only foreground values should differ between light and dark.
+- Shared SystemVerilog token buckets are comments, keywords, types,
+  identifiers, literals, diagnostics/invalid tokens, and source default.
+- Shared workbench surface groups are activity bar, title bar, command center,
+  editor, gutter, side bar, list, panel, tabs, status bar, notifications,
+  quick input, terminal, and text links.
+
+## Shared Semantic Roles
+
+Use the same semantic role when choosing different light and dark values.
+
+| Role | Light rule | Dark rule |
+| --- | --- | --- |
+| Primary pccx action/accent | Use `#0b5fff` for primary action and focus surfaces. | Keep `#0b5fff` for the same structural accent surfaces. |
+| Editor foreground/background | Dark text on white or near-white editor surfaces. | Light text on near-black editor surfaces. |
+| Muted text | Lower-contrast gray that remains readable on light surfaces. | Higher-luminance gray that remains readable on dark surfaces. |
+| Selection/focus fill | Low-saturation blue fill that does not obscure syntax. | Deeper blue fill with enough contrast from the editor shell. |
+| Hover/secondary fill | Neutral gray fill distinct from the editor background. | Near-black or slate fill distinct from the editor background. |
+| Error/deleted | Red role for diagnostics and deletion. | Brighter red role for diagnostics and deletion. |
+| Warning/literals | Amber role for warnings and literal-like tokens. | Brighter amber role for warnings and literal-like tokens. |
+| Info/identifier | Blue role for information and identifier-like tokens. | Brighter blue role for information and identifier-like tokens. |
+| Added | Green role for additions. | Brighter green role for additions. |
+
+The shared accent `#0b5fff` is expected on paired structural surfaces such as
+buttons, focus borders, progress bars, modified gutters, activity badges, tab
+active borders, panel active borders, and prominent status bar items.  A dark
+theme may use a brighter related value for hover text, links, cursor, or syntax
+when contrast requires it.
+
+## Allowed Differences
+
+The dark theme may differ from the light theme for contrast and legibility:
+
+- background luminance and shell layering;
+- default, muted, inactive, and placeholder foreground values;
+- selection, hover, line-highlight, and find-match fills;
+- action hover colors;
+- terminal ANSI bright colors;
+- diagnostic foreground brightness;
+- link and cursor foreground brightness.
+
+Avoid introducing a new hue family or changing the meaning of a token bucket
+in only one theme.  For example, if keywords are purple in the light theme,
+the dark theme should use a contrast-adjusted purple rather than moving
+keywords to blue or green.
+
+## Review Checklist
+
+Before merging future theme changes:
+
+- Compare the two JSON files for key parity in `colors`.
+- Compare the two `tokenColors` arrays for matching bucket names, order, and
+  scope lists.
+- Confirm both themes still appear in `package.json` with the expected
+  `uiTheme` values and file paths.
+- Check that the primary pccx action/accent surfaces still use `#0b5fff`
+  unless a specific contrast exception is recorded.
+- Review diagnostics, gutter, and terminal colors as semantic pairs, not as
+  isolated palette values.
+- Capture or review both themes with the same fixture workspace, editor tab,
+  side bar, panel, status bar, selection state, and representative
+  SystemVerilog syntax.
+
+Do not use theme documentation or screenshots to imply marketplace
+availability, production readiness, stable API/ABI, LSP support, provider
+runtime calls, launcher calls, pccx-lab execution, or completed custom theme
+support.

--- a/editors/vscode-prototype/package.json
+++ b/editors/vscode-prototype/package.json
@@ -133,6 +133,11 @@
         "label": "pccx SystemVerilog Light",
         "uiTheme": "vs",
         "path": "./themes/pccx-systemverilog-light-color-theme.json"
+      },
+      {
+        "label": "pccx SystemVerilog Dark",
+        "uiTheme": "vs-dark",
+        "path": "./themes/pccx-systemverilog-dark-color-theme.json"
       }
     ],
     "configuration": {

--- a/editors/vscode-prototype/test/extension-manifest.test.mjs
+++ b/editors/vscode-prototype/test/extension-manifest.test.mjs
@@ -123,6 +123,11 @@ async function testVisualAssetContributions() {
       uiTheme: "vs",
       path: "./themes/pccx-systemverilog-light-color-theme.json",
     },
+    {
+      label: "pccx SystemVerilog Dark",
+      uiTheme: "vs-dark",
+      path: "./themes/pccx-systemverilog-dark-color-theme.json",
+    },
   ]);
 
   const icon = await readBytes(resolve(EXTENSION_ROOT, manifest.icon));
@@ -146,6 +151,20 @@ async function testVisualAssetContributions() {
   assert.ok(theme.tokenColors.some((token) => (
     token.name === "Types" && token.settings?.foreground === "#0d9488"
   )));
+}
+
+async function testThemeJsonTypes() {
+  const manifest = await readPackageJson();
+  const themes = manifest.contributes?.themes ?? [];
+
+  for (const contribution of themes) {
+    const theme = JSON.parse(await readText(resolve(EXTENSION_ROOT, contribution.path)));
+    if (contribution.uiTheme === "vs-dark") {
+      assert.equal(theme.type, "dark");
+    } else {
+      assert.equal(theme.type, "light");
+    }
+  }
 }
 
 async function testDocsKeepExperimentalScope() {
@@ -187,6 +206,7 @@ await testPackageManifestShape();
 await testNoMarketplacePublishingShape();
 await testCommandContributions();
 await testVisualAssetContributions();
+await testThemeJsonTypes();
 await testDocsKeepExperimentalScope();
 
 console.log("vscode extension manifest tests ok");

--- a/editors/vscode-prototype/themes/pccx-systemverilog-dark-color-theme.json
+++ b/editors/vscode-prototype/themes/pccx-systemverilog-dark-color-theme.json
@@ -1,0 +1,230 @@
+{
+  "name": "pccx SystemVerilog Dark",
+  "type": "dark",
+  "semanticHighlighting": true,
+  "colors": {
+    "activityBar.background": "#070a12",
+    "activityBar.foreground": "#e5e7eb",
+    "activityBar.inactiveForeground": "#8b95a7",
+    "activityBar.border": "#1f2937",
+    "activityBarBadge.background": "#0b5fff",
+    "activityBarBadge.foreground": "#ffffff",
+    "badge.background": "#123a7a",
+    "badge.foreground": "#dbeafe",
+    "button.background": "#0b5fff",
+    "button.foreground": "#ffffff",
+    "button.hoverBackground": "#3b82f6",
+    "checkbox.background": "#0b1020",
+    "checkbox.border": "#2f3b52",
+    "checkbox.foreground": "#0b5fff",
+    "commandCenter.background": "#0b1020",
+    "commandCenter.border": "#1f2937",
+    "commandCenter.foreground": "#e5e7eb",
+    "commandCenter.inactiveForeground": "#8b95a7",
+    "debugToolBar.background": "#0e1320",
+    "debugToolBar.border": "#1f2937",
+    "descriptionForeground": "#8b95a7",
+    "dropdown.background": "#0b1020",
+    "dropdown.border": "#2f3b52",
+    "dropdown.foreground": "#e5e7eb",
+    "editor.background": "#070a12",
+    "editor.foreground": "#e5e7eb",
+    "editor.findMatchBackground": "#5f3b08",
+    "editor.findMatchBorder": "#f59e0b",
+    "editor.findMatchHighlightBackground": "#123a7a",
+    "editor.lineHighlightBackground": "#0b1020",
+    "editor.selectionBackground": "#123a7a",
+    "editor.selectionHighlightBackground": "#111827",
+    "editor.wordHighlightBackground": "#111827",
+    "editorBracketMatch.background": "#123a7a",
+    "editorBracketMatch.border": "#0b5fff",
+    "editorCursor.foreground": "#60a5fa",
+    "editorError.foreground": "#f87171",
+    "editorGutter.addedBackground": "#22c55e",
+    "editorGutter.background": "#070a12",
+    "editorGutter.deletedBackground": "#f87171",
+    "editorGutter.modifiedBackground": "#0b5fff",
+    "editorIndentGuide.activeBackground1": "#4b5563",
+    "editorIndentGuide.background1": "#1f2937",
+    "editorInfo.foreground": "#60a5fa",
+    "editorLineNumber.activeForeground": "#dbeafe",
+    "editorLineNumber.foreground": "#8b95a7",
+    "editorRuler.foreground": "#1f2937",
+    "editorWarning.foreground": "#fbbf24",
+    "editorWidget.background": "#0b1020",
+    "editorWidget.border": "#1f2937",
+    "errorForeground": "#f87171",
+    "focusBorder": "#0b5fff",
+    "foreground": "#e5e7eb",
+    "input.background": "#0b1020",
+    "input.border": "#2f3b52",
+    "input.foreground": "#e5e7eb",
+    "input.placeholderForeground": "#8b95a7",
+    "inputOption.activeBackground": "#123a7a",
+    "inputOption.activeBorder": "#0b5fff",
+    "list.activeSelectionBackground": "#123a7a",
+    "list.activeSelectionForeground": "#ffffff",
+    "list.focusBackground": "#123a7a",
+    "list.highlightForeground": "#60a5fa",
+    "list.hoverBackground": "#111827",
+    "list.inactiveSelectionBackground": "#111827",
+    "notificationCenter.border": "#1f2937",
+    "notifications.background": "#0b1020",
+    "notifications.border": "#1f2937",
+    "notifications.foreground": "#e5e7eb",
+    "panel.background": "#0b1020",
+    "panel.border": "#1f2937",
+    "panelTitle.activeBorder": "#0b5fff",
+    "panelTitle.activeForeground": "#e5e7eb",
+    "panelTitle.inactiveForeground": "#8b95a7",
+    "peekView.border": "#1f2937",
+    "peekViewEditor.background": "#070a12",
+    "peekViewResult.background": "#0b1020",
+    "peekViewResult.selectionBackground": "#123a7a",
+    "pickerGroup.border": "#1f2937",
+    "pickerGroup.foreground": "#8b95a7",
+    "progressBar.background": "#0b5fff",
+    "quickInput.background": "#0b1020",
+    "quickInput.foreground": "#e5e7eb",
+    "quickInputList.focusBackground": "#123a7a",
+    "scrollbar.shadow": "#00000000",
+    "scrollbarSlider.activeBackground": "#4b5563",
+    "scrollbarSlider.background": "#2f3b52",
+    "scrollbarSlider.hoverBackground": "#4b5563",
+    "sideBar.background": "#090d18",
+    "sideBar.border": "#1f2937",
+    "sideBar.foreground": "#e5e7eb",
+    "sideBarSectionHeader.background": "#0b1020",
+    "sideBarSectionHeader.border": "#1f2937",
+    "sideBarSectionHeader.foreground": "#e5e7eb",
+    "sideBarTitle.foreground": "#e5e7eb",
+    "statusBar.background": "#0e1320",
+    "statusBar.border": "#1f2937",
+    "statusBar.debuggingBackground": "#123a7a",
+    "statusBar.debuggingForeground": "#ffffff",
+    "statusBar.foreground": "#e5e7eb",
+    "statusBar.noFolderBackground": "#0e1320",
+    "statusBar.noFolderForeground": "#e5e7eb",
+    "statusBarItem.hoverBackground": "#111827",
+    "statusBarItem.prominentBackground": "#0b5fff",
+    "statusBarItem.prominentForeground": "#ffffff",
+    "tab.activeBackground": "#070a12",
+    "tab.activeBorderTop": "#0b5fff",
+    "tab.activeForeground": "#e5e7eb",
+    "tab.border": "#1f2937",
+    "tab.hoverBackground": "#111827",
+    "tab.inactiveBackground": "#0b1020",
+    "tab.inactiveForeground": "#8b95a7",
+    "terminal.ansiBlack": "#070a12",
+    "terminal.ansiBlue": "#0b5fff",
+    "terminal.ansiBrightBlack": "#8b95a7",
+    "terminal.ansiBrightBlue": "#60a5fa",
+    "terminal.ansiBrightCyan": "#2dd4bf",
+    "terminal.ansiBrightGreen": "#22c55e",
+    "terminal.ansiBrightMagenta": "#a78bfa",
+    "terminal.ansiBrightRed": "#f87171",
+    "terminal.ansiBrightWhite": "#ffffff",
+    "terminal.ansiBrightYellow": "#fbbf24",
+    "terminal.ansiCyan": "#2dd4bf",
+    "terminal.ansiGreen": "#22c55e",
+    "terminal.ansiMagenta": "#a78bfa",
+    "terminal.ansiRed": "#f87171",
+    "terminal.ansiWhite": "#e5e7eb",
+    "terminal.ansiYellow": "#fbbf24",
+    "terminal.background": "#070a12",
+    "terminal.foreground": "#e5e7eb",
+    "textBlockQuote.background": "#0b1020",
+    "textBlockQuote.border": "#1f2937",
+    "textCodeBlock.background": "#0b1020",
+    "textLink.activeForeground": "#93c5fd",
+    "textLink.foreground": "#60a5fa",
+    "titleBar.activeBackground": "#0e1320",
+    "titleBar.activeForeground": "#e5e7eb",
+    "titleBar.border": "#1f2937",
+    "titleBar.inactiveBackground": "#070a12",
+    "titleBar.inactiveForeground": "#8b95a7"
+  },
+  "tokenColors": [
+    {
+      "name": "Comments",
+      "scope": [
+        "comment",
+        "punctuation.definition.comment"
+      ],
+      "settings": {
+        "foreground": "#8b95a7"
+      }
+    },
+    {
+      "name": "Keywords",
+      "scope": [
+        "keyword",
+        "storage.type",
+        "storage.modifier",
+        "constant.language"
+      ],
+      "settings": {
+        "foreground": "#a78bfa"
+      }
+    },
+    {
+      "name": "Types",
+      "scope": [
+        "entity.name.type",
+        "support.type",
+        "support.class",
+        "variable.language.this"
+      ],
+      "settings": {
+        "foreground": "#2dd4bf"
+      }
+    },
+    {
+      "name": "Identifiers",
+      "scope": [
+        "entity.name.function",
+        "entity.name.module",
+        "entity.name.tag",
+        "variable.other.readwrite",
+        "variable.parameter"
+      ],
+      "settings": {
+        "foreground": "#60a5fa"
+      }
+    },
+    {
+      "name": "Literals",
+      "scope": [
+        "constant.numeric",
+        "constant.other",
+        "string",
+        "string.quoted"
+      ],
+      "settings": {
+        "foreground": "#fbbf24"
+      }
+    },
+    {
+      "name": "Diagnostics And Invalid",
+      "scope": [
+        "invalid",
+        "invalid.illegal",
+        "invalid.deprecated"
+      ],
+      "settings": {
+        "foreground": "#f87171"
+      }
+    },
+    {
+      "name": "Source Default",
+      "scope": [
+        "source",
+        "punctuation",
+        "meta"
+      ],
+      "settings": {
+        "foreground": "#e5e7eb"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Refs #125.

Summary:
- Adds pccx SystemVerilog Dark beside the existing light theme.
- Uses the aperture-mark blue and ink colors with a darker editor/workbench base.
- Adds manifest wiring, README listing, and type-only JSON theme validation.

Validation:
- node editors/vscode-prototype/test/extension-manifest.test.mjs
- jq empty editors/vscode-prototype/package.json editors/vscode-prototype/themes/pccx-systemverilog-light-color-theme.json editors/vscode-prototype/themes/pccx-systemverilog-dark-color-theme.json
- git diff --check

Scope guard:
- Theme variant only.
- No command, activation, runtime, LSP, provider, API, ABI, or publishing metadata changes.