### PR TITLE
Add PCCX legal and community policy pointers

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,13 @@
+PCCX™ Project Notice
+
+Copyright (c) 2026 Hyun Woo Kim.
+
+Unless otherwise stated in individual files or license notices, this
+repository is part of the PCCX project. PCCX™ is a mark used by the
+PCCX project. Korean trademark applications are pending in Classes 09
+and 42. Do not use `PCCX®` until registration is granted and the
+central trademark policy is updated.
+
+See:
+- https://github.com/pccxai/pccx/blob/main/TRADEMARKS.md
+- https://github.com/pccxai/pccx/blob/main/IP_POLICY.md

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,10 @@
+# PCCX Trademark Notice
+
+`PCCX™` is a pending mark used by the PCCX project. This repository
+follows the central PCCX trademark policy:
+
+<https://github.com/pccxai/pccx/blob/main/TRADEMARKS.md>
+
+Do not use `PCCX®` until registration is granted and the central
+policy is updated. Use of the PCCX name does not imply certification,
+compatibility approval, endorsement, partnership, or official status.


### PR DESCRIPTION
Adds concise NOTICE/TRADEMARKS pointers to central PCCX policies. No binding legal contract, no PCCX® claim, no private filing material, and no code behavior changes.