### PR TITLE
feat: add local synthesis plan surface

### DIFF
--- a/editors/vscode-prototype/README.md
+++ b/editors/vscode-prototype/README.md
@@ -146,6 +146,7 @@ The contributed commands are:
 - `pccxSystemVerilog.clearPatchProposalPreview`
 - `pccxSystemVerilog.showLocalWorkflowStatus`
 - `pccxSystemVerilog.showContextBundleAudit`
+- `pccxSystemVerilog.showLocalSynthesisPlan`
 - `pccxSystemVerilog.showPccxLabBackendStatus`
 - `pccxSystemVerilog.showDiagnosticsHandoffSummary`
 - `pccxSystemVerilog.showAssistStatus`
@@ -229,6 +230,15 @@ commands.
 simulation handoff descriptor for the validation boundary.  It does not
 execute a simulator, write RTL, touch hardware, or bypass the existing
 approved validation runner gate.
+
+`pccxSystemVerilog.showLocalSynthesisPlan` creates a plan-only local
+synthesis descriptor for VS Code and JetBrains surfaces.  It returns the
+fixed CLI argument arrays for `pccx synth --local` and
+`pccx deploy --target kv260`, marks user-machine vendor toolchains as the
+execution boundary, keeps cloud sync optional and entitlement-gated, and
+does not execute shell commands, call network paths, upload artifacts, or
+touch hardware.  The boundary notes are tracked in
+[`docs/local-synthesis-extension-plan.md`](./docs/local-synthesis-extension-plan.md).
 
 `pccxSystemVerilog.showPccxLabBackendStatus` prepares a command palette
 status surface for future pccx-lab integration.  It returns the configured
@@ -445,10 +455,11 @@ device.  The boundary notes are tracked in
 `src/local-workflow-status.mjs` summarizes local prototype state for
 `pccxSystemVerilog.showLocalWorkflowStatus`: extension mode, live workspace
 gate, validation runner state, recent validation cache status, pccx-lab
-descriptor state, launcher fixture state, and a bounded context item count.
-It uses local/fixture data only and does not execute pccx-lab, call the
-launcher, call providers, implement an MCP server, bundle a language server, or package the
-extension.
+descriptor state, launcher fixture state, local synthesis plan boundary,
+and a bounded context item count. It uses local/fixture data only and does
+not execute pccx-lab, call the launcher, run local synthesis, call
+providers, implement an MCP server, bundle a language server, or package
+the extension.
 
 `src/context-bundle-audit.mjs` reports approximate context bundle size,
 diagnostic/snippet/validation summary counts, redaction/truncation flags,

--- a/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
+++ b/editors/vscode-prototype/docs/EXTENSION_HOST_READINESS.md
@@ -59,6 +59,9 @@ should earn CI promotion separately.
 - Diagnostics handoff summary status smoke.  The command reports the
   existing adapter summary as local data and does not execute launcher,
   pccx-lab, shell commands, providers, MCP, or LSP.
+- Local synthesis plan smoke.  The command returns fixed `pccx synth
+  --local` and `pccx deploy --target kv260` argument arrays for the CLI
+  boundary and does not execute vendor tools.
 - Guard behavior for the local-only Extension Host runtime smoke.
 - Pinned Extension Host activation and command-registration smoke when
   explicitly enabled locally.

--- a/editors/vscode-prototype/docs/local-synthesis-extension-plan.md
+++ b/editors/vscode-prototype/docs/local-synthesis-extension-plan.md
@@ -1,0 +1,26 @@
+# Local Synthesis Extension Plan
+
+This note records the editor-side boundary for local synthesis mode.
+
+The data contract is `pccx.localSynthesisPlan.v0`. It is shared by:
+
+- VS Code command: `pccxSystemVerilog.showLocalSynthesisPlan`
+- JetBrains action: `pccx.systemverilog.showLocalSynthesisPlan`
+
+The extension surface prepares fixed argument arrays for the CLI boundary:
+
+```text
+pccx synth --local --script synth.tcl --vendor auto --work-dir . --dry-run
+pccx deploy --target kv260 --artifact build/pccx.xclbin --dry-run
+```
+
+Actual local tool invocation stays in the CLI or launcher local wrapper.
+Those layers are responsible for detecting user-machine Vivado or Quartus
+installations and for using `--run` after explicit user approval. The
+editor surface stays plan-only, has no shell execution, and does not call
+network, telemetry, upload, provider, launcher, pccx-lab, or hardware paths.
+
+Cloud project/library sync and synthesis-result backup are optional
+entitlement-gated services. The local synthesis plan marks them as
+`cloudSyncRequired: false` so offline synthesis can remain available when
+the user machine has the required vendor toolchain.

--- a/editors/vscode-prototype/package.json
+++ b/editors/vscode-prototype/package.json
@@ -33,6 +33,7 @@
     "onCommand:pccxSystemVerilog.clearPatchProposalPreview",
     "onCommand:pccxSystemVerilog.showLocalWorkflowStatus",
     "onCommand:pccxSystemVerilog.showContextBundleAudit",
+    "onCommand:pccxSystemVerilog.showLocalSynthesisPlan",
     "onCommand:pccxSystemVerilog.showPccxLabBackendStatus",
     "onCommand:pccxSystemVerilog.showDiagnosticsHandoffSummary",
     "onCommand:pccxSystemVerilog.showAssistStatus",
@@ -122,6 +123,10 @@
       {
         "command": "pccxSystemVerilog.showContextBundleAudit",
         "title": "PCCX SystemVerilog: Show Context Bundle Audit (Experimental)"
+      },
+      {
+        "command": "pccxSystemVerilog.showLocalSynthesisPlan",
+        "title": "PCCX SystemVerilog: Show Local Synthesis Plan (Experimental, No Execution)"
       },
       {
         "command": "pccxSystemVerilog.showPccxLabBackendStatus",

--- a/editors/vscode-prototype/src/config.mjs
+++ b/editors/vscode-prototype/src/config.mjs
@@ -53,6 +53,10 @@ export const WORKFLOW_COMMAND_IDS = Object.freeze([
   "pccxSystemVerilog.showContextBundleAudit",
 ]);
 
+export const LOCAL_SYNTHESIS_COMMAND_IDS = Object.freeze([
+  "pccxSystemVerilog.showLocalSynthesisPlan",
+]);
+
 export const PCCX_LAB_COMMAND_IDS = Object.freeze([
   "pccxSystemVerilog.showPccxLabBackendStatus",
 ]);
@@ -70,6 +74,7 @@ export const ASSIST_COMMAND_IDS = Object.freeze([
 export const COMMAND_IDS = Object.freeze([
   ...FACADE_COMMAND_IDS,
   ...WORKFLOW_COMMAND_IDS,
+  ...LOCAL_SYNTHESIS_COMMAND_IDS,
   ...PCCX_LAB_COMMAND_IDS,
   ...DIAGNOSTICS_HANDOFF_COMMAND_IDS,
   ...ASSIST_COMMAND_IDS,

--- a/editors/vscode-prototype/src/extension.mjs
+++ b/editors/vscode-prototype/src/extension.mjs
@@ -65,6 +65,10 @@ import {
   formatLocalWorkflowStatus,
 } from "./local-workflow-status.mjs";
 import {
+  createLocalSynthesisPlan,
+  formatLocalSynthesisPlan,
+} from "./local-synthesis-plan.mjs";
+import {
   createContextBundleAudit,
   formatContextBundleAudit,
 } from "./context-bundle-audit.mjs";
@@ -119,6 +123,8 @@ export const SHOW_LOCAL_WORKFLOW_STATUS_COMMAND =
   "pccxSystemVerilog.showLocalWorkflowStatus";
 export const SHOW_CONTEXT_BUNDLE_AUDIT_COMMAND =
   "pccxSystemVerilog.showContextBundleAudit";
+export const SHOW_LOCAL_SYNTHESIS_PLAN_COMMAND =
+  "pccxSystemVerilog.showLocalSynthesisPlan";
 export const PCCX_LAB_BACKEND_STATUS_COMMAND =
   "pccxSystemVerilog.showPccxLabBackendStatus";
 export const SHOW_DIAGNOSTICS_HANDOFF_SUMMARY_COMMAND =
@@ -437,6 +443,9 @@ function appendCommandOutput(outputChannel, commandId, result) {
   }
   if (result.kind === "local-workflow-status") {
     outputChannel.appendLine(formatLocalWorkflowStatus(result.status));
+  }
+  if (result.kind === "local-synthesis-plan") {
+    outputChannel.appendLine(formatLocalSynthesisPlan(result.plan));
   }
   if (result.kind === "context-bundle-audit") {
     outputChannel.appendLine(formatContextBundleAudit(result.audit));
@@ -1118,6 +1127,30 @@ export function createCommandHandler(commandId, vscodeApi, runtime = {}) {
         };
         vscodeApi?.window?.showInformationMessage?.(
           `Context bundle audit: ${audit.approximateCharacterCount} character(s), ${audit.diagnosticCount} diagnostic(s).`,
+          result,
+        );
+      } catch (error) {
+        result = { ok: false, commandId, error: error.message };
+        vscodeApi?.window?.showWarningMessage?.(result.error, result);
+      }
+      appendCommandOutput(runtime.outputChannel, commandId, result);
+      return result;
+    }
+
+    if (commandId === SHOW_LOCAL_SYNTHESIS_PLAN_COMMAND) {
+      let result;
+      try {
+        const plan = createLocalSynthesisPlan(
+          input && typeof input === "object" && !input.fsPath ? input : {},
+        );
+        result = {
+          ok: true,
+          commandId,
+          kind: "local-synthesis-plan",
+          plan,
+        };
+        vscodeApi?.window?.showInformationMessage?.(
+          `Local synthesis plan: ${plan.localBuild.vendor}, ${plan.localBuild.target}, plan-only.`,
           result,
         );
       } catch (error) {

--- a/editors/vscode-prototype/src/local-synthesis-plan.mjs
+++ b/editors/vscode-prototype/src/local-synthesis-plan.mjs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
+
+export const LOCAL_SYNTHESIS_PLAN_VERSION = "pccx.localSynthesisPlan.v0";
+export const SHOW_LOCAL_SYNTHESIS_PLAN_COMMAND =
+  "pccxSystemVerilog.showLocalSynthesisPlan";
+export const JETBRAINS_LOCAL_SYNTHESIS_ACTION =
+  "pccx.systemverilog.showLocalSynthesisPlan";
+
+const VENDORS = Object.freeze(["auto", "vivado", "quartus"]);
+const TARGETS = Object.freeze(["kv260"]);
+const SHELL_CONTROL_PATTERN = /(?:&&|\|\||;|`|\$\(|>|<)/;
+
+function singleLineString(value, fallback, label) {
+  if (value == null) {
+    return fallback;
+  }
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  if (value.includes("\0") || value.includes("\n") || value.includes("\r")) {
+    throw new Error(`${label} must be a single-line string`);
+  }
+  if (SHELL_CONTROL_PATTERN.test(value)) {
+    throw new Error(`${label} must not contain shell control syntax`);
+  }
+  return value;
+}
+
+function enumValue(value, fallback, allowedValues, label) {
+  const normalized = singleLineString(value, fallback, label);
+  if (!allowedValues.includes(normalized)) {
+    throw new Error(`${label} must be one of: ${allowedValues.join(", ")}`);
+  }
+  return normalized;
+}
+
+function modeFlag(input = {}) {
+  return input.run === true ? "--run" : "--dry-run";
+}
+
+export function createLocalSynthesisPlan(input = {}) {
+  const vendor = enumValue(input.vendor, "auto", VENDORS, "vendor");
+  const target = enumValue(input.target, "kv260", TARGETS, "target");
+  const scriptPath = singleLineString(input.scriptPath, "synth.tcl", "scriptPath");
+  const workDir = singleLineString(input.workDir, ".", "workDir");
+  const artifactPath = singleLineString(input.artifactPath, "build/pccx.xclbin", "artifactPath");
+  const flag = modeFlag(input);
+
+  return {
+    version: LOCAL_SYNTHESIS_PLAN_VERSION,
+    kind: "local-synthesis-plan",
+    proposalOnly: true,
+    surfaces: {
+      vscode: {
+        commandId: SHOW_LOCAL_SYNTHESIS_PLAN_COMMAND,
+        execution: "plan-only",
+      },
+      jetbrains: {
+        actionId: JETBRAINS_LOCAL_SYNTHESIS_ACTION,
+        execution: "plan-only",
+      },
+    },
+    localProject: {
+      workDir,
+      syncRequired: false,
+    },
+    syncStatus: {
+      cloudSyncRequired: false,
+      entitlement: "paid-only",
+      projectSync: "not-configured",
+      buildBackup: "not-configured",
+    },
+    localBuild: {
+      vendor,
+      target,
+      scriptPath,
+      workDir,
+      artifactPath,
+      synthArgv: [
+        "pccx",
+        "synth",
+        "--local",
+        "--script",
+        scriptPath,
+        "--vendor",
+        vendor,
+        "--work-dir",
+        workDir,
+        flag,
+      ],
+      deployArgv: [
+        "pccx",
+        "deploy",
+        "--target",
+        target,
+        "--artifact",
+        artifactPath,
+        flag,
+      ],
+      localToolchain: true,
+      offlineSupported: true,
+      cloudSyncRequired: false,
+    },
+    safety: {
+      planOnly: true,
+      executes: false,
+      shellExecution: false,
+      providerCalls: false,
+      networkCalls: false,
+      telemetry: false,
+      automaticUpload: false,
+      writeBack: false,
+    },
+  };
+}
+
+export function formatLocalSynthesisPlan(plan) {
+  return [
+    "Local Synthesis Plan",
+    `version: ${plan.version}`,
+    `vendor: ${plan.localBuild.vendor}`,
+    `target: ${plan.localBuild.target}`,
+    `offline: ${plan.localBuild.offlineSupported ? "yes" : "no"}`,
+    `cloudSyncRequired: ${plan.localBuild.cloudSyncRequired ? "yes" : "no"}`,
+    `VS Code: ${plan.surfaces.vscode.commandId} (${plan.surfaces.vscode.execution})`,
+    `JetBrains: ${plan.surfaces.jetbrains.actionId} (${plan.surfaces.jetbrains.execution})`,
+    `synthArgv: ${plan.localBuild.synthArgv.join(" ")}`,
+    `deployArgv: ${plan.localBuild.deployArgv.join(" ")}`,
+    "safety: plan-only, no shell execution, no network calls, no upload",
+  ].join("\n");
+}

--- a/editors/vscode-prototype/src/local-workflow-status.mjs
+++ b/editors/vscode-prototype/src/local-workflow-status.mjs
@@ -19,6 +19,9 @@ import {
 import {
   createRuntimeReadinessStatusSurface,
 } from "./runtime-readiness-status-surface.mjs";
+import {
+  createLocalSynthesisPlan,
+} from "./local-synthesis-plan.mjs";
 
 export const LOCAL_WORKFLOW_STATUS_VERSION = "pccx.localWorkflowStatus.v0";
 
@@ -75,6 +78,7 @@ export function createLocalWorkflowStatus(config = {}, input = {}) {
   const runtimeReadinessSurface = createRuntimeReadinessStatusSurface(
     input.runtimeReadinessSummary,
   );
+  const localSynthesisPlan = createLocalSynthesisPlan(input.localSynthesis ?? {});
   const validationCache = validationStatusFromCache(input.validationResultCache);
   const extensionMode = typeof config.mode === "string" ? config.mode : "checkedExample";
   const validationRunner = config.validationRunner ?? {};
@@ -144,6 +148,22 @@ export function createLocalWorkflowStatus(config = {}, input = {}) {
       throughputState: runtimeReadinessSurface.states.throughput,
       blockerCount: runtimeReadinessSurface.blockers.count,
     },
+    localSynthesisBoundary: {
+      version: localSynthesisPlan.version,
+      status: "plan-only",
+      vendor: localSynthesisPlan.localBuild.vendor,
+      target: localSynthesisPlan.localBuild.target,
+      offlineSupported: localSynthesisPlan.localBuild.offlineSupported === true,
+      cloudSyncRequired: localSynthesisPlan.localBuild.cloudSyncRequired === true,
+      vscodeCommandId: localSynthesisPlan.surfaces.vscode.commandId,
+      jetbrainsActionId: localSynthesisPlan.surfaces.jetbrains.actionId,
+      executes: localSynthesisPlan.safety.executes === true,
+      shellExecution: localSynthesisPlan.safety.shellExecution === true,
+      networkCalls: localSynthesisPlan.safety.networkCalls === true,
+      providerCalls: localSynthesisPlan.safety.providerCalls === true,
+      synthArgv: localSynthesisPlan.localBuild.synthArgv,
+      deployArgv: localSynthesisPlan.localBuild.deployArgv,
+    },
     contextBundle: contextBundleEstimate({
       ...input,
       runtimeReadinessBlockerCount: runtimeReadinessSurface.blockers.count,
@@ -154,6 +174,9 @@ export function createLocalWorkflowStatus(config = {}, input = {}) {
       pccxLabExecution: false,
       fpgaRepoAccess: false,
       kv260RuntimeExecution: false,
+      localSynthesisExecution: false,
+      networkCalls: false,
+      cloudSyncRequired: false,
       mcpCalls: false,
       lspImplemented: false,
       marketplaceFlow: false,
@@ -177,6 +200,7 @@ export function formatLocalWorkflowStatus(status) {
     `diagnosticsHandoffSummary: ${status.diagnosticsHandoffBoundary.surfaceStatus} diagnostics=${status.diagnosticsHandoffBoundary.diagnosticCount}`,
     `runtimeReadinessBoundary: ${status.runtimeReadinessBoundary.supportedSchemaVersion} readOnly=${status.runtimeReadinessBoundary.readOnly ? "yes" : "no"}`,
     `runtimeReadinessSummary: ${status.runtimeReadinessBoundary.statusAnswer} readiness=${status.runtimeReadinessBoundary.readinessState} blockers=${status.runtimeReadinessBoundary.blockerCount}`,
+    `localSynthesisBoundary: ${status.localSynthesisBoundary.version} vendor=${status.localSynthesisBoundary.vendor} offline=${status.localSynthesisBoundary.offlineSupported ? "yes" : "no"} vscode=yes jetbrains=yes`,
     `contextBundleItems: ${status.contextBundle.itemCount}`,
     "safety: no provider calls, no launcher calls, no pccx-lab execution, no FPGA repo access, no KV260 runtime",
   ].join("\n");

--- a/editors/vscode-prototype/test/extension-entrypoint.test.mjs
+++ b/editors/vscode-prototype/test/extension-entrypoint.test.mjs
@@ -17,6 +17,7 @@ import {
   PCCX_LAB_BACKEND_STATUS_COMMAND,
   SHOW_CONTEXT_BUNDLE_AUDIT_COMMAND,
   SHOW_DIAGNOSTICS_HANDOFF_SUMMARY_COMMAND,
+  SHOW_LOCAL_SYNTHESIS_PLAN_COMMAND,
   SHOW_LOCAL_WORKFLOW_STATUS_COMMAND,
   SHOW_PATCH_PROPOSAL_PREVIEW_COMMAND,
   SHOW_RECENT_VALIDATION_RESULTS_COMMAND,
@@ -857,6 +858,36 @@ async function testAssistStatusCommandReturnsCitationCounts() {
   assert.ok(result.citations.uniqueCitationCount >= 20);
   assert.equal(result.demoPlan.executesSimulation, false);
   assert.equal(result.demoPlan.writesRtl, false);
+}
+
+async function testLocalSynthesisPlanCommandReturnsPlanOnly() {
+  const handler = createCommandHandler(SHOW_LOCAL_SYNTHESIS_PLAN_COMMAND, null, {});
+
+  const result = await handler({
+    vendor: "vivado",
+    scriptPath: "build/synth.tcl",
+    workDir: "build",
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.commandId, SHOW_LOCAL_SYNTHESIS_PLAN_COMMAND);
+  assert.equal(result.kind, "local-synthesis-plan");
+  assert.equal(result.plan.version, "pccx.localSynthesisPlan.v0");
+  assert.equal(result.plan.localBuild.vendor, "vivado");
+  assert.equal(result.plan.localBuild.offlineSupported, true);
+  assert.equal(result.plan.syncStatus.cloudSyncRequired, false);
+  assert.equal(result.plan.safety.executes, false);
+  assert.deepEqual(result.plan.localBuild.synthArgv.slice(0, 3), [
+    "pccx",
+    "synth",
+    "--local",
+  ]);
+  assert.deepEqual(result.plan.localBuild.deployArgv.slice(0, 4), [
+    "pccx",
+    "deploy",
+    "--target",
+    "kv260",
+  ]);
 }
 
 async function testVeribleLintCommandPublishesDiagnosticsFromFixedInvocation() {
@@ -1738,6 +1769,7 @@ await testActivationRegistersCheckedExampleDefinitionProvider();
 await testNoVsCodeRuntimeIsANoop();
 await testCommandHandlerCanBeUsedWithoutRealVsCode();
 await testAssistStatusCommandReturnsCitationCounts();
+await testLocalSynthesisPlanCommandReturnsPlanOnly();
 await testVeribleLintCommandPublishesDiagnosticsFromFixedInvocation();
 await testPrepareSimulationHandoffIsDataOnly();
 await testWorkflowStatusCommandReturnsDisabledBackendNone();

--- a/editors/vscode-prototype/test/extension-host-readiness.test.mjs
+++ b/editors/vscode-prototype/test/extension-host-readiness.test.mjs
@@ -116,6 +116,7 @@ async function testReadinessDocsAndCiPolicy() {
   assert.match(`${readme}\n${readiness}`, /clearPatchProposalPreview/);
   assert.match(`${readme}\n${readiness}`, /showLocalWorkflowStatus/);
   assert.match(`${readme}\n${readiness}`, /showContextBundleAudit/);
+  assert.match(`${readme}\n${readiness}`, /showLocalSynthesisPlan/);
   assert.match(`${readme}\n${readiness}`, /showPccxLabBackendStatus/);
   assert.match(`${readme}\n${readiness}`, /showDiagnosticsHandoffSummary/);
   assert.match(`${readme}\n${readiness}`, /showAssistStatus/);
@@ -189,6 +190,7 @@ async function testRuntimeRunnerIsPinnedAndBounded() {
   assert.match(suite, /clearPatchProposalPreview/);
   assert.match(suite, /showLocalWorkflowStatus/);
   assert.match(suite, /showContextBundleAudit/);
+  assert.match(suite, /showLocalSynthesisPlan/);
   assert.match(suite, /validationRunner\.enabled/);
   assert.match(suite, /vscodeAdapterSmoke/);
   assert.match(suite, /showPccxLabBackendStatus/);

--- a/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
+++ b/editors/vscode-prototype/test/extension-host/smoke-suite.cjs
@@ -79,6 +79,7 @@ async function run() {
     "pccxSystemVerilog.clearPatchProposalPreview",
     "pccxSystemVerilog.showLocalWorkflowStatus",
     "pccxSystemVerilog.showContextBundleAudit",
+    "pccxSystemVerilog.showLocalSynthesisPlan",
     "pccxSystemVerilog.showPccxLabBackendStatus",
     "pccxSystemVerilog.showDiagnosticsHandoffSummary",
     "pccxSystemVerilog.showAssistStatus",
@@ -467,6 +468,9 @@ async function run() {
   assert.equal(localWorkflowStatus.status.launcherBoundary.launcherCalls, false);
   assert.equal(localWorkflowStatus.status.safety.providerCalls, false);
   assert.equal(localWorkflowStatus.status.safety.pccxLabExecution, false);
+  assert.equal(localWorkflowStatus.status.localSynthesisBoundary.version, "pccx.localSynthesisPlan.v0");
+  assert.equal(localWorkflowStatus.status.localSynthesisBoundary.offlineSupported, true);
+  assert.equal(localWorkflowStatus.status.localSynthesisBoundary.executes, false);
 
   const contextBundleAudit = await vscode.commands.executeCommand(
     "pccxSystemVerilog.showContextBundleAudit",
@@ -477,6 +481,22 @@ async function run() {
   assert.equal(contextBundleAudit.audit.safety.providerCalls, false);
   assert.equal(contextBundleAudit.audit.safety.fullLogsExcluded, true);
   assert.doesNotMatch(JSON.stringify(contextBundleAudit.audit), /\/home\//);
+
+  const localSynthesisPlan = await vscode.commands.executeCommand(
+    "pccxSystemVerilog.showLocalSynthesisPlan",
+    { vendor: "auto", scriptPath: "synth.tcl", workDir: "." },
+  );
+  assert.equal(localSynthesisPlan.ok, true);
+  assert.equal(localSynthesisPlan.kind, "local-synthesis-plan");
+  assert.equal(localSynthesisPlan.plan.version, "pccx.localSynthesisPlan.v0");
+  assert.equal(localSynthesisPlan.plan.localBuild.offlineSupported, true);
+  assert.equal(localSynthesisPlan.plan.localBuild.cloudSyncRequired, false);
+  assert.equal(localSynthesisPlan.plan.safety.executes, false);
+  assert.deepEqual(localSynthesisPlan.plan.localBuild.synthArgv.slice(0, 3), [
+    "pccx",
+    "synth",
+    "--local",
+  ]);
 
   const disabledValidationRun = await vscode.commands.executeCommand(
     "pccxSystemVerilog.runApprovedValidationCommand",

--- a/editors/vscode-prototype/test/extension-manifest.test.mjs
+++ b/editors/vscode-prototype/test/extension-manifest.test.mjs
@@ -29,6 +29,7 @@ const COMMAND_IDS = [
   "pccxSystemVerilog.clearPatchProposalPreview",
   "pccxSystemVerilog.showLocalWorkflowStatus",
   "pccxSystemVerilog.showContextBundleAudit",
+  "pccxSystemVerilog.showLocalSynthesisPlan",
   "pccxSystemVerilog.showPccxLabBackendStatus",
   "pccxSystemVerilog.showDiagnosticsHandoffSummary",
   "pccxSystemVerilog.showAssistStatus",
@@ -157,6 +158,7 @@ async function testDocsKeepExperimentalScope() {
   assert.match(combined, /launcher status contract/i);
   assert.match(combined, /showLocalWorkflowStatus/);
   assert.match(combined, /showContextBundleAudit/);
+  assert.match(combined, /showLocalSynthesisPlan/);
   assert.match(combined, /approved validation runner/i);
   assert.match(combined, /allowlisted proposal IDs/i);
   assert.match(combined, /pccx-lab backend status/i);

--- a/editors/vscode-prototype/test/local-synthesis-plan.test.mjs
+++ b/editors/vscode-prototype/test/local-synthesis-plan.test.mjs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 pccxai
+
+import assert from "node:assert/strict";
+
+import {
+  JETBRAINS_LOCAL_SYNTHESIS_ACTION,
+  LOCAL_SYNTHESIS_PLAN_VERSION,
+  SHOW_LOCAL_SYNTHESIS_PLAN_COMMAND,
+  createLocalSynthesisPlan,
+  formatLocalSynthesisPlan,
+} from "../src/local-synthesis-plan.mjs";
+
+function testDefaultPlanIsLocalOfflineAndPlanOnly() {
+  const plan = createLocalSynthesisPlan();
+
+  assert.equal(plan.version, LOCAL_SYNTHESIS_PLAN_VERSION);
+  assert.equal(plan.kind, "local-synthesis-plan");
+  assert.equal(plan.proposalOnly, true);
+  assert.equal(plan.surfaces.vscode.commandId, SHOW_LOCAL_SYNTHESIS_PLAN_COMMAND);
+  assert.equal(plan.surfaces.jetbrains.actionId, JETBRAINS_LOCAL_SYNTHESIS_ACTION);
+  assert.equal(plan.localBuild.vendor, "auto");
+  assert.equal(plan.localBuild.target, "kv260");
+  assert.deepEqual(plan.localBuild.synthArgv, [
+    "pccx",
+    "synth",
+    "--local",
+    "--script",
+    "synth.tcl",
+    "--vendor",
+    "auto",
+    "--work-dir",
+    ".",
+    "--dry-run",
+  ]);
+  assert.deepEqual(plan.localBuild.deployArgv, [
+    "pccx",
+    "deploy",
+    "--target",
+    "kv260",
+    "--artifact",
+    "build/pccx.xclbin",
+    "--dry-run",
+  ]);
+  assert.equal(plan.localBuild.localToolchain, true);
+  assert.equal(plan.localBuild.offlineSupported, true);
+  assert.equal(plan.syncStatus.cloudSyncRequired, false);
+  assert.equal(plan.safety.planOnly, true);
+  assert.equal(plan.safety.executes, false);
+  assert.equal(plan.safety.shellExecution, false);
+  assert.equal(plan.safety.networkCalls, false);
+  assert.equal(plan.safety.providerCalls, false);
+  assert.equal(plan.safety.automaticUpload, false);
+  assert.equal(plan.safety.writeBack, false);
+  assert.doesNotMatch(JSON.stringify(plan), /\/home\/|TOKEN=|model\.gguf/);
+}
+
+function testCustomPlanKeepsFixedArgvShape() {
+  const plan = createLocalSynthesisPlan({
+    vendor: "quartus",
+    scriptPath: "fpga/synth.tcl",
+    workDir: "build/local",
+    artifactPath: "build/local/pccx.xclbin",
+    run: true,
+  });
+
+  assert.equal(plan.localBuild.vendor, "quartus");
+  assert.deepEqual(plan.localBuild.synthArgv, [
+    "pccx",
+    "synth",
+    "--local",
+    "--script",
+    "fpga/synth.tcl",
+    "--vendor",
+    "quartus",
+    "--work-dir",
+    "build/local",
+    "--run",
+  ]);
+  assert.deepEqual(plan.localBuild.deployArgv, [
+    "pccx",
+    "deploy",
+    "--target",
+    "kv260",
+    "--artifact",
+    "build/local/pccx.xclbin",
+    "--run",
+  ]);
+  assert.ok(plan.localBuild.synthArgv.every((arg) => typeof arg === "string"));
+  assert.doesNotMatch(plan.localBuild.synthArgv.join("\n"), /(?:&&|\|\||;|`|\$\(|>|<)/);
+}
+
+function testUnsafeInputsAreRejected() {
+  assert.throws(
+    () => createLocalSynthesisPlan({ vendor: "ise" }),
+    /vendor must be one of: auto, vivado, quartus/,
+  );
+  assert.throws(
+    () => createLocalSynthesisPlan({ scriptPath: "synth.tcl; rm -rf /" }),
+    /scriptPath must not contain shell control syntax/,
+  );
+  assert.throws(
+    () => createLocalSynthesisPlan({ workDir: "build && whoami" }),
+    /workDir must not contain shell control syntax/,
+  );
+}
+
+function testFormatterNamesBothEditorSurfaces() {
+  const text = formatLocalSynthesisPlan(createLocalSynthesisPlan());
+
+  assert.match(text, /Local Synthesis Plan/);
+  assert.match(text, /offline: yes/);
+  assert.match(text, /cloudSyncRequired: no/);
+  assert.match(text, /VS Code: pccxSystemVerilog\.showLocalSynthesisPlan/);
+  assert.match(text, /JetBrains: pccx\.systemverilog\.showLocalSynthesisPlan/);
+  assert.match(text, /pccx synth --local/);
+  assert.match(text, /no shell execution/);
+  assert.match(text, /no network calls/);
+}
+
+testDefaultPlanIsLocalOfflineAndPlanOnly();
+testCustomPlanKeepsFixedArgvShape();
+testUnsafeInputsAreRejected();
+testFormatterNamesBothEditorSurfaces();
+
+console.log("vscode local synthesis plan tests ok");

--- a/editors/vscode-prototype/test/local-workflow-status.test.mjs
+++ b/editors/vscode-prototype/test/local-workflow-status.test.mjs
@@ -95,12 +95,44 @@ function testLocalWorkflowStatusUsesDeterministicLocalDataOnly() {
   assert.equal(status.runtimeReadinessBoundary.runtimeEvidenceState, "blocked");
   assert.equal(status.runtimeReadinessBoundary.throughputState, "target");
   assert.equal(status.runtimeReadinessBoundary.blockerCount, 6);
+  assert.equal(status.localSynthesisBoundary.version, "pccx.localSynthesisPlan.v0");
+  assert.equal(status.localSynthesisBoundary.status, "plan-only");
+  assert.equal(status.localSynthesisBoundary.vendor, "auto");
+  assert.equal(status.localSynthesisBoundary.target, "kv260");
+  assert.equal(status.localSynthesisBoundary.offlineSupported, true);
+  assert.equal(status.localSynthesisBoundary.cloudSyncRequired, false);
+  assert.equal(
+    status.localSynthesisBoundary.vscodeCommandId,
+    "pccxSystemVerilog.showLocalSynthesisPlan",
+  );
+  assert.equal(
+    status.localSynthesisBoundary.jetbrainsActionId,
+    "pccx.systemverilog.showLocalSynthesisPlan",
+  );
+  assert.equal(status.localSynthesisBoundary.executes, false);
+  assert.equal(status.localSynthesisBoundary.shellExecution, false);
+  assert.equal(status.localSynthesisBoundary.networkCalls, false);
+  assert.equal(status.localSynthesisBoundary.providerCalls, false);
+  assert.deepEqual(status.localSynthesisBoundary.synthArgv.slice(0, 3), [
+    "pccx",
+    "synth",
+    "--local",
+  ]);
+  assert.deepEqual(status.localSynthesisBoundary.deployArgv.slice(0, 4), [
+    "pccx",
+    "deploy",
+    "--target",
+    "kv260",
+  ]);
   assert.equal(status.contextBundle.itemCount, 15);
   assert.equal(status.safety.providerCalls, false);
   assert.equal(status.safety.launcherCalls, false);
   assert.equal(status.safety.pccxLabExecution, false);
   assert.equal(status.safety.fpgaRepoAccess, false);
   assert.equal(status.safety.kv260RuntimeExecution, false);
+  assert.equal(status.safety.localSynthesisExecution, false);
+  assert.equal(status.safety.networkCalls, false);
+  assert.equal(status.safety.cloudSyncRequired, false);
   assert.equal(status.safety.telemetry, false);
   assert.equal(status.safety.automaticUpload, false);
   assert.equal(status.safety.writeBack, false);
@@ -126,12 +158,16 @@ function testLocalWorkflowStatusDefaultsAreDisabledAndSafe() {
   assert.equal(status.runtimeReadinessBoundary.kv260RuntimeExecution, false);
   assert.equal(status.runtimeReadinessBoundary.statusAnswer, "blocked_not_yet_evidence_backed");
   assert.equal(status.runtimeReadinessBoundary.blockerCount, 6);
+  assert.equal(status.localSynthesisBoundary.executes, false);
+  assert.equal(status.localSynthesisBoundary.offlineSupported, true);
+  assert.equal(status.localSynthesisBoundary.cloudSyncRequired, false);
   assert.match(text, /Local Workflow Status/);
   assert.match(text, /validationRunner: disabled/);
   assert.match(text, /diagnosticsHandoffBoundary: pccx\.diagnosticsHandoff\.v0 readOnly=yes/);
   assert.match(text, /diagnosticsHandoffSummary: available diagnostics=5/);
   assert.match(text, /runtimeReadinessBoundary: pccx\.runtimeReadiness\.v0 readOnly=yes/);
   assert.match(text, /runtimeReadinessSummary: blocked_not_yet_evidence_backed readiness=blocked blockers=6/);
+  assert.match(text, /localSynthesisBoundary: pccx\.localSynthesisPlan\.v0 vendor=auto offline=yes vscode=yes jetbrains=yes/);
   assert.match(text, /no pccx-lab execution/);
   assert.match(text, /no FPGA repo access/);
   assert.match(text, /no KV260 runtime/);


### PR DESCRIPTION
## Summary
- add pccx.localSynthesisPlan.v0 for VS Code and JetBrains local synthesis planning
- expose showLocalSynthesisPlan as a plan-only command with fixed pccx synth/deploy argv
- extend local workflow status, docs, manifest, and tests without adding shell/network execution

## Tests
- node editors/vscode-prototype/test/local-synthesis-plan.test.mjs
- node editors/vscode-prototype/test/local-workflow-status.test.mjs
- node editors/vscode-prototype/test/extension-manifest.test.mjs
- node editors/vscode-prototype/test/extension-entrypoint.test.mjs
- node editors/vscode-prototype/test/static-boundary.test.mjs
- node editors/vscode-prototype/test/extension-host-readiness.test.mjs
- node editors/vscode-prototype/test/command-handlers.test.mjs
- node editors/vscode-prototype/test/extension-config.test.mjs
- python3 -m pytest -q
- bash scripts/vscode-adapter-smoke.sh
- bash scripts/editor-bridge-smoke.sh
- bash scripts/check-editor-bridge-examples.sh
- git diff --check

No direct push to main.